### PR TITLE
feat(plugin): adds k8s_camel_case validator for k8s API conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,14 +282,15 @@ For rules that accept additional configuration, there will be a limited set of a
 - Some rules check strings for adherence to a specific case convention. In some cases, the case convention checked is configurable.
 - Rules with configurable case conventions will end in `_case_convention`, such as `param_name_case_convention`.
 
-| Option           | Description                                              | Example          |
-| ---------------- | -------------------------------------------------------- | ---------------- |
-| lower_snake_case | Words must follow standard lower snake case conventions. | learning_opt_out |
-| upper_snake_case | Words must follow standard upper snake case conventions. | LEARNING_OPT_OUT |
-| upper_camel_case | Words must follow standard upper camel case conventions. | LearningOptOut   |
-| lower_camel_case | Words must follow standard lower camel case conventions. | learningOptOut   |
-| lower_dash_case  | Words must follow standard lower dash case conventions.  | learning-opt-out |
-| upper_dash_case  | Words must follow standard upper dash case conventions.  | LEARNING-OPT-OUT |
+| Option           | Description                                              | Example           |
+| ---------------- | -------------------------------------------------------- | ----------------- |
+| lower_snake_case | Words must follow standard lower snake case conventions. | learning_opt_out  |
+| upper_snake_case | Words must follow standard upper snake case conventions. | LEARNING_OPT_OUT  |
+| upper_camel_case | Words must follow standard upper camel case conventions. | LearningOptOut    |
+| lower_camel_case | Words must follow standard lower camel case conventions. | learningOptOut    |
+| k8s_camel_case   | Words must follow Kubernetes API camel case conventions. | learningOptOutAPI |
+| lower_dash_case  | Words must follow standard lower dash case conventions.  | learning-opt-out  |
+| upper_dash_case  | Words must follow standard upper dash case conventions.  | LEARNING-OPT-OUT  |
 
 ### Configuration file
 

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -115,6 +115,7 @@ const configOptions = {
     'upper_snake_case',
     'upper_camel_case',
     'lower_camel_case',
+    'k8s_camel_case',
     'lower_dash_case',
     'upper_dash_case',
     'operation_id_case'

--- a/src/plugins/utils/caseConventionCheck.js
+++ b/src/plugins/utils/caseConventionCheck.js
@@ -3,12 +3,18 @@
   directly follow letter characters, without an underscore in between. The
   snakecase module in lodash (which was previously used) did not allow this
   behavior. This is especially important in API paths e.g. '/api/v1/path'
+
+  K8S Camel Case: Similar to lower camel case except allowing consecutive upper
+  case letters.  The K8S API convention is to have all letters in an acronym be
+  the same case:
+  https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#naming-conventions
 */
 
 const lowerSnakeCase = /^[a-z][a-z0-9]*(_[a-z0-9]+)*$/;
 const upperSnakeCase = /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/;
 const upperCamelCase = /^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$/;
 const lowerCamelCase = /^[a-z][a-z0-9]*([A-Z][a-z0-9]+)*$/;
+const k8sCamelCase = /^[a-z][a-z0-9]*([A-Z]+[a-z0-9]*)*$/;
 const lowerDashCase = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 const upperDashCase = /^[A-Z][A-Z0-9]*(-[A-Z0-9]+)*$/;
 
@@ -25,6 +31,9 @@ module.exports = (string, convention) => {
 
     case 'lower_camel_case':
       return lowerCamelCase.test(string);
+
+    case 'k8s_camel_case':
+      return k8sCamelCase.test(string);
 
     case 'lower_dash_case':
       return lowerDashCase.test(string);

--- a/test/plugins/caseConventionCheck.js
+++ b/test/plugins/caseConventionCheck.js
@@ -95,6 +95,29 @@ describe('case convention regex tests', function() {
     });
   });
 
+  describe('k8s camel case tests', function() {
+    const convention = 'k8s_camel_case';
+    it('apiVersion is k8s camel case', function() {
+      const string = 'apiVersion';
+      expect(checkCase(string, convention)).toEqual(true);
+    });
+
+    it('hostPID is k8s camel case', function() {
+      const string = 'hostPID';
+      expect(checkCase(string, convention)).toEqual(true);
+    });
+
+    it('ApiVersion is NOT k8s camel case', function() {
+      const string = 'ApiVersion';
+      expect(checkCase(string, convention)).toEqual(false);
+    });
+
+    it('isGIFOrJPEG is k8s camel case', function() {
+      const string = 'isGIFOrJPEG';
+      expect(checkCase(string, convention)).toEqual(true);
+    });
+  });
+
   describe('lower dash case tests', function() {
     const convention = 'lower_dash_case';
     it('sha1 is lower dash case', function() {


### PR DESCRIPTION
The Kubernetes API conventions use lower_camel_case except for acronyms which are expected to be all the same case.  When an acronym is not at the beginning of the string it should be capitalized.

This change adds a new validator called k8s_camel_case that relaxes lower_camel_case to allow this.

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#naming-conventions

fix #105