### PR TITLE
fix: issue 55 problems when filename with path is passed to --config

### DIFF
--- a/src/cli-validator/utils/processConfiguration.js
+++ b/src/cli-validator/utils/processConfiguration.js
@@ -171,8 +171,17 @@ const validateConfigObject = function(configObject, chalk) {
 const getConfigObject = async function(defaultMode, chalk, configFileOverride) {
   let configObject;
 
-  // if user explicitly provided a config file, use it instead of .validaterc
-  const configFileName = configFileOverride || '.validaterc';
+  const findUpOpts = {};
+  let configFileName;
+
+  // You cannot pass a full path into findUp as a file name, you must split the
+  // path or else findUp redudantly prepends the path to the result.
+  if (configFileOverride) {
+    configFileName = path.basename(configFileOverride);
+    findUpOpts.cwd = path.dirname(configFileOverride);
+  } else {
+    configFileName = '.validaterc';
+  }
 
   // search up the file system for the first instance
   // of '.validaterc' or,

--- a/src/cli-validator/utils/processConfiguration.js
+++ b/src/cli-validator/utils/processConfiguration.js
@@ -187,7 +187,7 @@ const getConfigObject = async function(defaultMode, chalk, configFileOverride) {
   // of '.validaterc' or,
   // if a config file override is passed in, use find-up
   // to verify existence of the file
-  const configFile = await findUp(configFileName);
+  const configFile = await findUp(configFileName, findUpOpts);
 
   // if the user does not have a config file, run in default mode and warn them
   // (findUp returns null if it does not find a file)


### PR DESCRIPTION
It turns out that the findUp method cannot handle a full path to a file as input. When this
is passed in, it redudantly or completely incorrectly prepends the current working directory
to the front of the returned path.  Work around is to split any path information off of the
input path and pass the path portion into the method as opt.cwd.

Closes #55