### PR TITLE
Fix operationID case convention to match API Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The default values for each rule are described below.
 | Rule                         | Default |
 | ---------------------------- | ------- |
 | no_operation_id              | warning |
-| operation_id_case_convention | warning, lower_camel_case |
+| operation_id_case_convention | warning, lower_snake_case |
 | no_summary                   | warning |
 | no_array_responses           | error   |
 | parameter_order              | warning |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -22,7 +22,7 @@ const defaults = {
   'shared': {
     'operations': {
       'no_operation_id': 'warning',
-      'operation_id_case_convention': ['warning', 'lower_camel_case'],
+      'operation_id_case_convention': ['warning', 'lower_snake_case'],
       'no_summary': 'warning',
       'no_array_responses': 'error',
       'parameter_order': 'warning'

--- a/test/cli-validator/mockFiles/clean.yml
+++ b/test/cli-validator/mockFiles/clean.yml
@@ -33,7 +33,7 @@ paths:
       - "pet"
       summary: "Add a new pet to the store"
       description: "post a pet to store"
-      operationId: "addPet"
+      operationId: "add_pet"
       consumes:
       - "application/json"
       - "application/xml"
@@ -59,7 +59,7 @@ paths:
       - "pet"
       summary: "Update an existing pet"
       description: "put new data for existing pet"
-      operationId: "updatePet"
+      operationId: "update_pet"
       consumes:
       - "application/json"
       - "application/xml"
@@ -90,7 +90,7 @@ paths:
       - "pet"
       summary: "Finds Pets by status"
       description: "Multiple status values can be provided with comma separated strings"
-      operationId: "findPetsByStatus"
+      operationId: "find_pets_by_status"
       produces:
       - "application/xml"
       - "application/json"

--- a/test/cli-validator/mockFiles/cleanWithTabs.yml
+++ b/test/cli-validator/mockFiles/cleanWithTabs.yml
@@ -33,7 +33,7 @@ paths:
 			- "pet"
 			summary: "Add a new pet to the store"
 			description: "post a pet to store"
-			operationId: "addPet"
+			operationId: "add_pet"
 			consumes:
 			- "application/json"
 			- "application/xml"
@@ -59,7 +59,7 @@ paths:
 			- "pet"
 			summary: "Update an existing pet"
 			description: "put new data for existing pet"
-			operationId: "updatePet"
+			operationId: "update_pet"
 			consumes:
 			- "application/json"
 			- "application/xml"
@@ -90,7 +90,7 @@ paths:
 			- "pet"
 			summary: "Finds Pets by status"
 			description: "Multiple status values can be provided with comma separated strings"
-			operationId: "findPetsByStatus"
+			operationId: "find_pets_by_status"
 			produces:
 			- "application/xml"
 			- "application/json"

--- a/test/cli-validator/mockFiles/errAndWarn.yaml
+++ b/test/cli-validator/mockFiles/errAndWarn.yaml
@@ -84,7 +84,7 @@ paths:
       - "pet"
       summary: "Finds Pets by status"
       description: "Multiple status values can be provided with comma separated strings"
-      operationId: "findPetsByStatus"
+      operationId: "find_pets_by_status"
       produces:
       - "application/xml"
       - "application/json"

--- a/test/cli-validator/mockFiles/justWarn.yml
+++ b/test/cli-validator/mockFiles/justWarn.yml
@@ -59,7 +59,7 @@ paths:
       - "pet"
       summary: "Update an existing pet"
       description: "put new data for existing pet"
-      operationId: "updatePet"
+      operationId: "update_pet"
       consumes:
       - "application/json"
       - "application/xml"
@@ -90,7 +90,7 @@ paths:
       - "pet"
       summary: "Finds Pets by status"
       description: "Multiple status values can be provided with comma separated strings"
-      operationId: "findPetsByStatus"
+      operationId: "find_pets_by_status"
       produces:
       - "application/xml"
       - "application/json"

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -10,7 +10,7 @@ paths:
   /pets:
     get:
       summary: List all pets
-      operationId: listPets
+      operationId: list_pets
       tags:
         - pets
       parameters:
@@ -41,7 +41,7 @@ paths:
                 $ref: "#/components/schemas/Error"
     post:
       summary: Create a pet
-      operationId: createPets
+      operationId: create_pets
       tags:
         - pets
       responses:
@@ -56,7 +56,7 @@ paths:
   /pets/{pet_id}:
     get:
       summary: Info for a specific pet
-      operationId: showPetById
+      operationId: show_pet_by_id
       tags:
         - pets
       parameters:

--- a/test/cli-validator/mockFiles/trailingComma.json
+++ b/test/cli-validator/mockFiles/trailingComma.json
@@ -16,7 +16,7 @@
     "/v1/thing": {
       "post": {
         "summary": "Create a thing.",
-        "operationId": "createThing",
+        "operationId": "create_thing",
         "consumes": [
           "multipart/form-data"
         ],

--- a/test/plugins/validation/2and3/operations-shared.js
+++ b/test/plugins/validation/2and3/operations-shared.js
@@ -13,7 +13,7 @@ describe('validation plugin - semantic - operations-shared', function() {
         paths: {
           '/': {
             get: {
-              operationId: 'getEverything',
+              operationId: 'get_everything',
               summary: 'this is a summary',
               parameters: [
                 {
@@ -120,7 +120,7 @@ describe('validation plugin - semantic - operations-shared', function() {
           '/CoolPath': {
             put: {
               consumes: ['consumes'],
-              operationId: 'operationId',
+              operationId: 'operation_id',
               parameters: [
                 {
                   name: 'BadParameter',
@@ -156,7 +156,7 @@ describe('validation plugin - semantic - operations-shared', function() {
             put: {
               consumes: ['consumes'],
               summary: '  ',
-              operationId: 'operationId',
+              operationId: 'operation_id',
               parameters: [
                 {
                   name: 'BadParameter',
@@ -222,7 +222,7 @@ describe('validation plugin - semantic - operations-shared', function() {
           '/stuff': {
             get: {
               summary: 'list stuff',
-              operationId: 'listStuff',
+              operationId: 'list_stuff',
               produces: ['application/json'],
               responses: {
                 200: {
@@ -257,7 +257,7 @@ describe('validation plugin - semantic - operations-shared', function() {
           '/stuff': {
             get: {
               summary: 'list stuff',
-              operationId: 'listStuff',
+              operationId: 'list_stuff',
               produces: ['application/json'],
               responses: {
                 200: {
@@ -300,7 +300,7 @@ describe('validation plugin - semantic - operations-shared', function() {
             'x-vendor-put-op': {
               consumes: ['consumes'],
               summary: '  ',
-              operationId: 'operationId',
+              operationId: 'operation_id',
               parameters: [
                 {
                   name: 'BadParameter',
@@ -331,7 +331,7 @@ describe('validation plugin - semantic - operations-shared', function() {
           '/stuff': {
             get: {
               summary: 'list stuff',
-              operationId: 'listStuff',
+              operationId: 'list_stuff',
               produces: ['application/json'],
               parameters: [
                 {
@@ -375,7 +375,7 @@ describe('validation plugin - semantic - operations-shared', function() {
           '/stuff': {
             get: {
               summary: 'list stuff',
-              operationId: 'listStuff',
+              operationId: 'list_stuff',
               produces: ['application/json'],
               parameters: [
                 {
@@ -432,7 +432,7 @@ describe('validation plugin - semantic - operations-shared', function() {
           '/fake/{id}': {
             get: {
               summary: 'get fake data by id',
-              operationId: 'getFakeData',
+              operationId: 'get_fake_data',
               produces: ['application/json'],
               parameters: [
                 {
@@ -492,7 +492,7 @@ describe('validation plugin - semantic - operations-shared', function() {
           '/fake/{id}': {
             get: {
               summary: 'get fake data by id',
-              operationId: 'getFakeData',
+              operationId: 'get_fake_data',
               produces: ['application/json'],
               parameters: [
                 {
@@ -553,7 +553,7 @@ describe('validation plugin - semantic - operations-shared', function() {
             put: {
               consumes: ['consumes'],
               summary: 'this is a summary',
-              operationId: 'cool_path_put',
+              operationId: 'coolPathPut',
               parameters: [
                 {
                   name: 'BadParameter',
@@ -577,7 +577,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(1);
       expect(res.warnings[0].path).toEqual('paths./CoolPath.put.operationId');
       expect(res.warnings[0].message).toEqual(
-        'operationIds must follow case convention: lower_camel_case'
+        'operationIds must follow case convention: lower_snake_case'
       );
       expect(res.errors.length).toEqual(0);
     });
@@ -589,7 +589,7 @@ describe('validation plugin - semantic - operations-shared', function() {
             put: {
               consumes: ['consumes'],
               summary: 'this is a summary',
-              operationId: 'coolPathPut',
+              operationId: 'cool_path_put',
               parameters: [
                 {
                   name: 'BadParameter',
@@ -633,7 +633,7 @@ describe('validation plugin - semantic - operations-shared', function() {
         paths: {
           '/': {
             get: {
-              operationId: 'getEverything',
+              operationId: 'get_everything',
               summary: 'this is a summary',
               responses: {
                 default: {
@@ -679,7 +679,7 @@ describe('validation plugin - semantic - operations-shared', function() {
         paths: {
           '/': {
             get: {
-              operationId: 'getEverything',
+              operationId: 'get_everything',
               summary: 'get everything as a string or an array',
               responses: {
                 '200': {


### PR DESCRIPTION
This PR fixes the default case convention for operationIds to be lower_snake_case, to conform to the convention proscribed in the API Handbook.