### PR TITLE
Handle allOf, oneOf, anyOf schemas

### DIFF
--- a/src/cli-validator/utils/validator.js
+++ b/src/cli-validator/utils/validator.js
@@ -60,7 +60,7 @@ module.exports = function validateSwagger(allSpecs, config) {
   }
 
   // run semantic validators
-  const allValidators = Object.assign(
+  const allValidators = Object.assign({},
     semanticValidators,
     sharedSemanticValidators
   );

--- a/src/cli-validator/utils/validator.js
+++ b/src/cli-validator/utils/validator.js
@@ -60,7 +60,8 @@ module.exports = function validateSwagger(allSpecs, config) {
   }
 
   // run semantic validators
-  const allValidators = Object.assign({},
+  const allValidators = Object.assign(
+    {},
     semanticValidators,
     sharedSemanticValidators
   );

--- a/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -56,11 +56,17 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
     ) {
       const pushLeafSchemas = (obj, path) => {
         if (obj.allOf && Array.isArray(obj.allOf)) {
-          obj.allOf.forEach((e, i) => pushLeafSchemas(e, [...path, 'allOf', i]));
+          obj.allOf.forEach((e, i) =>
+            pushLeafSchemas(e, [...path, 'allOf', i])
+          );
         } else if (isOAS3 && obj.oneOf && Array.isArray(obj.oneOf)) {
-          obj.oneOf.forEach((e, i) => pushLeafSchemas(e, [...path, 'oneOf', i]));
+          obj.oneOf.forEach((e, i) =>
+            pushLeafSchemas(e, [...path, 'oneOf', i])
+          );
         } else if (isOAS3 && obj.anyOf && Array.isArray(obj.anyOf)) {
-          obj.anyOf.forEach((e, i) => pushLeafSchemas(e, [...path, 'anyOf', i]));
+          obj.anyOf.forEach((e, i) =>
+            pushLeafSchemas(e, [...path, 'anyOf', i])
+          );
         } else {
           schemas.push({ schema: obj, path });
         }
@@ -109,7 +115,8 @@ function generateFormatErrors(schema, contextPath, config) {
   if (checkStatus !== 'off' && schema.type === 'array' && schema.items) {
     if (schema.items.type === 'array') {
       const path = contextPath.concat(['items', 'type']);
-      const message = 'Array properties should avoid having items of type array.';
+      const message =
+        'Array properties should avoid having items of type array.';
       result[checkStatus].push({ path, message });
     }
   }

--- a/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -19,7 +19,7 @@ const includes = require('lodash/includes');
 const isSnakecase = require('../../../utils/checkSnakeCase');
 const walk = require('../../../utils/walk');
 
-module.exports.validate = function({ jsSpec }, config) {
+module.exports.validate = function({ jsSpec, isOAS3 }, config) {
   const errors = [];
   const warnings = [];
 
@@ -54,7 +54,18 @@ module.exports.validate = function({ jsSpec }, config) {
       current === 'items' ||
       modelLocations.indexOf(path[path.length - 2]) > -1
     ) {
-      schemas.push({ schema: obj, path });
+      const pushLeafSchemas = (obj, path) => {
+        if (obj.allOf && Array.isArray(obj.allOf)) {
+          obj.allOf.forEach((e, i) => pushLeafSchemas(e, [...path, 'allOf', i]));
+        } else if (isOAS3 && obj.oneOf && Array.isArray(obj.oneOf)) {
+          obj.oneOf.forEach((e, i) => pushLeafSchemas(e, [...path, 'oneOf', i]));
+        } else if (isOAS3 && obj.anyOf && Array.isArray(obj.anyOf)) {
+          obj.anyOf.forEach((e, i) => pushLeafSchemas(e, [...path, 'anyOf', i]));
+        } else {
+          schemas.push({ schema: obj, path });
+        }
+      };
+      pushLeafSchemas(obj, path);
     }
   });
 
@@ -89,63 +100,36 @@ function generateFormatErrors(schema, contextPath, config) {
   result.error = [];
   result.warning = [];
 
-  if (!schema.properties) {
+  if (schema.$ref) {
     return result;
   }
 
-  forIn(schema.properties, (property, propName) => {
-    if (property.$ref || propName.slice(0, 2) === 'x-') return;
-    let path = contextPath.concat(['properties', propName, 'type']);
-    let valid = true;
-    switch (property.type) {
-      case 'integer':
-      case 'number':
-      case 'string':
-      case 'boolean':
-        valid = formatValid(property);
-        break;
-      case 'array':
-        path = contextPath.concat(['properties', propName, 'items', 'type']);
-        if (property.items) {
-          if (property.items.type === 'array') {
-            const message =
-              'Array properties should avoid having items of type array.';
-            const checkStatus = config.array_of_arrays;
-            if (checkStatus !== 'off') {
-              result[checkStatus].push({ path, message });
-            }
-          } else {
-            valid = formatValid(property.items);
-          }
-        }
-        break;
-      case 'object':
-        valid = true; // TODO: validate nested schemas
-        break;
-      case null:
-        valid = true; // Not valid, but should be flagged because type is required
-        break;
-      default:
-        valid = false;
+  // Special case: check for arrays of arrays
+  let checkStatus = config.array_of_arrays;
+  if (checkStatus !== 'off' && schema.type === 'array' && schema.items) {
+    if (schema.items.type === 'array') {
+      const path = contextPath.concat(['items', 'type']);
+      const message = 'Array properties should avoid having items of type array.';
+      result[checkStatus].push({ path, message });
     }
+  }
 
-    if (!valid) {
-      const message = 'Property type+format is not well-defined.';
-      const checkStatus = config.invalid_type_format_pair;
-      if (checkStatus !== 'off') {
-        result[checkStatus].push({
-          path,
-          message
-        });
-      }
-    }
-  });
+  checkStatus = config.invalid_type_format_pair;
+  if (checkStatus !== 'off' && !formatValid(schema)) {
+    const path = contextPath.concat(['type']);
+    const message = 'Property type+format is not well-defined.';
+    result[checkStatus].push({ path, message });
+  }
 
   return result;
 }
 
 function formatValid(property) {
   if (property.$ref) {
+    return true;
+  }
+  // if type is not present, skip validation of format
+  if (!property.type) {
     return true;
   }
   let valid = true;
@@ -172,7 +156,8 @@ function formatValid(property) {
       valid = property.format === undefined; // No valid formats for boolean -- should be omitted
       break;
     case 'object':
-      valid = true; // TODO: validate nested schemas
+    case 'array':
+      valid = true;
       break;
     default:
       valid = false;
@@ -194,6 +179,9 @@ function generateDescriptionWarnings(schema, contextPath, config) {
   forIn(schema.properties, (property, propName) => {
     // if property is defined by a ref, it does not need a description
     if (property.$ref || propName.slice(0, 2) === 'x-') return;
+
+    // if property has a allOf, anyOf, or oneOf schema, it does not needs a description
+    if (property.allOf || property.anyOf || property.oneOf) return;
 
     const path = contextPath.concat(['properties', propName, 'description']);
 

--- a/test/cli-validator/mockFiles/oas3/testoneof.yaml
+++ b/test/cli-validator/mockFiles/oas3/testoneof.yaml
@@ -1,0 +1,76 @@
+openapi: 3.0.0
+components:
+  responses:
+    Ok:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Ok'
+      description: Ok response.
+  schemas:
+    A:
+      description: a string
+      type: string
+    B:
+      description: a boolean
+      type: boolean
+    AorB:
+      description: either string or boolean
+      oneOf:
+      - $ref: '#/components/schemas/A'
+      - $ref: '#/components/schemas/B'
+    C:
+      oneOf:
+        - allOf:
+          - type: foo
+          - description: 'foo type'
+        - anyOf:
+          - type: string
+            format: url
+            description: 'url string'
+    Ok:
+      type: object
+      properties:
+        ok:
+          description: ok
+          type: boolean
+paths:
+  /ref:
+    post:
+      description: accept an A or B (ref)
+      operationId: createRef
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: body with a test property
+              properties:
+                test:
+                  $ref: '#/components/schemas/AorB'
+              type: object
+          description: A body.
+      responses:
+        '200':
+          $ref: '#/components/responses/Ok'
+      summary: test ref
+  /inline:
+    post:
+      description: accept an A or B (inline)
+      operationId: createInline
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: body with a test property
+              properties:
+                test:
+                  oneOf:
+                  - $ref: '#/components/schemas/A'
+                  - $ref: '#/components/schemas/B'
+                  - $ref: '#/components/schemas/C'
+              type: object
+          description: A body.
+      responses:
+        '200':
+          $ref: '#/components/responses/Ok'
+      summary: test inline

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -579,7 +579,9 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       }
     };
 
-    var spec = yaml.safeLoad(fs.readFileSync('test/cli-validator/mockFiles/oas3/testoneof.yaml'));
+    const spec = yaml.safeLoad(
+      fs.readFileSync('test/cli-validator/mockFiles/oas3/testoneof.yaml')
+    );
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
     expect(res.errors.length).toEqual(2);

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -1,4 +1,6 @@
 const expect = require('expect');
+const yaml = require('js-yaml');
+const fs = require('fs');
 const {
   validate
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/schema-ibm');
@@ -565,6 +567,26 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'type'
     ]);
     expect(res.errors[0].message).toEqual(
+      'Property type+format is not well-defined.'
+    );
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should process allOf, oneOf, anyOf schemas correctly', () => {
+    const config = {
+      schemas: {
+        invalid_type_format_pair: 'error'
+      }
+    };
+
+    var spec = yaml.safeLoad(fs.readFileSync('test/cli-validator/mockFiles/oas3/testoneof.yaml'));
+
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
+    expect(res.errors.length).toEqual(2);
+    expect(res.errors[0].message).toEqual(
+      'Property type+format is not well-defined.'
+    );
+    expect(res.errors[1].message).toEqual(
       'Property type+format is not well-defined.'
     );
     expect(res.warnings.length).toEqual(0);


### PR DESCRIPTION
This PR reworks the way schema-ibm finds and validates schema. The motivation for these changes was to handle "allOf", "anyOf", and "oneOf" constructs properly, but this evolved into some more fundamental changes in the process of development and debugging. I think the code is now simpler and more general.

I've added a test for the new functionality. I also did a before/after comparison of the validation of the Watson API docs, and found that the validator now reports errors for a number of previously undetected problems:
```
[mkistler@mkistlers-MacBook-Pro] ~/Projects/watson-developer-cloud/api-definitions (master)>lint-openapi apis-public/language-translator-v3.json 

errors

  Message :   Property type+format is not well-defined.
  Path    :   paths./v3/documents/{document_id}/translated_document.get.responses.200.schema.type
  Line    :   2013
```
and

```
[mkistler@mkistlers-MacBook-Pro] ~/Projects/watson-developer-cloud/api-definitions (master)>lint-openapi apis-public/text-to-speech-v1.json 

errors

  Message :   Property type+format is not well-defined.
  Path    :   paths./v1/synthesize.get.responses.200.schema.type
  Line    :   604

  Message :   Property type+format is not well-defined.
  Path    :   paths./v1/synthesize.post.responses.200.schema.type
  Line    :   748
```

All of these are response schema with "type" of "file", which is not valid.

Fixes #14