### PR TITLE
feat: Added -j/--json output option to cli-validator

### DIFF
--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -25,6 +25,10 @@ program
     'turn off output coloring'
   )
   .option(
+    '-j, --json',
+    'output as json'
+  )
+  .option(
     '-d, --default_mode',
     'ignore config file and run in default mode'
   )

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -12,6 +12,7 @@ const config = require('./utils/processConfiguration');
 const buildSwaggerObject = require('./utils/buildSwaggerObject');
 const validator = require('./utils/validator');
 const print = require('./utils/printResults');
+const printJson = require('./utils/printJsonResults');
 const printError = require('./utils/printError');
 const preprocessFile = require('./utils/preprocessFile');
 
@@ -35,6 +36,7 @@ const processInput = async function(program) {
 
   const turnOffColoring = !!program.no_colors;
   const defaultMode = !!program.default_mode;
+  const jsonOutput = !!program.json;
 
   // turn on coloring by default
   const colors = turnOffColoring ? false : true;
@@ -217,13 +219,17 @@ const processInput = async function(program) {
       continue;
     }
 
-    if (results.error || results.warning) {
-      print(results, chalk, printValidators, reportingStats, originalFile);
-      // fail on errors, but not if there are only warnings
-      if (results.error) exitCode = 1;
+    if (jsonOutput) {
+      printJson(results, originalFile);
     } else {
-      console.log(chalk.green(`\n${validFile} passed the validator`));
-      if (validFile === last(filesToValidate)) console.log();
+      if (results.error || results.warning) {
+        print(results, chalk, printValidators, reportingStats, originalFile);
+        // fail on errors, but not if there are only warnings
+        if (results.error) exitCode = 1;
+      } else {
+        console.log(chalk.green(`\n${validFile} passed the validator`));
+        if (validFile === last(filesToValidate)) console.log();
+      }
     }
   }
 

--- a/src/cli-validator/utils/printJsonResults.js
+++ b/src/cli-validator/utils/printJsonResults.js
@@ -1,0 +1,38 @@
+const each = require('lodash/each');
+
+// get line-number-producing, 'magic' code from Swagger Editor
+const getLineNumberForPath = require(__dirname + '/../../plugins/ast/ast')
+  .getLineNumberForPath;
+
+// function to print the results as json to the console.
+module.exports = function printJson(results, originalFile) {
+  const types = ['errors', 'warnings'];
+  types.forEach(type => {
+    each(results[type], problems => {
+      problems.forEach(problem => {
+        // TODO figure out how to include the config option that caused the error/warning
+        // and inject that as additional data.
+
+        let path = problem.path;
+
+        // path needs to be an array to get the line number
+        if (!Array.isArray(path)) {
+          path = path.split('.');
+        }
+
+        // get line number from the path of strings to the problem
+        // as they say in src/plugins/validation/semantic-validators/hook.js,
+        //
+        //                  "it's magic!"
+        //
+        const line = getLineNumberForPath(originalFile, path);
+
+        // add the line number to the result JSON
+        problem.line = line;
+      });
+    });
+  });
+  // render the results to json in the console with 2 char spacing
+  const jsonstr = JSON.stringify(results, null, 2);
+  console.log(jsonstr);
+};


### PR DESCRIPTION
This revision adds a new --json option to the cli-validator that prints the internal
result data in json format to stdout.  It does additionally include the line number
as a 'line' field in the JSON (this is not in the internal json data).  Automated
test validates that json is received.

Closes #43 