### PR TITLE
fix: use correct working dir when resolving multi-file definitions

### DIFF
--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -207,22 +207,17 @@ const processInput = async function(program) {
     try {
       swagger = await buildSwaggerObject(input);
     } catch (err) {
-      // messing with the working directory can have unintended drawbacks
-      // using the try/catch to ensure that the directory is changed back
-      // to the original, even if the ref parser fails
-      // the tests fail without this line
-      process.chdir(originalWorkingDirectory);
-
       printError(chalk, 'There is a problem with the Swagger.', getError(err));
       // Uncomment the line below to see the stack trace when the validator fails
       // console.log(err.stack);
       exitCode = 1;
       continue;
+    } finally {
+      // return the working directory to its original location so that
+      // the rest of the program runs as expected. using finally block
+      // because this must happen regardless of result in buildSwaggerObject
+      process.chdir(originalWorkingDirectory);
     }
-
-    // return the working directory to its original location so that
-    // the rest of the program runs as expected
-    process.chdir(originalWorkingDirectory);
 
     // run validator, print the results, and determine if validator passed
     let results;

--- a/test/cli-validator/mockFiles/multi-file-spec/main.yaml
+++ b/test/cli-validator/mockFiles/multi-file-spec/main.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+paths:
+  /example:
+    get:
+      summary: Summary
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./schema.yaml#/components/schemas/SchemaDef"

--- a/test/cli-validator/mockFiles/multi-file-spec/schema.yaml
+++ b/test/cli-validator/mockFiles/multi-file-spec/schema.yaml
@@ -1,0 +1,6 @@
+openapi: 3.0.0
+paths: {}
+components:
+  schemas:
+    SchemaDef:
+      type: object

--- a/test/cli-validator/tests/expectedOutput.js
+++ b/test/cli-validator/tests/expectedOutput.js
@@ -226,10 +226,35 @@ describe('test expected output - OpenAPI 3', function() {
     const allOutput = capturedText.join('');
 
     expect(exitCode).toEqual(0);
-    expect(
-      allOutput.includes(
-        './test/cli-validator/mockFiles/oas3/clean.yml passed the validator'
-      )
-    ).toEqual(true);
+    expect(allOutput).toContain(
+      './test/cli-validator/mockFiles/oas3/clean.yml passed the validator'
+    );
+  });
+
+  it('should catch problems in a multi-file spec from an outside directory', async function() {
+    const capturedText = [];
+
+    const unhookIntercept = intercept(function(txt) {
+      capturedText.push(stripAnsiFrom(txt));
+      return '';
+    });
+
+    const program = {};
+    program.args = ['./test/cli-validator/mockFiles/multi-file-spec/main.yaml'];
+    program.default_mode = true;
+
+    const exitCode = await commandLineValidator(program);
+
+    unhookIntercept();
+
+    const allOutput = capturedText.join('');
+
+    expect(exitCode).toEqual(1);
+    expect(allOutput).toContain('errors');
+    expect(allOutput).toContain('API definition must have an `info` object');
+    expect(allOutput).toContain('warnings');
+    expect(allOutput).toContain(
+      'Operations must have a non-empty `operationId`.'
+    );
   });
 });


### PR DESCRIPTION
This fixes a bug caused by running the validator on a multi-file definition from any directory other than that of the root file.

The issue is that we read the API definition contents and store them in memory before we run the ref resolver package. When we run the resolver, it has no way to know the context of the original file so it uses the current working directory, the directory from which the command was executed.

One potential solution was to pass the filepath directly to the resolver. It can handle reading in the file and resolving references based on the location of the file as it should. The problem with this solution is that we lose all of the preprocessing we do to remove problematic characters from the document. This leads to the inability to run the validator on files that we would otherwise be able to.

So, that solution proved no good. What I did instead was programmatically change the working directory to the location of the root definition file, just for the resolving of the spec, and then change it back to the original working directory so that nothing else changes. This provides the resolver with the correct context, leaves us with the preprocessing step intact, and has no other impact on how the code runs.

Fixes #29 