### PR TITLE
Add engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-openapi-validator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
   },
   "bin": {
     "lint-openapi": "src/cli-validator/index.js"
+  },
+  "engines": {
+    "node": ">=8.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ibm-openapi-validator",
   "description": "Configurable and extensible validator/linter for OpenAPI documents",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/lib/index.js",
   "repository": "https://github.com/IBM/openapi-validator",
   "license": "Apache-2.0",


### PR DESCRIPTION
The engines property in the `package.json` is used to 
>  specify the version of node that your stuff works on

We already state in the README that Node v8.9.x is a prerequisite and we even have a module to enforce users have a supported version but I think it is best practice to have this defined in the `package.json`.

This will also _warn_ users if they install the package and are using an unsupported version so I am bumping the version so this ends up in the published module.