### PR TITLE
Fix regex for camel case checks to avoid backtrack hangs.

### DIFF
--- a/src/plugins/utils/caseConventionCheck.js
+++ b/src/plugins/utils/caseConventionCheck.js
@@ -6,8 +6,8 @@
 
 */
 const lowerSnakeCase = /^[a-z][a-z0-9]*(_[a-z0-9]+)*$/;
-const upperCamelCase = /^[A-Z](([a-z0-9]+[A-Z]?[a-z0-9]+)+)?$/;
-const lowerCamelCase = /^[a-z](([a-z0-9]*[A-Z]?[a-z0-9]+)+)?$/;
+const upperCamelCase = /^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$/;
+const lowerCamelCase = /^[a-z][a-z0-9]*([A-Z][a-z0-9]+)*$/;
 const lowerDashCase = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 
 module.exports = (string, convention) => {

--- a/test/plugins/caseConventionCheck.js
+++ b/test/plugins/caseConventionCheck.js
@@ -37,6 +37,11 @@ describe('case convention regex tests', function() {
       const string = 'badCaseString';
       expect(checkCase(string, convention)).toEqual(false);
     });
+
+    it('does not hang on long identifiers', function() {
+      const string = 'downloadGeneratedApplicationUsingGET';
+      expect(checkCase(string, convention)).toEqual(false);
+    });
   });
 
   describe('lower camel case tests', function() {
@@ -53,6 +58,11 @@ describe('case convention regex tests', function() {
 
     it('BadCaseString is NOT lower camel case', function() {
       const string = 'BadCaseString';
+      expect(checkCase(string, convention)).toEqual(false);
+    });
+
+    it('does not hang on long identifiers', function() {
+      const string = 'downloadGeneratedApplicationUsingGET';
       expect(checkCase(string, convention)).toEqual(false);
     });
   });


### PR DESCRIPTION
Fixes hang (exponentially long run time) of regex checks for case conventions.

Test cases included that exhibit the hang with the previous regexs.