### PR TITLE
fix: prevent crash when `parameters` is illegally not an array

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/paths.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths.js
@@ -73,14 +73,18 @@ module.exports.validate = function({ resolvedSpec }) {
       return param;
     });
 
-    each(path, (thing, thingName) => {
-      if (thing && thing.parameters) {
+    each(path, (operation, operationName) => {
+      if (
+        operation &&
+        operation.parameters &&
+        Array.isArray(operation.parameters)
+      ) {
         availableParameters.push(
-          ...thing.parameters.map((param, i) => {
+          ...operation.parameters.map((param, i) => {
             if (!isObject(param)) {
               return;
             }
-            param.$$path = `paths.${pathName}.${thingName}.parameters[${i}]`;
+            param.$$path = `paths.${pathName}.${operationName}.parameters[${i}]`;
             return param;
           })
         );

--- a/test/plugins/validation/2and3/paths.js
+++ b/test/plugins/validation/2and3/paths.js
@@ -352,4 +352,40 @@ describe('validation plugin - semantic - paths', function() {
       expect(res.warnings).toEqual([]);
     });
   });
+
+  it('should not crash when `parameters` is not an array', function() {
+    const spec = {
+      paths: {
+        '/resource': {
+          get: {
+            operationId: 'listResources',
+            description: 'operation with bad parameters...',
+            summary: '...but it should not crash the code',
+            parameters: {
+              allOf: [
+                {
+                  name: 'one',
+                  type: 'string'
+                },
+                {
+                  name: 'two',
+                  type: 'string'
+                }
+              ]
+            },
+            responses: {
+              '200': {
+                description: 'response'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec });
+    // errors/warnings would be caught it parameters-ibm.js
+    expect(res.errors.length).toBe(0);
+    expect(res.warnings.length).toBe(0);
+  });
 });


### PR DESCRIPTION
This file assumes `parameters` will be an array and calls the `map` method on it. This prevents it from doing so if parameters is not an array.

Resolves #101 