### PR TITLE
fix: raises warning for tag that hasnt been defined in tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ The supported rules are described below:
 ##### operations
 | Rule                         | Description                                                                         | Spec     |
 | ---------------------------- | ----------------------------------------------------------------------------------- | -------- |
+| unused_tag                   | Flag a tag that is in operations and not listed in `tags` on the top level.         | shared   |
 | no_consumes_for_put_or_post  | Flag `put` or `post` operations that do not have a `consumes` field.                | swagger2 |
 | get_op_has_consumes          | Flag `get` operations that contain a `consumes` field.                              | swagger2 |
 | no_produces                  | Flag operations that do not have a `produces` field (except for `head` and operations that return a 204). | swagger2 |

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ The default values for each rule are described below.
 ###### operations
 | Rule                         | Default |
 | ---------------------------- | ------- |
+| unused_tag                   | warning |
 | no_operation_id              | warning |
 | operation_id_case_convention | warning, lower_snake_case |
 | no_summary                   | warning |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -25,7 +25,8 @@ const defaults = {
       'operation_id_case_convention': ['warning', 'lower_snake_case'],
       'no_summary': 'warning',
       'no_array_responses': 'error',
-      'parameter_order': 'warning'
+      'parameter_order': 'warning',
+      'unused_tag': 'warning'
     },
     'parameters': {
       'no_parameter_description': 'error',

--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -132,7 +132,7 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
             if (checkStatus !== 'off') {
               result[checkStatus].push({
                 path: `paths.${pathKey}.${opKey}.tags`,
-                message: 'tag is not defined in operations'
+                message: 'tag is not defined at the global level: ' + op.tags[i]
               });
             }
           }

--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -119,6 +119,25 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
           });
         }
       }
+      const hasOperationTags = op.tags && op.tags.length > 0;
+      const hasGlobalTags = resolvedSpec.tags && resolvedSpec.tags.length > 0;
+      const resolvedTags = [];
+      if (hasOperationTags && hasGlobalTags) {
+        for (let i = 0; i < resolvedSpec.tags.length; i++) {
+          resolvedTags.push(resolvedSpec.tags[i].name);
+        }
+        for (let i = 0, len = op.tags.length; i < len; i++) {
+          if (!resolvedTags.includes(op.tags[i])) {
+            const checkStatus = config.unused_tag;
+            if (checkStatus !== 'off') {
+              result[checkStatus].push({
+                path: `paths.${pathKey}.${opKey}.tags`,
+                message: 'tag is not defined in operations'
+              });
+            }
+          }
+        }
+      }
 
       const hasSummary =
         op.summary && op.summary.length > 0 && !!op.summary.toString().trim();

--- a/test/plugins/validation/2and3/operations-shared.js
+++ b/test/plugins/validation/2and3/operations-shared.js
@@ -715,5 +715,56 @@ describe('validation plugin - semantic - operations-shared', function() {
       );
       expect(res.warnings.length).toEqual(0);
     });
+
+    it('should complain about an unused tag', function() {
+      const spec = {
+        tags: [
+          {
+            name: 'some tag'
+          },
+          {
+            name: 'some other tag'
+          }
+        ],
+        paths: {
+          '/': {
+            get: {
+              operationId: 'get_everything',
+              tags: ['not a tag'],
+              summary: 'get everything as a string or an array',
+              responses: {
+                '200': {
+                  content: {
+                    'text/plain': {
+                      schema: {
+                        type: 'string'
+                      }
+                    },
+                    'application/json': {
+                      schema: {
+                        type: '',
+                        items: {
+                          type: 'string'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      console.log(res);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings.length).toEqual(1);
+
+      expect(res.warnings[0].path).toEqual('paths./.get.tags');
+      expect(res.warnings[0].message).toEqual(
+        'tag is not defined in operations'
+      );
+    });
   });
 });

--- a/test/plugins/validation/2and3/operations-shared.js
+++ b/test/plugins/validation/2and3/operations-shared.js
@@ -739,14 +739,6 @@ describe('validation plugin - semantic - operations-shared', function() {
                       schema: {
                         type: 'string'
                       }
-                    },
-                    'application/json': {
-                      schema: {
-                        type: '',
-                        items: {
-                          type: 'string'
-                        }
-                      }
                     }
                   }
                 }
@@ -763,7 +755,7 @@ describe('validation plugin - semantic - operations-shared', function() {
 
       expect(res.warnings[0].path).toEqual('paths./.get.tags');
       expect(res.warnings[0].message).toEqual(
-        'tag is not defined in operations'
+        'tag is not defined at the global level: not a tag'
       );
     });
   });

--- a/test/plugins/validation/2and3/operations-shared.js
+++ b/test/plugins/validation/2and3/operations-shared.js
@@ -731,7 +731,7 @@ describe('validation plugin - semantic - operations-shared', function() {
             get: {
               operationId: 'get_everything',
               tags: ['not a tag'],
-              summary: 'get everything as a string or an array',
+              summary: 'get everything as a string',
               responses: {
                 '200': {
                   content: {


### PR DESCRIPTION
if there is a tag in operation tags that isn't in the top level tags then a warning will be raised