### PR TITLE
Debug VPC document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-openapi-validator",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ibm-openapi-validator",
   "description": "Configurable and extensible validator/linter for OpenAPI documents",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/lib/index.js",
   "repository": "https://github.com/IBM/openapi-validator",
   "license": "Apache-2.0",

--- a/src/cli-validator/utils/preprocessFile.js
+++ b/src/cli-validator/utils/preprocessFile.js
@@ -8,11 +8,16 @@ module.exports = function(originalFile) {
   const twoSpaces = '  ';
   processedFile = originalFile.replace(tabExpression, twoSpaces);
 
-  // replace all instances of an escapted solidus (`\/`) with a solidus (`/`)
+  const escapedSolidus = /\\\//g;
+
+  // replace all instances of a double escaped solidus (`\\/`) with a single escaped solidus `\/`
+  const doubleEscapedSolidus = /\\\\\//g;
+  processedFile = processedFile.replace(doubleEscapedSolidus, escapedSolidus);
+
+  // replace all instances of an escaped solidus (`\/`) with a solidus (`/`)
   // the `yaml-js` package crashes if there is an escaped solidus
-  const escapedSolidusExpression = /\\\//g;
   const solidus = '/';
-  processedFile = processedFile.replace(escapedSolidusExpression, solidus);
+  processedFile = processedFile.replace(escapedSolidus, solidus);
 
   return processedFile;
 };

--- a/src/cli-validator/utils/preprocessFile.js
+++ b/src/cli-validator/utils/preprocessFile.js
@@ -8,14 +8,9 @@ module.exports = function(originalFile) {
   const twoSpaces = '  ';
   processedFile = originalFile.replace(tabExpression, twoSpaces);
 
-  const escapedSolidus = /\\\//g;
-
-  // replace all instances of a double escaped solidus (`\\/`) with a single escaped solidus `\/`
-  const doubleEscapedSolidus = /\\\\\//g;
-  processedFile = processedFile.replace(doubleEscapedSolidus, escapedSolidus);
-
-  // replace all instances of an escaped solidus (`\/`) with a solidus (`/`)
+  // sanitize all instances of a solidus preceded by 1 or more escape characters
   // the `yaml-js` package crashes if there is an escaped solidus
+  const escapedSolidus = /\\+\//g;
   const solidus = '/';
   processedFile = processedFile.replace(escapedSolidus, solidus);
 

--- a/test/cli-validator/mockFiles/clean.yml
+++ b/test/cli-validator/mockFiles/clean.yml
@@ -187,6 +187,7 @@ definitions:
       tags:
         type: "array"
         description: "string"
+        pattern: "^http(s)?:\\/\\/([^\\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$"
         xml:
           name: "tag"
           wrapped: true


### PR DESCRIPTION
The API definition document for VPC contains the following line:
`"pattern": "^http(s)?:\\/\\/([^\\/?#]*)([^?#]*)(\\?([^#]*))?(#(.*))?$",`

This causes the validator to crash. The problem expression in the pattern about is `\\/`. It has already been known that an escaped solidus (`\/`) is a problem for the validator, and we are sanitizing them in the preprocessing step by converting them to an unescaped solidus (`/`).

The problem with this new pattern is that the preprocessor turns `\\/` into `\/`, which is the problem expression from before.

This PR addresses this case by generalizing the sanitation to correct any amount of escape characters before a solidus (`\/`, `\\/`, `\\\/`, etc.)