### PR TITLE
Add validation rule for missing description in top-level schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The supported rules are described below:
 | --------------------------- | ----------------------------------------------------------------------------- | -------- |
 | invalid_type_format_pair    | Flag any schema that does not follow the [data type/format rules.][2]         | shared   |
 | snake_case_only             | Flag any property with a `name` that is not lower snake case.                 | shared   |
+| no_schema_description       | Flag any schema without a `description` field.                                | shared   |
 | no_property_description     | Flag any schema that contains a 'property' without a `description` field.     | shared   |
 | description_mentions_json   | Flag any schema with a 'property' description that mentions the word 'JSON'.  | shared   |
 | array_of_arrays             | Flag any schema with a 'property' of type `array` with items of type `array`. | shared   |
@@ -371,6 +372,7 @@ The default values for each rule are described below.
 | --------------------------- | --------|
 | invalid_type_format_pair    | error   |
 | snake_case_only             | warning |
+| no_schema_description       | warning |
 | no_property_description     | warning |
 | description_mentions_json   | warning |
 | array_of_arrays             | warning |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -53,6 +53,7 @@ const defaults = {
     'schemas': {
       'invalid_type_format_pair': 'error',
       'snake_case_only': 'warning',
+      'no_schema_description': 'warning',
       'no_property_description': 'warning',
       'description_mentions_json': 'warning',
       'array_of_arrays': 'warning'

--- a/test/cli-validator/mockFiles/clean.yml
+++ b/test/cli-validator/mockFiles/clean.yml
@@ -130,6 +130,7 @@ securityDefinitions:
 definitions:
   InlineResponse200:
     type: "object"
+    description: "string"
     properties:
       pets:
         type: "array"
@@ -138,6 +139,7 @@ definitions:
           $ref: "#/definitions/Pet"
   Category:
     type: "object"
+    description: "string"
     properties:
       id:
         type: "integer"
@@ -150,6 +152,7 @@ definitions:
       name: "Category"
   Tag:
     type: "object"
+    description: "string"
     properties:
       id:
         type: "integer"
@@ -162,6 +165,7 @@ definitions:
       name: "Tag"
   Pet:
     type: "object"
+    description: "string"
     required:
     - "name"
     - "photo_urls"

--- a/test/cli-validator/mockFiles/cleanWithTabs.yml
+++ b/test/cli-validator/mockFiles/cleanWithTabs.yml
@@ -130,6 +130,7 @@ securityDefinitions:
 definitions:
 	InlineResponse200:
 	  type: "object"
+		description: "string"
 	  properties:
 	    pets:
 	      type: "array"
@@ -138,6 +139,7 @@ definitions:
 	        $ref: "#/definitions/Pet"
 	Category:
 		type: "object"
+		description: "string"
 		properties:
 			id:
 				type: "integer"
@@ -150,6 +152,7 @@ definitions:
 			name: "Category"
 	Tag:
 		type: "object"
+		description: "string"
 		properties:
 			id:
 				type: "integer"
@@ -162,6 +165,7 @@ definitions:
 			name: "Tag"
 	Pet:
 		type: "object"
+		description: "string"
 		required:
 		- "name"
 		- "photo_urls"

--- a/test/cli-validator/mockFiles/errAndWarn.yaml
+++ b/test/cli-validator/mockFiles/errAndWarn.yaml
@@ -141,6 +141,7 @@ definitions:
       name: "Category"
   Tag:
     type: "object"
+    description: "string"
     properties:
       id:
         type: "integer"
@@ -153,6 +154,7 @@ definitions:
       name: "Tag"
   Pet:
     type: "object"
+    description: "string"
     required:
     - "name"
     - "photoUrls"
@@ -193,6 +195,7 @@ definitions:
     xml:
       name: "Pet"
   UnusedString:
+    description: "string"
     type: "string"
 externalDocs:
   description: "Find out more about Swagger"

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -30,7 +30,7 @@ paths:
               schema:
                 type: string
           content:
-            application/json:    
+            application/json:
               schema:
                 $ref: "#/components/schemas/Pets"
         default:
@@ -82,6 +82,8 @@ paths:
 components:
   schemas:
     Pet:
+      description:
+        A pet
       required:
         - id
         - name
@@ -97,6 +99,8 @@ components:
           type: string
           description: "tag property"
     Pets:
+      description:
+        A list of pets
       required:
         - list
       properties:
@@ -106,6 +110,8 @@ components:
           items:
             $ref: "#/components/schemas/Pet"
     Error:
+      description:
+        An error in processing a service request
       required:
         - code
         - message

--- a/test/cli-validator/tests/expectedOutput.js
+++ b/test/cli-validator/tests/expectedOutput.js
@@ -93,11 +93,12 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(capturedText[16].match(/\S+/g)[2]).toEqual('108');
     expect(capturedText[21].match(/\S+/g)[2]).toEqual('36');
     expect(capturedText[25].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[29].match(/\S+/g)[2]).toEqual('195');
+    expect(capturedText[29].match(/\S+/g)[2]).toEqual('197');
     expect(capturedText[33].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[37].match(/\S+/g)[2]).toEqual('134');
-    expect(capturedText[41].match(/\S+/g)[2]).toEqual('170');
-    expect(capturedText[45].match(/\S+/g)[2]).toEqual('126');
+    expect(capturedText[37].match(/\S+/g)[2]).toEqual('131');
+    expect(capturedText[41].match(/\S+/g)[2]).toEqual('134');
+    expect(capturedText[45].match(/\S+/g)[2]).toEqual('172');
+    expect(capturedText[49].match(/\S+/g)[2]).toEqual('126');
   });
 
   it('should return exit code of 0 if there are only warnings', async function() {

--- a/test/cli-validator/tests/optionHandling.js
+++ b/test/cli-validator/tests/optionHandling.js
@@ -129,7 +129,7 @@ describe('cli tool - test option handling', function() {
 
     // totals
     expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('4');
-    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('7');
+    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('8');
 
     // errors
     expect(capturedText[statsSection + 4].match(/\S+/g)[0]).toEqual('2');
@@ -143,22 +143,25 @@ describe('cli tool - test option handling', function() {
 
     // warnings
     expect(capturedText[statsSection + 9].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 9].match(/\S+/g)[1]).toEqual('(29%)');
+    expect(capturedText[statsSection + 9].match(/\S+/g)[1]).toEqual('(25%)');
 
     expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 13].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 14].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(13%)');
+
+    expect(capturedText[statsSection + 15].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(13%)');
   });
 
   it('should not print statistics report by default', async function() {

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -17,6 +17,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       definitions: {
         WordStyle: {
           type: 'object',
+          description: 'word style',
           properties: {
             level: {
               type: 'number',
@@ -54,6 +55,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       definitions: {
         Thing: {
           type: 'object',
+          description: 'thing',
           properties: {
             level: {
               type: 'array',
@@ -95,6 +97,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       definitions: {
         Thing: {
           type: 'object',
+          description: 'thing',
           properties: {
             level: {
               type: 'array',
@@ -106,7 +109,8 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
           }
         },
         levelItem: {
-          type: 'string'
+          type: 'string',
+          description: 'level item'
         }
       }
     };
@@ -166,6 +170,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       definitions: {
         Thing: {
           type: 'object',
+          description: 'thing',
           properties: {
             thingString: {
               type: 'string',
@@ -201,6 +206,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       definitions: {
         Thing: {
           type: 'object',
+          description: 'thing',
           properties: {
             thing: {
               type: 'array',
@@ -234,6 +240,86 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     ]);
     expect(res.warnings[0].message).toEqual(
       'Property names must be lower snake case.'
+    );
+  });
+
+  it('should return an error when a schema has no description', () => {
+    const config = {
+      schemas: {
+        no_schema_description: 'warning'
+      }
+    };
+
+    const spec = {
+      definitions: {
+        Pet: {
+          required: ['id', 'name'],
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+              description: 'string'
+            },
+            name: {
+              type: 'string',
+              description: 'string'
+            },
+            tag: {
+              type: 'string',
+              description: 'string'
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual(['definitions', 'Pet']);
+    expect(res.warnings[0].message).toEqual(
+      'Schema must have a non-empty description.'
+    );
+  });
+
+  it('should return an error when an OASv3 schema has no description', () => {
+    const config = {
+      schemas: {
+        no_schema_description: 'warning'
+      }
+    };
+
+    const spec = {
+      components: {
+        schemas: {
+          Pet: {
+            required: ['id', 'name'],
+            properties: {
+              id: {
+                type: 'integer',
+                format: 'int64',
+                description: 'string'
+              },
+              name: {
+                type: 'string',
+                description: 'string'
+              },
+              tag: {
+                type: 'string',
+                description: 'string'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual(['components', 'schemas', 'Pet']);
+    expect(res.warnings[0].message).toEqual(
+      'Schema must have a non-empty description.'
     );
   });
 
@@ -423,6 +509,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       definitions: {
         Thing: {
           type: 'object',
+          description: 'thing',
           properties: {
             level: {
               type: 'array',
@@ -605,6 +692,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       definitions: {
         Thing: {
           type: 'object',
+          description: 'thing',
           properties: {
             color: {
               type: 'string',


### PR DESCRIPTION
This PR adds a validation rule for checking that all top-level schema -- within "definitions" of an OASv2 doc, or within "components/schemas" of an OASv3 doc -- contain a description.

The rationale for this rule is that JSON schema rules disallow a "description" sibling of a "$ref", so it is important for all "$ref"-able schema to have descriptions.

The default configuration for this rule is set to "warning" since it will generate _many_ messages for the Watson API docs.