### PR TITLE
Config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The default values for each rule are described below.
 | Rule                        | Default |
 | --------------------------- | --------|
 | no_parameter_description    | error   |
-| param_name_case_convention  | warning, lower_snake_case |
+| param_name_case_convention  | error, lower_snake_case |
 | invalid_type_format_pair    | error   |
 | content_type_parameter      | error   |
 | accept_type_parameter       | error   |
@@ -370,8 +370,8 @@ The default values for each rule are described below.
 | Rule                        | Default |
 | --------------------------- | ------- |
 | missing_path_parameter      | error   |
-| snake_case_only             | warning |
-| paths_case_convention       | off, lower_snake_case |
+| snake_case_only             | off     |
+| paths_case_convention       | error, lower_snake_case |
 
 ##### responses
 | Rule                      | Default |
@@ -393,13 +393,13 @@ The default values for each rule are described below.
 | Rule                        | Default |
 | --------------------------- | ------- |
 | invalid_type_format_pair    | error   |
-| snake_case_only             | warning |
+| snake_case_only             | off     |
 | no_schema_description       | warning |
 | no_property_description     | warning |
 | description_mentions_json   | warning |
 | array_of_arrays             | warning |
-| property_case_convention    | off, lower_snake_case |
-| enum_case_convention        | off, lower_snake_case |
+| property_case_convention    | error, lower_snake_case |
+| enum_case_convention        | error, lower_snake_case |
 
 ###### walker
 | Rule                          | Default |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -30,7 +30,7 @@ const defaults = {
     },
     'parameters': {
       'no_parameter_description': 'error',
-      'param_name_case_convention': ['warning', 'lower_snake_case'],
+      'param_name_case_convention': ['error', 'lower_snake_case'],
       'invalid_type_format_pair': 'error',
       'content_type_parameter': 'error',
       'accept_type_parameter': 'error',
@@ -39,8 +39,8 @@ const defaults = {
     },
     'paths': {
       'missing_path_parameter': 'error',
-      'snake_case_only': 'warning',
-      'paths_case_convention': ['off', 'lower_snake_case']
+      'snake_case_only': 'off',
+      'paths_case_convention': ['error', 'lower_snake_case']
     },
     'responses': {
       'inline_response_schema': 'warning'
@@ -54,13 +54,13 @@ const defaults = {
     },
     'schemas': {
       'invalid_type_format_pair': 'error',
-      'snake_case_only': 'warning',
+      'snake_case_only': 'off',
       'no_schema_description': 'warning',
       'no_property_description': 'warning',
       'description_mentions_json': 'warning',
       'array_of_arrays': 'warning',
-      'property_case_convention': [ 'off', 'lower_snake_case'],
-      'enum_case_convention': [ 'off', 'lower_snake_case']
+      'property_case_convention': [ 'error', 'lower_snake_case'],
+      'enum_case_convention': [ 'error', 'lower_snake_case']
     },
     'walker': {
       'no_empty_descriptions': 'error',

--- a/test/cli-validator/tests/configFileValidator.js
+++ b/test/cli-validator/tests/configFileValidator.js
@@ -296,7 +296,7 @@ describe('cli tool - test config file validator', function() {
     expect(res.invalid).toEqual(false);
     expect(capturedText.length).toEqual(0);
     expect(Array.isArray(status)).toEqual(true);
-    expect(status[0]).not.toEqual(defaultStatus[0]);
+    expect(status[0]).toEqual(defaultStatus[0]);
     expect(status[1]).toEqual(defaultStatus[1]);
   });
 

--- a/test/cli-validator/tests/expectedOutput.js
+++ b/test/cli-validator/tests/expectedOutput.js
@@ -87,17 +87,21 @@ describe('cli tool - test expected output - Swagger 2', function() {
 
     // .match(/\S+/g) returns an array of all non-whitespace strings
     //   example output would be [ 'Line', ':', '59' ]
+
+    // errors
     expect(capturedText[4].match(/\S+/g)[2]).toEqual('31');
     expect(capturedText[8].match(/\S+/g)[2]).toEqual('54');
     expect(capturedText[12].match(/\S+/g)[2]).toEqual('59');
     expect(capturedText[16].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[21].match(/\S+/g)[2]).toEqual('36');
-    expect(capturedText[25].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[29].match(/\S+/g)[2]).toEqual('197');
-    expect(capturedText[33].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[37].match(/\S+/g)[2]).toEqual('131');
-    expect(capturedText[41].match(/\S+/g)[2]).toEqual('134');
-    expect(capturedText[45].match(/\S+/g)[2]).toEqual('172');
+    expect(capturedText[20].match(/\S+/g)[2]).toEqual('172');
+
+    // warnings
+    expect(capturedText[25].match(/\S+/g)[2]).toEqual('36');
+    expect(capturedText[29].match(/\S+/g)[2]).toEqual('59');
+    expect(capturedText[33].match(/\S+/g)[2]).toEqual('197');
+    expect(capturedText[37].match(/\S+/g)[2]).toEqual('108');
+    expect(capturedText[41].match(/\S+/g)[2]).toEqual('131');
+    expect(capturedText[45].match(/\S+/g)[2]).toEqual('134');
     expect(capturedText[49].match(/\S+/g)[2]).toEqual('126');
   });
 

--- a/test/cli-validator/tests/optionHandling.js
+++ b/test/cli-validator/tests/optionHandling.js
@@ -149,40 +149,40 @@ describe('cli tool - test option handling', function() {
     const statsSection = capturedText.findIndex(x => x.includes('statistics'));
 
     // totals
-    expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('4');
-    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('8');
+    expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('5');
+    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('7');
 
     // errors
     expect(capturedText[statsSection + 4].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 4].match(/\S+/g)[1]).toEqual('(50%)');
+    expect(capturedText[statsSection + 4].match(/\S+/g)[1]).toEqual('(40%)');
 
     expect(capturedText[statsSection + 5].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 5].match(/\S+/g)[1]).toEqual('(25%)');
+    expect(capturedText[statsSection + 5].match(/\S+/g)[1]).toEqual('(20%)');
 
     expect(capturedText[statsSection + 6].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 6].match(/\S+/g)[1]).toEqual('(25%)');
+    expect(capturedText[statsSection + 6].match(/\S+/g)[1]).toEqual('(20%)');
+
+    expect(capturedText[statsSection + 7].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 7].match(/\S+/g)[1]).toEqual('(20%)');
 
     // warnings
-    expect(capturedText[statsSection + 9].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 9].match(/\S+/g)[1]).toEqual('(25%)');
-
-    expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(13%)');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('2');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(29%)');
 
     expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(13%)');
+    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(14%)');
 
     expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(13%)');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(14%)');
 
     expect(capturedText[statsSection + 13].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(13%)');
+    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(14%)');
 
     expect(capturedText[statsSection + 14].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(13%)');
+    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(14%)');
 
     expect(capturedText[statsSection + 15].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(13%)');
+    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(14%)');
   });
 
   it('should not print statistics report by default', async function() {

--- a/test/plugins/validation/2and3/parameters-ibm.js
+++ b/test/plugins/validation/2and3/parameters-ibm.js
@@ -58,16 +58,16 @@ describe('validation plugin - semantic - parameters-ibm', () => {
       };
 
       const res = validate({ jsSpec: spec }, config);
-      expect(res.errors.length).toEqual(0);
-      expect(res.warnings.length).toEqual(1);
-      expect(res.warnings[0].path).toEqual([
+      expect(res.errors.length).toEqual(1);
+      expect(res.warnings.length).toEqual(0);
+      expect(res.errors[0].path).toEqual([
         'paths',
         '/pets',
         'get',
         'parameters',
         '0'
       ]);
-      expect(res.warnings[0].message).toEqual(
+      expect(res.errors[0].message).toEqual(
         'Parameter names must follow case convention: lower_snake_case'
       );
     });


### PR DESCRIPTION
Changes in the configs to accommodate to the API handbook rules that say that all 'MUST' guidelines should be defaulted to errors