### PR TITLE
fix: skips validation for non-string enum values

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -369,7 +369,7 @@ function checkEnumValues(schema, contextPath, config) {
         if (!isSnakecase(enumValue)) {
           result[checkStatus].push({
             path: contextPath.concat(['enum', i.toString()]),
-            message: 'Enum values must be lower snake case strings.'
+            message: 'Enum values must be lower snake case.'
           });
         }
       }

--- a/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -363,14 +363,15 @@ function checkEnumValues(schema, contextPath, config) {
 
   for (let i = 0; i < schema.enum.length; i++) {
     const enumValue = schema.enum[i];
-
-    const checkStatus = config.snake_case_only || 'off';
-    if (checkStatus.match('error|warning')) {
-      if (!isSnakecase(enumValue)) {
-        result[checkStatus].push({
-          path: contextPath.concat(['enum', i.toString()]),
-          message: 'Enum values must be lower snake case.'
-        });
+    if (typeof enumValue === 'string') {
+      const checkStatus = config.snake_case_only || 'off';
+      if (checkStatus.match('error|warning')) {
+        if (!isSnakecase(enumValue)) {
+          result[checkStatus].push({
+            path: contextPath.concat(['enum', i.toString()]),
+            message: 'Enum values must be lower snake case strings.'
+          });
+        }
       }
     }
   }
@@ -398,16 +399,17 @@ function checkEnumCaseConvention(schema, contextPath, caseConvention) {
 
   for (let i = 0; i < schema.enum.length; i++) {
     const enumValue = schema.enum[i];
-
-    const checkStatus = caseConvention[0] || 'off';
-    if (checkStatus.match('error|warning')) {
-      const caseConventionValue = caseConvention[1];
-      const isCorrectCase = checkCase(enumValue, caseConventionValue);
-      if (!isCorrectCase) {
-        result[checkStatus].push({
-          path: contextPath.concat(['enum', i.toString()]),
-          message: `Enum values must follow case convention: ${caseConventionValue}`
-        });
+    if (typeof enumValue === 'string') {
+      const checkStatus = caseConvention[0] || 'off';
+      if (checkStatus.match('error|warning')) {
+        const caseConventionValue = caseConvention[1];
+        const isCorrectCase = checkCase(enumValue, caseConventionValue);
+        if (!isCorrectCase) {
+          result[checkStatus].push({
+            path: contextPath.concat(['enum', i.toString()]),
+            message: `Enum values must follow case convention: ${caseConventionValue}`
+          });
+        }
       }
     }
   }
@@ -428,3 +430,4 @@ function isRootSchema(path) {
     current === 'schema' || (parent === 'definitions' && path.length === 2)
   );
 }
+

--- a/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -430,4 +430,3 @@ function isRootSchema(path) {
     current === 'schema' || (parent === 'definitions' && path.length === 2)
   );
 }
-

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -1011,7 +1011,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '2'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case.'
+      'Enum values must be lower snake case strings.'
     );
   });
 
@@ -1059,7 +1059,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '1'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case.'
+      'Enum values must be lower snake case strings.'
     );
   });
 
@@ -1098,7 +1098,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '2'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case.'
+      'Enum values must be lower snake case strings.'
     );
   });
 
@@ -1146,7 +1146,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '1'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case.'
+      'Enum values must be lower snake case strings.'
     );
   });
 
@@ -1327,5 +1327,33 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
     expect(res.warnings[0].message).toEqual(
       'Enum values must follow case convention: lower_snake_case'
     );
+  });
+
+  it('should skip validation for non string values', () => {
+    const config = {
+      schemas: {
+        snake_case_only: 'warning'
+      }
+    };
+
+    const spec = {
+      definitions: {
+        Thing: {
+          type: 'object',
+          description: 'thing',
+          properties: {
+            color: {
+              type: 'string',
+              description: 'some color',
+              enum: [1, 2, 3]
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(0);
   });
 });

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -1342,9 +1342,9 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
           type: 'object',
           description: 'thing',
           properties: {
-            integers: {
+            integer: {
               type: 'integer',
-              description: 'list of integers',
+              description: 'an integer',
               enum: [1, 2, 3]
             }
           }

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -1011,7 +1011,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '2'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case strings.'
+      'Enum values must be lower snake case.'
     );
   });
 
@@ -1059,7 +1059,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '1'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case strings.'
+      'Enum values must be lower snake case.'
     );
   });
 
@@ -1098,7 +1098,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '2'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case strings.'
+      'Enum values must be lower snake case.'
     );
   });
 
@@ -1146,7 +1146,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '1'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Enum values must be lower snake case strings.'
+      'Enum values must be lower snake case.'
     );
   });
 
@@ -1342,9 +1342,9 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
           type: 'object',
           description: 'thing',
           properties: {
-            color: {
+            integers: {
               type: 'string',
-              description: 'some color',
+              description: 'list of integers',
               enum: [1, 2, 3]
             }
           }

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -1343,7 +1343,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
           description: 'thing',
           properties: {
             integers: {
-              type: 'string',
+              type: 'integer',
               description: 'list of integers',
               enum: [1, 2, 3]
             }


### PR DESCRIPTION
Validator will skip validation of non-string enum values.