### PR TITLE
fix: dont error on schemas with type file for oas2 specs

### DIFF
--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -188,6 +188,56 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     expect(res.warnings.length).toEqual(0);
   });
 
+  it('should return an error for a response schema with non-root type file', () => {
+    const config = {
+      schemas: {
+        invalid_type_format_pair: 'error'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            responses: {
+              '200': {
+                description: 'legal response',
+                schema: {
+                  properties: {
+                    'this_is_bad': {
+                      type: 'file',
+                      description: "non-root type of file is bad"
+                    }
+                  }
+
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      '200',
+      'schema',
+      'properties',
+      'this_is_bad',
+      'type'
+    ]);
+    expect(res.errors[0].message).toEqual(
+      'Property type+format is not well-defined.'
+    );
+
+    expect(res.warnings.length).toEqual(0);
+  });
+
   it('should return a warning when a property name is not snake case', () => {
     const config = {
       schemas: {

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -159,6 +159,35 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     expect(res.warnings.length).toEqual(0);
   });
 
+  it('should non return an error for a response schema of type file', () => {
+    const config = {
+      schemas: {
+        invalid_type_format_pair: 'error'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            responses: {
+              '200': {
+                description: 'legal response',
+                schema: {
+                  type: 'file'
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(0);
+  });
+
   it('should return a warning when a property name is not snake case', () => {
     const config = {
       schemas: {
@@ -574,7 +603,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       }
     };
 
-    const res = validate({ jsSpec: spec }, config);
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual([
       'components',
@@ -585,6 +614,52 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'schema',
       'properties',
       'BadProp',
+      'type'
+    ]);
+    expect(res.errors[0].message).toEqual(
+      'Property type+format is not well-defined.'
+    );
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should return an error for a response schema of type file', () => {
+    const config = {
+      schemas: {
+        invalid_type_format_pair: 'error'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'file'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      '200',
+      'content',
+      'application/json',
+      'schema',
       'type'
     ]);
     expect(res.errors[0].message).toEqual(
@@ -638,7 +713,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       }
     };
 
-    const res = validate({ jsSpec: spec }, config);
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual([
       'paths',
@@ -704,7 +779,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       }
     };
 
-    const res = validate({ jsSpec: spec }, config);
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(1);
     expect(res.warnings[0].path).toEqual([
@@ -750,7 +825,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       }
     };
 
-    const res = validate({ jsSpec: spec }, config);
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(1);
     expect(res.warnings[0].path).toEqual([

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -188,6 +188,27 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     expect(res.warnings.length).toEqual(0);
   });
 
+  it('should non return an error for a definition with root type of file', () => {
+    const config = {
+      schemas: {
+        invalid_type_format_pair: 'error'
+      }
+    };
+
+    const spec = {
+      definitions: {
+        SomeSchema: {
+          type: 'file',
+          description: 'file schema, used for parameter or response'
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(0);
+  });
+
   it('should return an error for a response schema with non-root type file', () => {
     const config = {
       schemas: {

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -225,12 +225,11 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                 description: 'legal response',
                 schema: {
                   properties: {
-                    'this_is_bad': {
+                    this_is_bad: {
                       type: 'file',
-                      description: "non-root type of file is bad"
+                      description: 'non-root type of file is bad'
                     }
                   }
-
                 }
               }
             }


### PR DESCRIPTION
As we learned from [the spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types) recently,
> An additional primitive data type "file" is used by the Parameter Object and the Response Object to set the parameter type or the response as being a file.

This PR addresses the fact that the validator was giving errors for schemas with type file.

It's worth noting that `parameters-ibm` already supported allowing type file if the condition is met that it's a `formData` parameter.

After some consideration, my solution here is to allow type "file" for all schemas. My reasoning behind this is that it would be non-trivial to check whether or not models in `definitions` are being uses for response schemas or not. Additionally, schemas pretty much only appear in parameters or responses - parameters are checked for their condition of using "file" elsewhere and responses can use "file" unconditionally. I don't see too many use cases where type "file" would be explicitly disallowed by the spec that we aren't covering.

I'm happy to revise this approach if it's found objectionable! This seemed to have the best time/value trade-off.