### PR TITLE
test: add type/format test for top level schema and move oas3 test

### DIFF
--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -44,6 +44,32 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     expect(res.warnings.length).toEqual(0);
   });
 
+  it('should return an error when a property does not use a well defined property type', () => {
+    const config = {
+      schemas: {
+        invalid_type_format_pair: 'error'
+      }
+    };
+
+    const spec = {
+      definitions: {
+        WordStyle: {
+          type: 'number',
+          format: 'integer',
+          description: 'word style'
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].path).toEqual(['definitions', 'WordStyle', 'type']);
+    expect(res.errors[0].message).toEqual(
+      'Property type+format is not well-defined.'
+    );
+    expect(res.warnings.length).toEqual(0);
+  });
+
   it("should return an error when an array property's items does not use a well defined property type", () => {
     const config = {
       schemas: {
@@ -381,47 +407,6 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     );
   });
 
-  it('should return an error when an OASv3 schema has no description', () => {
-    const config = {
-      schemas: {
-        no_schema_description: 'warning'
-      }
-    };
-
-    const spec = {
-      components: {
-        schemas: {
-          Pet: {
-            required: ['id', 'name'],
-            properties: {
-              id: {
-                type: 'integer',
-                format: 'int64',
-                description: 'string'
-              },
-              name: {
-                type: 'string',
-                description: 'string'
-              },
-              tag: {
-                type: 'string',
-                description: 'string'
-              }
-            }
-          }
-        }
-      }
-    };
-
-    const res = validate({ jsSpec: spec, isOAS3: true }, config);
-    expect(res.errors.length).toEqual(0);
-    expect(res.warnings.length).toEqual(1);
-    expect(res.warnings[0].path).toEqual(['components', 'schemas', 'Pet']);
-    expect(res.warnings[0].message).toEqual(
-      'Schema must have a non-empty description.'
-    );
-  });
-
   it('should return an error when a schema property has no description', () => {
     const config = {
       schemas: {
@@ -641,6 +626,47 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
 });
 
 describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
+  it('should return an error when an OASv3 schema has no description', () => {
+    const config = {
+      schemas: {
+        no_schema_description: 'warning'
+      }
+    };
+
+    const spec = {
+      components: {
+        schemas: {
+          Pet: {
+            required: ['id', 'name'],
+            properties: {
+              id: {
+                type: 'integer',
+                format: 'int64',
+                description: 'string'
+              },
+              name: {
+                type: 'string',
+                description: 'string'
+              },
+              tag: {
+                type: 'string',
+                description: 'string'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual(['components', 'schemas', 'Pet']);
+    expect(res.warnings[0].message).toEqual(
+      'Schema must have a non-empty description.'
+    );
+  });
+
   it('should return an error when a complex parameter schema does not use a well defined property type', () => {
     const config = {
       schemas: {


### PR DESCRIPTION
@mkistler you stated in an issue that
> The validator currently checks properties and parameters to ensure that the type and format are "well-defined" -- meaning that they are explicitly defined in the OpenAPI spec. But it seems that the validator misses "schema" -- top-level entries under definitions -- that violate this rule.

This doesn't seem to be an issue anymore and was likely resolved by your recent work. For assurance, I added a quick test that seems to match your description of what wasn't working.

I also moved an OAS3 test from the Swagger2 section to the OAS3 section of the `schema-ibm` tests. A minor detail but worth correcting while I was updating the tests.