### PR TITLE
fix: exapand check for operation id duplciates to include referenced paths

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -5,7 +5,7 @@ const reduce = require('lodash/reduce');
 const merge = require('lodash/merge');
 const each = require('lodash/each');
 
-module.exports.validate = function({ jsSpec }) {
+module.exports.validate = function({ resolvedSpec }) {
   const errors = [];
   const warnings = [];
 
@@ -21,7 +21,7 @@ module.exports.validate = function({ jsSpec }) {
   ];
 
   const operations = reduce(
-    jsSpec.paths,
+    resolvedSpec.paths,
     (arr, path, pathKey) => {
       const pathOps = pickBy(path, (obj, k) => {
         return validOperationKeys.indexOf(k) > -1;


### PR DESCRIPTION
Resolves #28 

Converts the `operation-ids` validation module, which checks for duplicated operation ids, to use `resolvedSpec` instead of `jsSpec`. This will allow it to pick up operations that live inside of referenced paths.