### PR TITLE
Add rule to check for duplicate path parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The supported rules are described below:
 | missing_path_parameter      | For a path that contains path parameters, flag any operations that do not correctly define those parameters. | shared |
 | snake_case_only             | Flag any path segment that does not use snake case.                                                          | shared |
 | paths_case_convention       | Flag any path segment that does not follow a given case convention. snake_case_only must be 'off' to use.    | shared |
+| duplicate_path_parameter    | Flag any path parameters that have identical definitions in all operations. | shared |
 
 ##### [responses][4]
 | Rule                      | Description                                                  | Spec |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -39,6 +39,7 @@ const defaults = {
     },
     'paths': {
       'missing_path_parameter': 'error',
+      'duplicate_path_parameter': 'warning',
       'snake_case_only': 'off',
       'paths_case_convention': ['error', 'lower_snake_case']
     },

--- a/test/plugins/validation/2and3/paths-ibm.js
+++ b/test/plugins/validation/2and3/paths-ibm.js
@@ -402,4 +402,102 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);
   });
+
+  it('should flag a common path parameter defined at the operation level', function() {
+    const config = {
+      paths: {
+        duplicate_path_parameter: 'warning'
+      }
+    };
+
+    const badSpec = {
+      paths: {
+        '/v1/api/resources/{id}': {
+          get: {
+            operationId: 'get_resource',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                type: 'string',
+                description: 'id of the resource'
+              }
+            ]
+          },
+          post: {
+            operationId: 'update_resource',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                type: 'string',
+                description: 'id of the resource'
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: badSpec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(2);
+    expect(res.warnings[0].path).toEqual(
+      'paths./v1/api/resources/{id}.get.parameters.0'
+    );
+    expect(res.warnings[0].message).toEqual(
+      'Common path parameters should be defined on path object'
+    );
+    expect(res.warnings[1].path).toEqual(
+      'paths./v1/api/resources/{id}.post.parameters.0'
+    );
+    expect(res.warnings[1].message).toEqual(
+      'Common path parameters should be defined on path object'
+    );
+  });
+
+  it('should not flag a common path parameter defined at the operation level if descriptions are different', function() {
+    const config = {
+      paths: {
+        duplicate_path_parameter: 'warning'
+      }
+    };
+
+    const goodSpec = {
+      paths: {
+        '/v1/api/resources/{id}': {
+          get: {
+            operationId: 'get_resource',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                type: 'string',
+                description: 'id of the resource to retrieve'
+              }
+            ]
+          },
+          post: {
+            operationId: 'update_resource',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                type: 'string',
+                description: 'id of the resource to update'
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: goodSpec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
This PR adds a rule, with default configuration of 'warn', that flags identical path parameters defined on the individual operations of a path.  These parameters should be defined on the path object.

Note that only completely identical parameters are flagged -- variations in the parameter description will suppress the warning.