### PR TITLE
fix: response links are not validated as responses

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/walker.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker.js
@@ -127,6 +127,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
 // values are globs!
 const unacceptableRefPatternsS2 = {
   responses: ['!*#/responses*'],
+  links: ['!*#/links*'],
   schema: ['!*#/definitions*'],
   parameters: ['!*#/parameters*']
 };

--- a/src/plugins/validation/2and3/semantic-validators/walker.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker.js
@@ -139,7 +139,8 @@ const unacceptableRefPatternsOAS3 = {
   security: ['!*#/components/securitySchemes*'],
   callbacks: ['!*#/components/callbacks*'],
   examples: ['!*#/components/examples*'],
-  headers: ['!*#/components/headers*']
+  headers: ['!*#/components/headers*'],
+  links: ['!*#/components/links*']
 };
 
 const exceptionedParents = ['properties'];

--- a/test/plugins/validation/2and3/walker.js
+++ b/test/plugins/validation/2and3/walker.js
@@ -600,6 +600,55 @@ describe('validation plugin - semantic - spec walker', () => {
           'description'
         ]);
       });
+      it('should return a problem for a parameters $ref in a response position', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              responses: {
+                '200': {
+                  desciption: 'hi',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'string'
+                      }
+                    }
+                  },
+                  headers: {
+                    Location: {
+                      description: 'hi',
+                      schema: {
+                        type: 'string'
+                      }
+                    }
+                  },
+                  links: {
+                    link1: {
+                      $ref: '#/parameters/abc'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec }, config);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/CoolPath/{id}',
+          'responses',
+          '200',
+          'links',
+          'link1',
+          '$ref'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'links $refs must follow this format: *#/links*'
+        );
+      });
     });
   });
 });

--- a/test/plugins/validation/2and3/walker.js
+++ b/test/plugins/validation/2and3/walker.js
@@ -600,7 +600,7 @@ describe('validation plugin - semantic - spec walker', () => {
           'description'
         ]);
       });
-      it('should return a problem for a parameters $ref in a response position', function() {
+      it('should return a problem for a links $ref that does not have the correct format', function() {
         const spec = {
           paths: {
             '/CoolPath/{id}': {


### PR DESCRIPTION
walker.js now recognizes links in components and adds it to the dictionary so the validator no longer returns an error asking for the response link refs to be formatted as responses instead of following the format of '#/components/links'.