### PR TITLE
Add check for 204 response with response body

### DIFF
--- a/src/cli-validator/utils/validator.js
+++ b/src/cli-validator/utils/validator.js
@@ -60,14 +60,21 @@ module.exports = function validateSwagger(allSpecs, config) {
   }
 
   // run semantic validators
-  const allValidators = Object.assign(
-    {},
-    semanticValidators,
-    sharedSemanticValidators
-  );
 
-  Object.keys(allValidators).forEach(key => {
-    const problem = allValidators[key].validate(allSpecs, config);
+  Object.keys(semanticValidators).forEach(key => {
+    const problem = semanticValidators[key].validate(allSpecs, config);
+    if (problem.errors.length) {
+      validationResults.errors[key] = [...problem.errors];
+      validationResults.error = true;
+    }
+    if (problem.warnings.length) {
+      validationResults.warnings[key] = [...problem.warnings];
+      validationResults.warning = true;
+    }
+  });
+
+  Object.keys(sharedSemanticValidators).forEach(key => {
+    const problem = sharedSemanticValidators[key].validate(allSpecs, config);
     if (problem.errors.length) {
       validationResults.errors[key] = [...problem.errors];
       validationResults.error = true;

--- a/src/cli-validator/utils/validator.js
+++ b/src/cli-validator/utils/validator.js
@@ -76,11 +76,17 @@ module.exports = function validateSwagger(allSpecs, config) {
   Object.keys(sharedSemanticValidators).forEach(key => {
     const problem = sharedSemanticValidators[key].validate(allSpecs, config);
     if (problem.errors.length) {
-      validationResults.errors[key] = [...problem.errors];
+      validationResults.errors[key] = [].concat(
+        validationResults.errors[key] || [],
+        problem.errors
+      );
       validationResults.error = true;
     }
     if (problem.warnings.length) {
-      validationResults.warnings[key] = [...problem.warnings];
+      validationResults.warnings[key] = [].concat(
+        validationResults.warnings[key] || [],
+        problem.warnings
+      );
       validationResults.warning = true;
     }
   });

--- a/test/plugins/validation/oas3/responses.js
+++ b/test/plugins/validation/oas3/responses.js
@@ -145,4 +145,55 @@ describe('validation plugin - semantic - responses - oas3', function() {
     );
     expect(res.errors.length).toEqual(0);
   });
+
+  it('should complain about 204 response that defines a response body', function() {
+    const config = {
+      responses: {
+        no_response_codes: 'error',
+        no_success_response_codes: 'warning'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/pets': {
+          delete: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              '204': {
+                description: 'bad request',
+                content: {
+                  schema: {
+                    type: 'string'
+                  }
+                }
+              },
+              '400': {
+                description: 'bad request'
+              },
+              default: {
+                description: 'any other response'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.warnings.length).toEqual(0);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].path).toEqual([
+      'paths',
+      '/pets',
+      'delete',
+      'responses',
+      '204',
+      'content'
+    ]);
+    expect(res.errors[0].message).toEqual(
+      'A 204 response MUST NOT include a message-body.'
+    );
+  });
 });


### PR DESCRIPTION
This PR adds a check for a 204 response that defines a response body.  I defined this rule as an error and did not make it configurable since returning a response body with a 204 response violates the HTTP spec:

https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5

The PR also contains a fix for a latent problem in the validator that was exposed by this new feature -- semantic validators with the same name as a shared (`2and3`) validator were not being run.