### PR TITLE
fix: check for operationId naming

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -19,7 +19,117 @@ module.exports.validate = function({ resolvedSpec }) {
     'options',
     'trace'
   ];
+  const normalParams = [];
+  const queryParams = [];
+  for (const head in resolvedSpec.paths) {
+    if (!/}$/.test(head)) {
+      normalParams.push(head);
+    } else {
+      queryParams.push(head);
+    }
+  }
+  for (const i in normalParams) {
+    for (const j in queryParams) {
+      if (
+        queryParams[j].includes(normalParams[i]) &&
+        resolvedSpec.paths[normalParams[i]].get &&
+        resolvedSpec.paths[normalParams[i]].post &&
+        resolvedSpec.paths[queryParams[j]].get &&
+        resolvedSpec.paths[queryParams[j]].delete &&
+        (resolvedSpec.paths[queryParams[j]].put ||
+          resolvedSpec.paths[queryParams[j]].post ||
+          resolvedSpec.paths[queryParams[j]].patch)
+      ) {
+        if (
+          !resolvedSpec.paths[normalParams[i]].get.operationId.startsWith(
+            'list'
+          )
+        ) {
+          warnings.push({
+            path: [
+              'paths',
+              resolvedSpec.paths[normalParams[i]],
+              'get',
+              'operationId'
+            ],
+            message:
+              'get `operationId` in a parent parameter should begin with `list`'
+          });
+        }
+        if (
+          !resolvedSpec.paths[normalParams[i]].post.operationId.startsWith(
+            'add'
+          ) &&
+          !resolvedSpec.paths[normalParams[i]].post.operationId.startsWith(
+            'create'
+          )
+        ) {
+          warnings.push({
+            path: [
+              'paths',
+              resolvedSpec.paths[normalParams[i]],
+              'post',
+              'operationId'
+            ],
+            message:
+              'post `operationId` in a parent parameter should begin with `add` or `create`'
+          });
+        }
 
+        if (
+          !resolvedSpec.paths[queryParams[j]].get.operationId.startsWith('get')
+        ) {
+          warnings.push({
+            path: [
+              'paths',
+              resolvedSpec.paths[queryParams[j]],
+              'get',
+              'operationId'
+            ],
+            message:
+              'get `operationId` in query parameter should begin with `get`'
+          });
+        }
+
+        if (
+          !resolvedSpec.paths[queryParams[j]].delete.operationId.startsWith(
+            'delete'
+          )
+        ) {
+          warnings.push({
+            path: [
+              'paths',
+              resolvedSpec.paths[queryParams[j]],
+              'delete',
+              'operationId'
+            ],
+            message:
+              'delete `operationId` in query parameter should begin with delete'
+          });
+        }
+        if (
+          (resolvedSpec.paths[queryParams[j]].post &&
+            !resolvedSpec.paths[queryParams[j]].post.operationId.startsWith(
+              'update'
+            )) ||
+          (resolvedSpec.paths[queryParams[j]].put &&
+            !resolvedSpec.paths[queryParams[j]].put.operationId.startsWith(
+              'update'
+            )) ||
+          (resolvedSpec.paths[queryParams[j]].patch &&
+            !resolvedSpec.paths[queryParams[j]].patch.operationId.startsWith(
+              'update'
+            ))
+        ) {
+          warnings.push({
+            path: ['paths', resolvedSpec.paths[queryParams[j]]],
+            message:
+              'post/put/patch `operationId` in query parameter should begin with `update`'
+          });
+        }
+      }
+    }
+  }
   const operations = reduce(
     resolvedSpec.paths,
     (arr, path, pathKey) => {

--- a/test/plugins/validation/2and3/operation-ids.js
+++ b/test/plugins/validation/2and3/operation-ids.js
@@ -97,4 +97,87 @@ describe('validation plugin - semantic - operation-ids', function() {
     expect(res.errors[0].message).toEqual('operationIds must be unique');
     expect(res.warnings.length).toEqual(0);
   });
+
+  it('should complain when parent parameter does not follow naming convention for operationId', function() {
+    const spec = {
+      paths: {
+        '/coolPath': {
+          post: {
+            summary: 'post operation',
+            operationId: 'insertOperation'
+          },
+          get: {
+            summary: 'get operation',
+            operationId: 'getOperation'
+          }
+        },
+        '/coolPath/{hi}': {
+          put: {
+            summary: 'put operation',
+            operationId: 'updateOperation'
+          },
+          delete: {
+            summary: 'post operation',
+            operationId: 'deleteOperation'
+          },
+          get: {
+            summary: 'get operation',
+            operationId: 'getOp'
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec });
+    expect(res.warnings.length).toEqual(2);
+    expect(res.warnings[0].message).toEqual(
+      'get `operationId` in a parent parameter should begin with `list`'
+    );
+    expect(res.warnings[1].message).toEqual(
+      'post `operationId` in a parent parameter should begin with `add` or `create`'
+    );
+  });
+
+  it('should complain when query parameter does not follow naming convention for operationId', function() {
+    const spec = {
+      paths: {
+        '/coolPath': {
+          post: {
+            summary: 'post operation',
+            operationId: 'addOperation'
+          },
+          get: {
+            summary: 'get operation',
+            operationId: 'listOperation'
+          }
+        },
+        '/coolPath/{hi}': {
+          put: {
+            summary: 'put operation',
+            operationId: 'upOperation'
+          },
+          delete: {
+            summary: 'post operation',
+            operationId: 'delOperation'
+          },
+          get: {
+            summary: 'get operation',
+            operationId: 'geOp'
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec });
+    expect(res.warnings.length).toEqual(3);
+    expect(res.warnings[0].message).toEqual(
+      'get `operationId` in query parameter should begin with `get`'
+    );
+    expect(res.warnings[1].message).toEqual(
+      'delete `operationId` in query parameter should begin with delete'
+    );
+    expect(res.warnings[2].message).toEqual(
+      'post/put/patch `operationId` in query parameter should begin with `update`'
+    );
+  });
 });


### PR DESCRIPTION
will check operationIds naming conventions for certain paths and path parameters
Fixes #957