### PR TITLE
fix: response schema support for oneOf, anyOf, and allOf refs

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -19,12 +19,52 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       each(obj, (response, responseKey) => {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
-            if (
-              mediaType.schema.oneOf ||
-              mediaType.schema.anyOf ||
-              mediaType.schema.allOf
-            ) {
-              for (let i = 0; i < mediaType.schema.oneOf; i++) {
+            if (mediaType.schema.oneOf) {
+              for (let i = 0; i < mediaType.schema.oneOf.length; i++) {
+                const hasInlineSchema =
+                  mediaType.schema &&
+                  mediaType.schema.oneOf &&
+                  !mediaType.schema.oneOf.$ref;
+                if (hasInlineSchema) {
+                  const checkStatus = config.inline_response_schema;
+                  if (checkStatus !== 'off') {
+                    result[checkStatus].push({
+                      path: [
+                        ...path,
+                        responseKey,
+                        'content',
+                        mediaTypeKey,
+                        'schema'
+                      ],
+                      message: INLINE_SCHEMA_MESSAGE
+                    });
+                  }
+                }
+              }
+            } else if (mediaType.schema.allOf) {
+              for (let i = 0; i < mediaType.schema.allOf.length; i++) {
+                const hasInlineSchema =
+                  mediaType.schema &&
+                  mediaType.schema.oneOf &&
+                  !mediaType.schema.oneOf.$ref;
+                if (hasInlineSchema) {
+                  const checkStatus = config.inline_response_schema;
+                  if (checkStatus !== 'off') {
+                    result[checkStatus].push({
+                      path: [
+                        ...path,
+                        responseKey,
+                        'content',
+                        mediaTypeKey,
+                        'schema'
+                      ],
+                      message: INLINE_SCHEMA_MESSAGE
+                    });
+                  }
+                }
+              }
+            } else if (mediaType.schema.anyOf) {
+              for (let i = 0; i < mediaType.schema.anyOf.length; i++) {
                 const hasInlineSchema =
                   mediaType.schema &&
                   mediaType.schema.oneOf &&

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -19,6 +19,33 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       each(obj, (response, responseKey) => {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
+            if (
+              mediaType.schema.oneOf ||
+              mediaType.schema.anyOf ||
+              mediaType.schema.allOf
+            ) {
+              for (let i = 0; i < mediaType.schema.oneOf; i++) {
+                const hasInlineSchema =
+                  mediaType.schema &&
+                  mediaType.schema.oneOf &&
+                  !mediaType.schema.oneOf.$ref;
+                if (hasInlineSchema) {
+                  const checkStatus = config.inline_response_schema;
+                  if (checkStatus !== 'off') {
+                    result[checkStatus].push({
+                      path: [
+                        ...path,
+                        responseKey,
+                        'content',
+                        mediaTypeKey,
+                        'schema'
+                      ],
+                      message: INLINE_SCHEMA_MESSAGE
+                    });
+                  }
+                }
+              }
+            }
             const hasInlineSchema = mediaType.schema && !mediaType.schema.$ref;
             if (
               hasInlineSchema &&

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -305,6 +305,49 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.warnings.length).toEqual(0);
         expect(res.errors.length).toEqual(0);
       });
+
+      it('should not complain about oneOf response schema that is defined by refs', function() {
+        const config = {
+          responses: {
+            no_response_codes: 'error',
+            no_success_response_codes: 'warning'
+          }
+        };
+
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                responses: {
+                  '400': {
+                    description: 'bad request',
+                    content: {
+                      'plain/text': {
+                        schema: {
+                          oneOf: [
+                            {
+                              $ref: '#/components/schemas/Status'
+                            },
+                            {
+                              $ref: '#/components/schemas/Error'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec }, config);
+        expect(res.warnings.length).toEqual(0);
+        expect(res.errors.length).toEqual(0);
+      });
     });
   });
 });


### PR DESCRIPTION
validator will not complain for refs in oneOf, allOf or anyOf unless they are defined inline