### PR TITLE
Check that param.in is defined when checking for path params

### DIFF
--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -213,6 +213,8 @@ const processInput = async function(program) {
       results = validator(swagger, configObject);
     } catch (err) {
       printError(chalk, 'There was a problem with a validator.', getError(err));
+      // Uncomment the line below to see the stack trace when the validator fails
+      // console.log(err.stack);
       exitCode = 1;
       continue;
     }

--- a/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
@@ -64,7 +64,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         let givenParameters = [];
         if (operation.parameters) {
           givenParameters = operation.parameters
-            .filter(param => param.in.toLowerCase() === 'path')
+            .filter(param => param.in && param.in.toLowerCase() === 'path')
             .map(param => param.name);
         }
 


### PR DESCRIPTION
This PR fixes a crash encountered in a spec file that is missing the `in` property on a parameter.