### PR TITLE
fix: don't crash validator when path has a period in it

### DIFF
--- a/src/plugins/validation/oas3/semantic-validators/operations.js
+++ b/src/plugins/validation/oas3/semantic-validators/operations.js
@@ -59,7 +59,8 @@ module.exports.validate = function({ resolvedSpec, jsSpec }, config) {
 
           // referenced request bodies have names
           const referencedRequestBody = Boolean(
-            at(jsSpec, `paths.${pathName}.${opName}.requestBody`)[0].$ref
+            at(jsSpec, `paths['${pathName}']['${opName}']['requestBody']`)[0]
+              .$ref
           );
 
           // form params do not need names

--- a/test/plugins/validation/2and3/paths-ibm.js
+++ b/test/plugins/validation/2and3/paths-ibm.js
@@ -305,6 +305,40 @@ describe('validation plugin - semantic - paths-ibm', function() {
     );
   });
 
+  it('should flag a path segment with a period in the name', function() {
+    const config = {
+      paths: {
+        snake_case_only: 'off',
+        paths_case_convention: ['warning', 'lower_snake_case']
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/v1/api/not.good_.segment/{id}/resource': {
+          parameters: [
+            {
+              in: 'path',
+              name: 'id',
+              description: 'id param',
+              type: 'string'
+            }
+          ]
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual(
+      'paths./v1/api/not.good_.segment/{id}/resource'
+    );
+    expect(res.warnings[0].message).toEqual(
+      'Path segments must follow case convention: lower_snake_case'
+    );
+  });
+
   it('should flag a path segment that does not follow paths_case_convention but should ignore path parameter', function() {
     const config = {
       paths: {

--- a/test/plugins/validation/oas3/operations.js
+++ b/test/plugins/validation/oas3/operations.js
@@ -189,4 +189,38 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.warnings.length).toEqual(0);
     expect(res.errors.length).toEqual(0);
   });
+
+  it('should not crash in request body name check when path name contains a period', function() {
+    const spec = {
+      paths: {
+        '/other.pets': {
+          post: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            requestBody: {
+              description: 'body for request',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      type: 'string'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual('paths./other.pets.post');
+    expect(res.warnings[0].message).toEqual(
+      'Operations with non-form request bodies should set a name with the x-codegen-request-body-name annotation.'
+    );
+    expect(res.errors.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
Passing in a dot-separated string to `lodash/at` is problematic when one of the segments contains a period itself. This PR sanitizes the dot separated strings by using square bracket notation instead.

Test cases added to ensure fix.

Resolves #53 