### PR TITLE
fix: skips warning for non-ref response schemas for primitive or non-…

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -19,11 +19,11 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       each(obj, (response, responseKey) => {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
-            const hasInlineSchema =
-              mediaType.schema &&
-              mediaTypeKey.startsWith('application/json') &&
-              !mediaType.schema.$ref;
-            if (hasInlineSchema) {
+            const hasInlineSchema = mediaType.schema && !mediaType.schema.$ref;
+            if (
+              hasInlineSchema &&
+              mediaTypeKey.startsWith('application/json')
+            ) {
               const checkStatus = config.inline_response_schema;
               if (checkStatus !== 'off') {
                 result[checkStatus].push({

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -19,7 +19,10 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       each(obj, (response, responseKey) => {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
-            const hasInlineSchema = mediaType.schema && !mediaType.schema.$ref;
+            const hasInlineSchema =
+              mediaType.schema &&
+              mediaTypeKey.startsWith('application/json') &&
+              !mediaType.schema.$ref;
             if (hasInlineSchema) {
               const checkStatus = config.inline_response_schema;
               if (checkStatus !== 'off') {

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -1,3 +1,4 @@
+
 const expect = require('expect');
 const {
   validate
@@ -269,7 +270,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain about schemas that dont require $ref', function() {
+      it('should not complain about non-json response that defines an inline schema', function() {
         const config = {
           responses: {
             no_response_codes: 'error',

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -268,6 +268,43 @@ describe('validation plugin - semantic - responses', function() {
         );
         expect(res.errors.length).toEqual(0);
       });
+
+      it('should not complain about schemas that dont require $ref', function() {
+        const config = {
+          responses: {
+            no_response_codes: 'error',
+            no_success_response_codes: 'warning'
+          }
+        };
+
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                responses: {
+                  '400': {
+                    description: 'bad request',
+                    content: {
+                      'plain/text': {
+                        schema: {
+                          type: 'string',
+                          format: 'binary'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec }, config);
+        expect(res.warnings.length).toEqual(0);
+        expect(res.errors.length).toEqual(0);
+      });
     });
   });
 });

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -1,4 +1,3 @@
-
 const expect = require('expect');
 const {
   validate


### PR DESCRIPTION
the validation will go through for media types starting with 'application/json'