### PR TITLE
fix: filter out #9d chars from input

### DIFF
--- a/src/cli-validator/utils/preprocessFile.js
+++ b/src/cli-validator/utils/preprocessFile.js
@@ -14,5 +14,8 @@ module.exports = function(originalFile) {
   const solidus = '/';
   processedFile = processedFile.replace(escapedSolidus, solidus);
 
+  // Another problematic character is #9d - replace with space
+  processedFile = processedFile.replace(/\x9d/g, ' ');
+
   return processedFile;
 };


### PR DESCRIPTION
This PR fixes a crash in the validator when the input API document contains a `x9d` character.  This problem was revealed by the open-service-broker API doc.

The fix is to simply replace these characters with space characters before calling the JSON/YAML parser.