### PR TITLE
Set up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
 - '8'
+cache:
+  directories:
+  - node_modules


### PR DESCRIPTION
This PR adds a very simple `.travis.yml` file that will notify Travis to start running builds for the repo.

I am using NodeJS Version 8 and caching dependencies for quicker builds. By default, for Node, Travis will run
`npm install` to build dependencies and
`npm test` to run the tests.

This is sufficient for our needs. The `npm test` command is already configured in the `package.json` folder to run both the linter and the tests.