### PR TITLE
fix: Consider as valid multiple schemes in a security requirement object

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
@@ -74,24 +74,25 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
 
   function flagUsedDefinitions(security) {
     security.forEach(scheme => {
-      // each object in this array should only have one key - the name of the scheme
-      const name = Object.keys(scheme)[0];
+      const schemeNames = Object.keys(scheme);
 
-      // make sure this scheme was in the security definitions, then label as used
-      if (definedSchemes[name]) {
-        definedSchemes[name].used = true;
+      schemeNames.forEach(schemeName => {
+        // make sure this scheme was in the security definitions, then label as used
+        if (definedSchemes[schemeName]) {
+          definedSchemes[schemeName].used = true;
 
-        const type = definedSchemes[name].type;
-        const scopesArray = scheme[name];
+          const type = definedSchemes[schemeName].type;
+          const scopesArray = scheme[schemeName];
 
-        if (type.toLowerCase() === 'oauth2') {
-          scopesArray.forEach(scope => {
-            if (definedScopes[scope]) {
-              definedScopes[scope].used = true;
-            }
-          });
+          if (type.toLowerCase() === 'oauth2') {
+            scopesArray.forEach(scope => {
+              if (definedScopes[scope]) {
+                definedScopes[scope].used = true;
+              }
+            });
+          }
         }
-      }
+      });
     });
   }
 

--- a/test/plugins/validation/2and3/security-definitions-ibm.js
+++ b/test/plugins/validation/2and3/security-definitions-ibm.js
@@ -26,7 +26,6 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
             }
           },
           api_key: {
-            // eslint-disable-line camelcase
             type: 'apiKey',
             name: 'api_key',
             in: 'header'
@@ -274,6 +273,48 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
               security: [
                 {
                   ScopedAuth: ['read:pets', 'write:pets']
+                }
+              ],
+              responses: {
+                default: {
+                  description: 'default response'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings.length).toEqual(0);
+    });
+
+    it('should not complain if all definitions are used with multiple auth schemes', function() {
+      const spec = {
+        components: {
+          securitySchemes: {
+            api_key: {
+              type: 'apiKey',
+              name: 'api_key',
+              in: 'header'
+            },
+            api_secret: {
+              type: 'apiKey',
+              name: 'api_secret',
+              in: 'header'
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'list',
+              summary: 'list everything',
+              security: [
+                {
+                  api_key: [],
+                  api_secret: []
                 }
               ],
               responses: {

--- a/test/plugins/validation/2and3/security-ibm.js
+++ b/test/plugins/validation/2and3/security-ibm.js
@@ -499,5 +499,34 @@ describe('validation plugin - semantic - security-ibm', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings.length).toEqual(0);
     });
+
+    it('should not complain when multiple security requirements are referenced', () => {
+      const spec = {
+        components: {
+          securitySchemes: {
+            api_key: {
+              type: 'apiKey',
+              name: 'api_key',
+              in: 'header'
+            },
+            api_secret: {
+              type: 'apiKey',
+              name: 'api_secret',
+              in: 'header'
+            }
+          }
+        },
+        security: [
+          {
+            api_key: [],
+            api_secret: []
+          }
+        ]
+      };
+
+      const res = validate({ jsSpec: spec, isOAS3: true }, config);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings.length).toEqual(0);
+    });
   });
 });


### PR DESCRIPTION
Multiple security schemes are now considered as valid and flagged as used.
Added unit tests for the new code.

Fixes #108