### PR TITLE
Add a "print version" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.2.0
+- The options `-v` or `--version` now prints the semantic version of the validator
+- The `--print_validator_modules` short-hand option is renamed to `-p`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This command line tool lets you validate OpenAPI documents according to their sp
 
 `npm install -g ibm-openapi-validator`
 
-The `-g` flag installs the tool globally so that the validator can be run from anywhere in the file system. Alternatively, you can pass the `--save` or `--save-dev` flag to add the validator as a dependency to your project and run it from your NPM scripts.
+The `-g` flag installs the tool globally so that the validator can be run from anywhere in the file system. Alternatively, you can pass no flag or the `--save-dev` flag to add the validator as a dependency to your project and run it from your NPM scripts.
 
 ### Build from source
 1. Clone or download this repository
@@ -50,11 +50,12 @@ The `-g` flag installs the tool globally so that the validator can be run from a
 `lint-openapi [options] [command] [<files>]`
 
 #### [options]
--  -v (print_validator_modules) : Print the name of the validator source file the error/warning was caught it. This is primarily for developing validations.
--  -n (no_colors) : The output is colored by default. If this bothers you, this flag will turn off the coloring.
--  -d (default_mode) : This option turns off [configuration](#configuration) and runs the validator in [default mode](#default-mode).
--  -s (report_statistics) : Print a simple report at the end of the output showing the frequency, in percentage, of each error/warning.
--  -h (help) : This option prints the usage menu.
+-  -s (--report_statistics) : Print a simple report at the end of the output showing the frequency, in percentage, of each error/warning.
+-  -d (--default_mode) : This option turns off [configuration](#configuration) and runs the validator in [default mode](#default-mode).
+-  -p (--print_validator_modules) : Print the name of the validator source file the error/warning was caught it. This can be helpful for developing validations.
+-  -n (--no_colors) : The output is colored by default. If this bothers you, this flag will turn off the coloring.
+-  -v (--version) : Print the current semantic version of the validator
+-  -h (--help) : This option prints the usage menu.
 
 _These options only apply to running the validator on a file, not to any commands._
 
@@ -73,7 +74,6 @@ _None of the above options pertain to these commands._
 - Multiple, space-separated files can be passed in and each will be validated. This includes support for globs (e.g. `lint-openapi files/*` will run the validator on all files in `files/`)
 
 ### Node module
-_Assumes the module was installed with a `--save` or `--save-dev` flag._
 ```javascript
 const validator = require('ibm-openapi-validator');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-openapi-validator",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ibm-openapi-validator",
   "description": "Configurable and extensible validator/linter for OpenAPI documents",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "main": "src/lib/index.js",
   "repository": "https://github.com/IBM/openapi-validator",
   "license": "Apache-2.0",

--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -8,15 +8,17 @@ require('./utils/updateNotifier');
 
 const program = require('commander');
 const cliValidator = require('./runValidator');
+const version = require('../../package.json').version;
 
 // set up the command line options
 /* prettier-ignore */
 program
+  .version(version, '-v, --version')
   .description('Run the validator on a specified file')
   .arguments('[<file>]')
   .option(
-    '-v, --print_validator_modules',
-    'print the validators that catch each error/warning'
+    '-p, --print_validator_modules',
+    'print the validators that catch each error/warning (helpful for development)'
   )
   .option(
     '-n, --no_colors',

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -37,11 +37,7 @@ const processInput = async function(program) {
   const defaultMode = !!program.default_mode;
 
   // turn on coloring by default
-  let colors = true;
-
-  if (turnOffColoring) {
-    colors = false;
-  }
+  const colors = turnOffColoring ? false : true;
 
   const chalk = new chalkPackage.constructor({ enabled: colors });
 

--- a/test/cli-validator/tests/optionHandling.js
+++ b/test/cli-validator/tests/optionHandling.js
@@ -70,7 +70,7 @@ describe('cli tool - test option handling', function() {
     });
   });
 
-  it('should print validator source file when -v option is given', async function() {
+  it('should print validator source file when -p option is given', async function() {
     const capturedText = [];
 
     const unhookIntercept = intercept(function(txt) {


### PR DESCRIPTION
This came up while looking at an issue with Allen - there was no obvious way to see which version he had installed locally. Since most CLI tools use the `-v` option to print the version, I decided to add this.

There was previously a `-v` arg for printing validator file names but that was a debug tool I made for myself and I can't imagine any users would use that, plus we are still in `0.x` so we can make breaking changes 😏 

In this PR...
- The `-v` option is updated to print the version
- The print validator version is changed to `-p`
- The logic for turning off coloring is simplified with a ternary operator
- The README is updated with new option and also correct some outdated statements (the npm `--save` option is now deprecated)
- The appropriate option handler test is updated