### PR TITLE
fix: Fix duplicate parameter checking when all parameters are defined at the path level

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
@@ -135,9 +135,9 @@ module.exports.validate = function({ resolvedSpec }, config) {
       if (operationKeys.length > 1) {
         parameters.forEach(parameter => {
           const operationPathParams = uniqWith(
-            flatten(operationKeys.map(op => pathObj[op].parameters)).filter(
-              p => p.name === parameter
-            ),
+            flatten(
+              operationKeys.map(op => pathObj[op].parameters).filter(Boolean)
+            ).filter(p => p.name === parameter),
             isEqual
           );
           if (operationPathParams.length === 1) {

--- a/test/plugins/validation/2and3/paths-ibm.js
+++ b/test/plugins/validation/2and3/paths-ibm.js
@@ -500,4 +500,38 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);
   });
+
+  it('should not flag a common path parameter defined at the path level', function() {
+    const config = {
+      paths: {
+        duplicate_path_parameter: 'warning'
+      }
+    };
+
+    const goodSpec = {
+      paths: {
+        '/v1/api/resources/{id}': {
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              type: 'string',
+              description: 'id of the resource to retrieve'
+            }
+          ],
+          get: {
+            operationId: 'get_resource'
+          },
+          post: {
+            operationId: 'update_resource'
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: goodSpec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
This PR fixes a bug with the logic of the duplicate path parameter checks that causes an exception when an operation has no parameters.  I've added a test for this case as well.