### PR TITLE
Response schemas

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -20,59 +20,59 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
             const combinedSchemaTypes = ['allOf', 'oneOf', 'anyOf'];
-            if (
+            const hasOfProperty =
               mediaType.schema.allOf ||
-              mediaType.schema.oneOf ||
-              mediaType.schema.anyOf
+              mediaType.schema.anyOf ||
+              mediaType.schema.oneOf;
+
+            if (
+              mediaType.schema &&
+              mediaTypeKey.startsWith('application/json')
             ) {
-              combinedSchemaTypes.forEach(schemaType => {
-                if (mediaType.schema[schemaType]) {
-                  for (
-                    let i = 0;
-                    i < mediaType.schema[schemaType].length;
-                    i++
-                  ) {
-                    const hasInlineSchema =
-                      mediaType.schema &&
-                      mediaType.schema[schemaType] &&
-                      !mediaType.schema[schemaType][i].$ref;
-                    if (hasInlineSchema) {
-                      const checkStatus = config.inline_response_schema;
-                      if (checkStatus !== 'off') {
-                        result[checkStatus].push({
-                          path: [
-                            ...path,
-                            responseKey,
-                            'content',
-                            mediaTypeKey,
-                            'schema',
-                            schemaType,
-                            i
-                          ],
-                          message: INLINE_SCHEMA_MESSAGE
-                        });
+              if (hasOfProperty) {
+                combinedSchemaTypes.forEach(schemaType => {
+                  if (mediaType.schema[schemaType]) {
+                    for (
+                      let i = 0;
+                      i < mediaType.schema[schemaType].length;
+                      i++
+                    ) {
+                      const hasInlineSchema = !mediaType.schema[schemaType][i]
+                        .$ref;
+                      if (hasInlineSchema) {
+                        const checkStatus = config.inline_response_schema;
+                        if (checkStatus !== 'off') {
+                          result[checkStatus].push({
+                            path: [
+                              ...path,
+                              responseKey,
+                              'content',
+                              mediaTypeKey,
+                              'schema',
+                              schemaType,
+                              i
+                            ],
+                            message: INLINE_SCHEMA_MESSAGE
+                          });
+                        }
                       }
                     }
                   }
-                }
-              });
-            } else if (
-              mediaType.schema &&
-              !mediaType.schema.$ref &&
-              mediaTypeKey.startsWith('application/json')
-            ) {
-              const checkStatus = config.inline_response_schema;
-              if (checkStatus !== 'off') {
-                result[checkStatus].push({
-                  path: [
-                    ...path,
-                    responseKey,
-                    'content',
-                    mediaTypeKey,
-                    'schema'
-                  ],
-                  message: INLINE_SCHEMA_MESSAGE
                 });
+              } else if (!mediaType.schema.$ref) {
+                const checkStatus = config.inline_response_schema;
+                if (checkStatus !== 'off') {
+                  result[checkStatus].push({
+                    path: [
+                      ...path,
+                      responseKey,
+                      'content',
+                      mediaTypeKey,
+                      'schema'
+                    ],
+                    message: INLINE_SCHEMA_MESSAGE
+                  });
+                }
               }
             }
           });

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -19,12 +19,52 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       each(obj, (response, responseKey) => {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
-            if (
-              mediaType.schema.oneOf ||
-              mediaType.schema.anyOf ||
-              mediaType.schema.allOf
-            ) {
-              for (let i = 0; i < mediaType.schema.oneOf; i++) {
+            if (mediaType.schema.oneOf) {
+              for (let i = 0; i < mediaType.schema.oneOf.length; i++) {
+                const hasInlineSchema =
+                  mediaType.schema &&
+                  mediaType.schema.oneOf &&
+                  !mediaType.schema.oneOf.$ref;
+                if (hasInlineSchema) {
+                  const checkStatus = config.inline_response_schema;
+                  if (checkStatus !== 'off') {
+                    result[checkStatus].push({
+                      path: [
+                        ...path,
+                        responseKey,
+                        'content',
+                        mediaTypeKey,
+                        'schema'
+                      ],
+                      message: INLINE_SCHEMA_MESSAGE
+                    });
+                  }
+                }
+              }
+            } else if (mediaType.schema.allOf) {
+              for (let i = 0; i < mediaType.schema.allOf.length; i++) {
+                const hasInlineSchema =
+                  mediaType.schema &&
+                  mediaType.schema.oneOf &&
+                  !mediaType.schema.oneOf.$ref;
+                if (hasInlineSchema) {
+                  const checkStatus = config.inline_response_schema;
+                  if (checkStatus !== 'off') {
+                    result[checkStatus].push({
+                      path: [
+                        ...path,
+                        responseKey,
+                        'content',
+                        mediaTypeKey,
+                        'schema'
+                      ],
+                      message: INLINE_SCHEMA_MESSAGE
+                    });
+                  }
+                }
+              }
+            } else if (mediaType.schema.anyOf) {
+              for (let i = 0; i < mediaType.schema.anyOf.length; i++) {
                 const hasInlineSchema =
                   mediaType.schema &&
                   mediaType.schema.oneOf &&

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -19,6 +19,33 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       each(obj, (response, responseKey) => {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
+            if (
+              mediaType.schema.oneOf ||
+              mediaType.schema.anyOf ||
+              mediaType.schema.allOf
+            ) {
+              for (let i = 0; i < mediaType.schema.oneOf; i++) {
+                const hasInlineSchema =
+                  mediaType.schema &&
+                  mediaType.schema.oneOf &&
+                  !mediaType.schema.oneOf.$ref;
+                if (hasInlineSchema) {
+                  const checkStatus = config.inline_response_schema;
+                  if (checkStatus !== 'off') {
+                    result[checkStatus].push({
+                      path: [
+                        ...path,
+                        responseKey,
+                        'content',
+                        mediaTypeKey,
+                        'schema'
+                      ],
+                      message: INLINE_SCHEMA_MESSAGE
+                    });
+                  }
+                }
+              }
+            }
             const hasInlineSchema = mediaType.schema && !mediaType.schema.$ref;
             if (
               hasInlineSchema &&

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -24,7 +24,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                 const hasInlineSchema =
                   mediaType.schema &&
                   mediaType.schema.oneOf &&
-                  !mediaType.schema.oneOf.$ref;
+                  !mediaType.schema.oneOf[i].$ref;
                 if (hasInlineSchema) {
                   const checkStatus = config.inline_response_schema;
                   if (checkStatus !== 'off') {
@@ -46,7 +46,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                 const hasInlineSchema =
                   mediaType.schema &&
                   mediaType.schema.oneOf &&
-                  !mediaType.schema.oneOf.$ref;
+                  !mediaType.schema.oneOf[i].$ref;
                 if (hasInlineSchema) {
                   const checkStatus = config.inline_response_schema;
                   if (checkStatus !== 'off') {
@@ -64,11 +64,11 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                 }
               }
             } else if (mediaType.schema.anyOf) {
-              for (let i = 0; i < mediaType.schema.anyOf.length; i++) {
+              for (let i = 0; i < mediaType.schema.anyOf.length[i]; i++) {
                 const hasInlineSchema =
                   mediaType.schema &&
                   mediaType.schema.oneOf &&
-                  !mediaType.schema.oneOf.$ref;
+                  !mediaType.schema.oneOf[i].$ref;
                 if (hasInlineSchema) {
                   const checkStatus = config.inline_response_schema;
                   if (checkStatus !== 'off') {

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -20,16 +20,17 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
         if (isOAS3) {
           each(response.content, (mediaType, mediaTypeKey) => {
             const combinedSchemaTypes = ['allOf', 'oneOf', 'anyOf'];
-            const hasOfProperty =
-              mediaType.schema.allOf ||
-              mediaType.schema.anyOf ||
-              mediaType.schema.oneOf;
 
             if (
               mediaType.schema &&
               mediaTypeKey.startsWith('application/json')
             ) {
-              if (hasOfProperty) {
+              const hasCombinedSchema =
+                mediaType.schema.allOf ||
+                mediaType.schema.anyOf ||
+                mediaType.schema.oneOf;
+
+              if (hasCombinedSchema) {
                 combinedSchemaTypes.forEach(schemaType => {
                   if (mediaType.schema[schemaType]) {
                     for (

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -161,7 +161,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a valid response in oneOf, anyOf, or allOf', function() {
+      it('should not complain for a valid response in oneOf', function() {
         const spec = {
           paths: {
             '/stuff': {
@@ -198,6 +198,79 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
+      it('should not complain for a valid response in allOf', function() {
+        const spec = {
+          paths: {
+            '/stuff': {
+              get: {
+                summary: 'list stuff',
+                operationId: 'listStuff',
+                responses: {
+                  200: {
+                    description: 'successful operation',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          allOf: [
+                            {
+                              $ref:
+                                '#/components/schemas/ListStuffResponseModel'
+                            },
+                            {
+                              $ref: '#/components/schemas/ListStuffSecondModel'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(0);
+        expect(res.errors.length).toEqual(0);
+      });
+
+      it('should not complain for a valid response in anyOf', function() {
+        const spec = {
+          paths: {
+            '/stuff': {
+              get: {
+                summary: 'list stuff',
+                operationId: 'listStuff',
+                responses: {
+                  200: {
+                    description: 'successful operation',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          anyOf: [
+                            {
+                              $ref:
+                                '#/components/schemas/ListStuffResponseModel'
+                            },
+                            {
+                              $ref: '#/components/schemas/ListStuffSecondModel'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(0);
+        expect(res.errors.length).toEqual(0);
+      });
       it('should complain about an inline schema', function() {
         const spec = {
           paths: {
@@ -245,7 +318,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should complain about an inline schema when using oneOf, anyOf, or allOf', function() {
+      it('should complain about an inline schema when using oneOf', function() {
         const spec = {
           paths: {
             '/stuff': {
@@ -261,6 +334,9 @@ describe('validation plugin - semantic - responses', function() {
                           oneOf: [
                             {
                               type: 'object'
+                            },
+                            {
+                              $ref: 'ref1'
                             }
                           ]
                         }
@@ -284,7 +360,110 @@ describe('validation plugin - semantic - responses', function() {
           'content',
           'application/json',
           'schema',
-          'oneOf'
+          'oneOf',
+          0
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'Response schemas should be defined with a named ref.'
+        );
+        expect(res.errors.length).toEqual(0);
+      });
+
+      it('should complain about an inline schema when using allOf', function() {
+        const spec = {
+          paths: {
+            '/stuff': {
+              get: {
+                summary: 'list stuff',
+                operationId: 'listStuff',
+                responses: {
+                  200: {
+                    description: 'successful operation',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          allOf: [
+                            {
+                              type: 'object'
+                            },
+                            {
+                              $ref: 'ref1'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/stuff',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/json',
+          'schema',
+          'allOf',
+          0
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'Response schemas should be defined with a named ref.'
+        );
+        expect(res.errors.length).toEqual(0);
+      });
+
+      it('should complain about an inline schema when using anyOf', function() {
+        const spec = {
+          paths: {
+            '/stuff': {
+              get: {
+                summary: 'list stuff',
+                operationId: 'listStuff',
+                responses: {
+                  200: {
+                    description: 'successful operation',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          anyOf: [
+                            {
+                              type: 'object'
+                            },
+                            {
+                              $ref: 'ref1'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/stuff',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/json',
+          'schema',
+          'anyOf',
+          0
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -161,6 +161,43 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
+      it('should not complain for a valid response in oneOf, anyOf, or allOf', function() {
+        const spec = {
+          paths: {
+            '/stuff': {
+              get: {
+                summary: 'list stuff',
+                operationId: 'listStuff',
+                responses: {
+                  200: {
+                    description: 'successful operation',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          oneOf: [
+                            {
+                              $ref:
+                                '#/components/schemas/ListStuffResponseModel'
+                            },
+                            {
+                              $ref: '#/components/schemas/ListStuffSecondModel'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(0);
+        expect(res.errors.length).toEqual(0);
+      });
+
       it('should complain about an inline schema', function() {
         const spec = {
           paths: {
@@ -201,6 +238,53 @@ describe('validation plugin - semantic - responses', function() {
           'content',
           'application/json',
           'schema'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'Response schemas should be defined with a named ref.'
+        );
+        expect(res.errors.length).toEqual(0);
+      });
+
+      it('should complain about an inline schema when using oneOf, anyOf, or allOf', function() {
+        const spec = {
+          paths: {
+            '/stuff': {
+              get: {
+                summary: 'list stuff',
+                operationId: 'listStuff',
+                responses: {
+                  200: {
+                    description: 'successful operation',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          oneOf: [
+                            {
+                              type: 'object'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/stuff',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/json',
+          'schema',
+          'oneOf'
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'
@@ -291,50 +375,6 @@ describe('validation plugin - semantic - responses', function() {
                         schema: {
                           type: 'string',
                           format: 'binary'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        };
-
-        const res = validate({ jsSpec: spec }, config);
-        expect(res.warnings.length).toEqual(0);
-        expect(res.errors.length).toEqual(0);
-      });
-
-      it('should not complain about oneOf response schema that is defined by refs', function() {
-        const config = {
-          responses: {
-            no_response_codes: 'error',
-            no_success_response_codes: 'warning'
-          }
-        };
-
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                responses: {
-                  '400': {
-                    description: 'bad request',
-                    content: {
-                      'plain/text': {
-                        schema: {
-                          oneOf: [
-                            {
-                              type: 'string',
-                              format: 'binary'
-                            },
-                            {
-                              $ref: 'bkk.'
-                            }
-                          ]
                         }
                       }
                     }

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -328,10 +328,11 @@ describe('validation plugin - semantic - responses', function() {
                         schema: {
                           oneOf: [
                             {
-                              $ref: '#/components/schemas/Status'
+                              type: 'string',
+                              format: 'binary'
                             },
                             {
-                              $ref: '#/components/schemas/Error'
+                              $ref: 'bkk.'
                             }
                           ]
                         }

--- a/test/plugins/validation/2and3/responses.js
+++ b/test/plugins/validation/2and3/responses.js
@@ -305,6 +305,49 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.warnings.length).toEqual(0);
         expect(res.errors.length).toEqual(0);
       });
+
+      it('should not complain about oneOf response schema that is defined by refs', function() {
+        const config = {
+          responses: {
+            no_response_codes: 'error',
+            no_success_response_codes: 'warning'
+          }
+        };
+
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                responses: {
+                  '400': {
+                    description: 'bad request',
+                    content: {
+                      'plain/text': {
+                        schema: {
+                          oneOf: [
+                            {
+                              $ref: '#/components/schemas/Status'
+                            },
+                            {
+                              $ref: '#/components/schemas/Error'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec }, config);
+        expect(res.warnings.length).toEqual(0);
+        expect(res.errors.length).toEqual(0);
+      });
     });
   });
 });


### PR DESCRIPTION
validator now recognizes oneOf, allOf, and anyOf and will only issue a warning if the lists contain inline schemas instead of only refs