### PR TITLE
docs: added .gitignore of .idea/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log*
 dist
 .validaterc
 .validateignore
+.idea/


### PR DESCRIPTION
Insignificant change to additionally ignore IntelliJ/Webstorm project information.
Does not change anything functionally in any code, just nicer for people like me
who develop JavaScript in WebStorm.