### PR TITLE
fix: flag any operations with array responses

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -67,32 +67,29 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
       });
 
       // Arrays MUST NOT be returned as the top-level structure in a response body.
-      const isGetOperation = opKey.toLowerCase() === 'get';
-      if (isGetOperation) {
-        const checkStatus = config.no_array_responses;
-        if (checkStatus !== 'off') {
-          each(op.responses, (response, name) => {
-            if (isOAS3) {
-              each(response.content, (content, contentType) => {
-                if (content.schema && content.schema.type === 'array') {
-                  result[checkStatus].push({
-                    path: `paths.${pathKey}.${opKey}.responses.${name}.content.${contentType}.schema`,
-                    message:
-                      'Arrays MUST NOT be returned as the top-level structure in a response body.'
-                  });
-                }
-              });
-            } else {
-              if (response.schema && response.schema.type === 'array') {
-                result[checkStatus].push({
-                  path: `paths.${pathKey}.${opKey}.responses.${name}.schema`,
+      const checkStatusArrRes = config.no_array_responses;
+      if (checkStatusArrRes !== 'off') {
+        each(op.responses, (response, name) => {
+          if (isOAS3) {
+            each(response.content, (content, contentType) => {
+              if (content.schema && content.schema.type === 'array') {
+                result[checkStatusArrRes].push({
+                  path: `paths.${pathKey}.${opKey}.responses.${name}.content.${contentType}.schema`,
                   message:
                     'Arrays MUST NOT be returned as the top-level structure in a response body.'
                 });
               }
+            });
+          } else {
+            if (response.schema && response.schema.type === 'array') {
+              result[checkStatusArrRes].push({
+                path: `paths.${pathKey}.${opKey}.responses.${name}.schema`,
+                message:
+                  'Arrays MUST NOT be returned as the top-level structure in a response body.'
+              });
             }
-          });
-        }
+          }
+        });
       }
 
       const hasOperationId =
@@ -153,8 +150,8 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
 
       // this should be good with resolved spec, but double check
       // All required parameters of an operation are listed before any optional parameters.
-      const checkStatus = config.parameter_order;
-      if (checkStatus !== 'off') {
+      const checkStatusParamOrder = config.parameter_order;
+      if (checkStatusParamOrder !== 'off') {
         if (op.parameters && op.parameters.length > 0) {
           let firstOptional = -1;
           for (let indx = 0; indx < op.parameters.length; indx++) {
@@ -165,7 +162,7 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
               }
             } else {
               if (param.required) {
-                result[checkStatus].push({
+                result[checkStatusParamOrder].push({
                   path: `paths.${pathKey}.${opKey}.parameters[${indx}]`,
                   message:
                     'Required parameters should appear before optional parameters.'

--- a/test/plugins/validation/2and3/operations-shared.js
+++ b/test/plugins/validation/2and3/operations-shared.js
@@ -255,7 +255,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       const spec = {
         paths: {
           '/stuff': {
-            get: {
+            post: {
               summary: 'list stuff',
               operationId: 'list_stuff',
               produces: ['application/json'],
@@ -285,7 +285,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       const res = validate({ resolvedSpec }, config);
       expect(res.errors.length).toEqual(1);
       expect(res.errors[0].path).toEqual(
-        'paths./stuff.get.responses.200.schema'
+        'paths./stuff.post.responses.200.schema'
       );
       expect(res.errors[0].message).toEqual(
         'Arrays MUST NOT be returned as the top-level structure in a response body.'
@@ -678,9 +678,19 @@ describe('validation plugin - semantic - operations-shared', function() {
       const spec = {
         paths: {
           '/': {
-            get: {
+            put: {
               operationId: 'get_everything',
               summary: 'get everything as a string or an array',
+              requestBody: {
+                description: 'simple body',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                }
+              },
               responses: {
                 '200': {
                   content: {
@@ -708,7 +718,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
       expect(res.errors.length).toEqual(1);
       expect(res.errors[0].path).toEqual(
-        'paths./.get.responses.200.content.application/json.schema'
+        'paths./.put.responses.200.content.application/json.schema'
       );
       expect(res.errors[0].message).toEqual(
         'Arrays MUST NOT be returned as the top-level structure in a response body.'


### PR DESCRIPTION
The validator was mistakenly checking only GET operations for array responses. This PR switches the logic to check _any_ operation, which is how we describe the check in our documentation. Test cases adjusted to verify this logic.

Resoves #71