### PR TITLE
fix: validator has new parameter differentiation checks

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
@@ -25,11 +25,24 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
     if (obj['x-sdk-exclude'] === true) {
       return;
     }
-
     const contentsOfParameterObject = path[path.length - 2] === 'parameters';
+    const pathsForParameters = [
+      'get',
+      'put',
+      'post',
+      'delete',
+      'options',
+      'head',
+      'patch',
+      'trace',
+      'components'
+    ];
 
-    // obj is a parameter object
-    if (contentsOfParameterObject) {
+    if (
+      contentsOfParameterObject &&
+      pathsForParameters.includes(path[path.length - 3])
+    ) {
+      // obj is a parameter object
       const isRef = !!obj.$ref;
       const hasDescription = !!obj.description;
 

--- a/test/plugins/validation/2and3/parameters-ibm.js
+++ b/test/plugins/validation/2and3/parameters-ibm.js
@@ -302,6 +302,35 @@ describe('validation plugin - semantic - parameters-ibm', () => {
   });
 
   describe('OpenAPI 3', () => {
+    it('should not complain about a property names parameters but is not a parameter object', () => {
+      const spec = {
+        components: {
+          responses: {
+            parameters: {
+              description: 'successful operation',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      parameters: {
+                        type: 'string',
+                        description: 'this is a description',
+                        additionalProperties: {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const res = validate({ jsSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(0);
+      expect(res.errors.length).toEqual(0);
+    });
+
     it('should return an error when a parameter defines content-type, accept, or authorization', () => {
       const spec = {
         paths: {


### PR DESCRIPTION
validator can now tell the difference between properties named 'parameters' and parameter objects and should not apply the same checks to properties named 'paramters'