### PR TITLE
Add rule to check pagination list operations conform to API Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ The supported categories are described below:
 | schemas    | Rules pertaining to [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject)       |
 | security_definitions | Rules pertaining to [Security Definition Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject) |
 | security   | Rules pertaining to [Security Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityRequirementObject) |
-| walker     | Rules pertaining to the entire document.                                                                                                   |
-
+| walker     | Rules pertaining to the entire document.                                                                                              |
+| pagination | Rules pertaining to [Pagination Objects](https://pages.github.ibm.com/CloudEngineering/api_handbook/collections/pagination.html)   |
 #### Rules
 
 Each category contains a group of rules. The spec that each rule applies to is marked in the third column. For the actual configuration structure, see the [default values](#default-values).
@@ -199,7 +199,13 @@ The supported rules are described below:
 | no_array_responses           | Flag any operations with a top-level array response.                                | shared   |
 | parameter_order              | Flag any operations with optional parameters before a required param.               | shared   |
 | no_request_body_content      | [Flag any operations with a `requestBody` that does not have a `content` field.][3] | oas3     |
-| no_request_body_name         | Flag any operations with a non-form `requestBody` that does not have a name set with `x-codegen-request-body-name`. | oas3 |
+| no_request_body_name         | Flag any operations with a non-form `requestBody` that does not have a name set with `x-codegen-request-body-name`. | oas3|
+
+##### pagination
+| Rule                        | Description                                                              | Spec   |
+| --------------------------- | ------------------------------------------------------------------------ | ------ |
+| pagination_style            | Flag any parameter or response object that doesnt follow pagination requirements. | oas3 |
+
 
 ##### parameters
 | Rule                        | Description                                                              | Spec   |
@@ -361,6 +367,11 @@ The default values for each rule are described below.
 | no_summary                   | warning |
 | no_array_responses           | error   |
 | parameter_order              | warning |
+
+###### pagination
+| Rule                        | Default |
+| --------------------------- | --------|
+| pagination_style            | warning |
 
 ###### parameters
 | Rule                        | Default |

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The supported categories are described below:
 | security_definitions | Rules pertaining to [Security Definition Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject) |
 | security   | Rules pertaining to [Security Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityRequirementObject) |
 | walker     | Rules pertaining to the entire document.                                                                                              |
-| pagination | Rules pertaining to [Pagination Objects](https://pages.github.ibm.com/CloudEngineering/api_handbook/collections/pagination.html)   |
+| pagination | Rules pertaining to pagination   |
 #### Rules
 
 Each category contains a group of rules. The spec that each rule applies to is marked in the third column. For the actual configuration structure, see the [default values](#default-values).
@@ -204,7 +204,7 @@ The supported rules are described below:
 ##### pagination
 | Rule                        | Description                                                              | Spec   |
 | --------------------------- | ------------------------------------------------------------------------ | ------ |
-| pagination_style            | Flag any parameter or response object that doesnt follow pagination requirements. | oas3 |
+| pagination_style            | Flag any parameter or response schema that does not follow pagination requirements. | oas3 |
 
 
 ##### parameters

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -28,6 +28,9 @@ const defaults = {
       'parameter_order': 'warning',
       'unused_tag': 'warning'
     },
+    'pagination': {
+      'pagination_style': 'warning'
+    },
     'parameters': {
       'no_parameter_description': 'error',
       'param_name_case_convention': ['error', 'lower_snake_case'],

--- a/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
@@ -1,0 +1,219 @@
+module.exports.validate = function({ resolvedSpec }, config) {
+  const result = {};
+  result.error = [];
+  result.warning = [];
+  config = config.pagination;
+  const checkStatus = config.pagination_style;
+
+  //when pagnation is turned off, skip all of the pagination checks
+  if (checkStatus == 'off') {
+    return;
+  }
+  //for our case, pagination should only be considered for paths without a path parameter and should apply for get responses for the mean time
+  for (const pathHead in resolvedSpec.paths) {
+    // Skip any path that ends in a path parameter
+    if (/}$/.test(pathHead)) {
+      continue;
+    }
+    // this an array that contains all of the query parameter names
+    if (
+      resolvedSpec.paths[pathHead].get.parameters &&
+      resolvedSpec.paths[pathHead].get.parameters.length > 0
+    ) {
+      const queryParameters = resolvedSpec.paths[pathHead].get.parameters.map(
+        parameter => parameter.name
+      );
+
+      // a paginated spec should have one of the following as query parameters
+      const isListX =
+        queryParameters.includes('limit') ||
+        queryParameters.includes('start') ||
+        queryParameters.includes('cursor') ||
+        queryParameters.includes('token') ||
+        queryParameters.includes('offset');
+      // apply checks only to get operations for now
+      if (resolvedSpec.paths[pathHead].get) {
+        for (const resp in resolvedSpec.paths[pathHead].get.responses) {
+          if (resp.startsWith('2')) {
+            const content =
+              resolvedSpec.paths[pathHead].get.responses[resp].content;
+            if (content && content['application/json']) {
+              const jsonContent = content['application/json'];
+              let arrayOnTop = false;
+              let trueObj;
+              if (
+                (jsonContent.schema && jsonContent.schema.properties) ||
+                (jsonContent.schema.properties.pagination &&
+                  jsonContent.schema.propeerties.pagination.properties)
+              ) {
+                if (!jsonContent.schema.properties.pagination) {
+                  for (const prop in jsonContent.schema.properties) {
+                    if (jsonContent.schema.properties[prop].type === 'array') {
+                      arrayOnTop = true;
+                      trueObj = jsonContent;
+                      //console.log(trueObj);
+                      break;
+                    }
+                  }
+                }
+                const content =
+                  resolvedSpec.paths[pathHead].get.responses[resp].content;
+                const parameterPath =
+                  resolvedSpec.paths[pathHead].get.parameters;
+                parameterChecker(parameterPath, content, isListX, arrayOnTop);
+                if (arrayOnTop && !jsonContent.schema.pagination && isListX) {
+                  const responseSchema = trueObj.schema;
+                  const path = [
+                    'paths',
+                    pathHead,
+                    'get',
+                    'responses',
+                    resp,
+                    'content',
+                    'application/json',
+                    'schema',
+                    'properties'
+                  ];
+                  checkResponseProperties(
+                    responseSchema,
+                    path,
+                    queryParameters,
+                    isListX,
+                    arrayOnTop
+                  );
+                } else if (jsonContent.schema.properties.pagination) {
+                  const paginatedResponse =
+                    jsonContent.schema.properties.pagination;
+                  const path = [
+                    'paths',
+                    pathHead,
+                    'get',
+                    'reponses',
+                    resp,
+                    'content',
+                    'application/json',
+                    'pagination',
+                    'schema',
+                    'properties'
+                  ];
+                  checkResponseProperties(
+                    paginatedResponse,
+                    path,
+                    queryParameters,
+                    isListX
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  function parameterChecker(parameterPath, content, isListX, arrayOnTop) {
+    if (isListX && arrayOnTop) {
+      const jsonContent = content['application/json'];
+      // loop through parameters and make sure that the pagination related parameters follow the correct defintions
+      if (parameterPath.length > 0) {
+        for (let i = 0; i < parameterPath.length; i++) {
+          const param = parameterPath[i];
+          // limit should be an integer, optional, and should have a default and maximum value defined
+          if (
+            param.name === 'limit' &&
+            (param.schema.type !== 'integer' ||
+              param.required === true ||
+              (jsonContent.schema.properties.limit &&
+                (!jsonContent.schema.properties.limit.default ||
+                  !jsonContent.schema.properties.limit.maximum)))
+          ) {
+            const path = ['paths', '/pets', 'get', 'parameters', i];
+            const message =
+              'The limit parameter must be of type integer and must be optional with default and maximum values.';
+            paginationWarning(message, path);
+          }
+          // The `start` and `cursor` parameters must be strings and are required
+          if (
+            (param.name === 'start' || param.name === 'cursor') &&
+            (param.schema.type !== 'integer' || param.required === true)
+          ) {
+            const path = [
+              'paths',
+              '/pets',
+              'get',
+              'responses',
+              '200',
+              'content',
+              'application/json',
+              'schema',
+              'properties'
+            ];
+            const message =
+              'The start or cursor properties must be integers and optional.';
+            paginationWarning(message, path);
+          }
+        }
+      }
+    }
+  }
+
+  // this is the message generating function
+  function paginationWarning(message, path) {
+    result[checkStatus].push({
+      path,
+      message
+    });
+  }
+
+  // this function checks the `offset` property in responses
+  function checkResponseProperties(obj, path, queryParameters, isListX) {
+    if (isListX) {
+      if (
+        queryParameters.includes('offset') &&
+        (!obj.properties.offset ||
+          obj.properties.offset.type !== 'integer' ||
+          !obj.required.includes('offset'))
+      ) {
+        const message =
+          'If a offset exists as a parameter query it must be defined as a property.';
+        paginationWarning(message, path);
+      }
+      // this function checks the `limit` property in responses
+      if (
+        queryParameters.includes('limit') &&
+        (!obj.properties.limit ||
+          obj.properties.limit.type != 'integer' ||
+          !obj.required.includes('limit'))
+      ) {
+        const message =
+          'If a limit exists as a parameter query it must be defined as a property.';
+        paginationWarning(message, path);
+      } // this function checks the `next_token` and `next_cursor` properties in responses
+      if (
+        (queryParameters.includes('start') ||
+          queryParameters.includes('token') ||
+          queryParameters.includes('cursor')) &&
+        (!obj.properties.next_token && !obj.properties.next_cursor)
+      ) {
+        const message =
+          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.';
+        paginationWarning(message, path);
+      }
+      // this function checks the `total_count` property in responses
+      if (
+        obj.properties.total_count &&
+        obj.properties.total_count.type != 'integer'
+      ) {
+        const message =
+          'If total_count is defined, it must be of type integer.';
+        paginationWarning(message, path);
+      }
+      // this function makes sure that there is a `next_url` property
+      if (!obj.properties.next_url) {
+        const message =
+          'A paginated success response must contain the next property.';
+        paginationWarning(message, path);
+      }
+    }
+  }
+  return { errors: result.error, warnings: result.warning };
+};

--- a/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
@@ -14,6 +14,7 @@
 // - If the operation has a `start`, `cursor`, or `page_token` query parameter, it must be type string and optional
 // - The response body must contain a `limit` property that is type integer and required
 // - If the operation has an `offset` query parameter, the response body must contain an `offset` property this is type integer and required
+// - The response body must contain an array property with the same plural resource name appearing in the collection’s URL.
 
 module.exports.validate = function({ resolvedSpec }, config) {
   const result = {};
@@ -153,7 +154,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     if (!limitProp) {
       result[checkStatus].push({
         path: propertiesPath,
-        message: `The response body of a paginated list operation must contain a "limit" property.`
+        message: `A paginated list operation must include a "limit" property in the response body schema.`
       });
     } else if (
       limitProp.type !== 'integer' ||
@@ -173,7 +174,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       if (!offsetProp) {
         result[checkStatus].push({
           path: propertiesPath,
-          message: `The response body of a paginated list operation must contain a "offset" property.`
+          message: `A paginated list operation with an "offset" parameter must include an "offset" property in the response body schema.`
         });
       } else if (
         offsetProp.type !== 'integer' ||
@@ -185,6 +186,17 @@ module.exports.validate = function({ resolvedSpec }, config) {
           message: `The "offset" property in the response body of a paginated list operation must be of type integer and required.`
         });
       }
+    }
+
+    // - The response body must contain an array property with the same plural resource name appearing in the collection’s URL.
+
+    const pluralResourceName = path.split('/').pop();
+    const resourcesProp = jsonResponse.schema.properties[pluralResourceName];
+    if (!resourcesProp || resourcesProp.type !== 'array') {
+      result[checkStatus].push({
+        path: propertiesPath,
+        message: `A paginated list operation must include an array property whose name matches the final segment of the path.`
+      });
     }
   }
 

--- a/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
@@ -1,219 +1,229 @@
+// This validator checks "list" type operations for correct pagaination style.
+//
+// An operation is considered to be a "list" operation if:
+// - its path does not end in a path parameter
+// - it is a "get"
+// - it contains an array at the top level of the response body object
+//
+// A "list" operation is considered to be a "paginated list" operation if:
+// - it has a `limit` query parameter
+//
+// The following checks are performed on "paginated list" operations:
+// - The `limit` query parameter be type integer, optional, and have default and maximum values.
+// - If the operation has an `offset` query parameter, it must be type integer and optional
+// - If the operation has a `start`, `cursor`, or `page_token` query parameter, it must be type string and optional
+// - The response body must contain a `limit` property that is type integer and required
+// - If the operation has an `offset` query parameter, the response body must contain an `offset` property this is type integer and required
+
 module.exports.validate = function({ resolvedSpec }, config) {
   const result = {};
   result.error = [];
   result.warning = [];
-  config = config.pagination;
-  const checkStatus = config.pagination_style;
+  const checkStatus = config.pagination.pagination_style;
 
   //when pagnation is turned off, skip all of the pagination checks
   if (checkStatus == 'off') {
-    return;
+    return { errors: [], warnings: [] };
   }
-  //for our case, pagination should only be considered for paths without a path parameter and should apply for get responses for the mean time
-  for (const pathHead in resolvedSpec.paths) {
-    // Skip any path that ends in a path parameter
-    if (/}$/.test(pathHead)) {
+
+  // Loop through all paths looking for "list" operations.
+  for (const path in resolvedSpec.paths) {
+    // Skip any path that ends in a path parameter or does not have a "get" operation
+    if (/}$/.test(path) || !resolvedSpec.paths[path].get) {
       continue;
     }
-    // this an array that contains all of the query parameter names
+
+    const resp = getJsonResponse(resolvedSpec.paths[path].get);
+    const jsonResponse = resp
+      ? resolvedSpec.paths[path].get.responses[resp].content['application/json']
+      : undefined;
+    // Can't check response schema for array property, so skip this path
     if (
-      resolvedSpec.paths[pathHead].get.parameters &&
-      resolvedSpec.paths[pathHead].get.parameters.length > 0
+      !jsonResponse ||
+      !jsonResponse.schema ||
+      !jsonResponse.schema.properties
     ) {
-      const queryParameters = resolvedSpec.paths[pathHead].get.parameters.map(
-        parameter => parameter.name
-      );
+      continue;
+    }
 
-      // a paginated spec should have one of the following as query parameters
-      const isListX =
-        queryParameters.includes('limit') ||
-        queryParameters.includes('start') ||
-        queryParameters.includes('cursor') ||
-        queryParameters.includes('token') ||
-        queryParameters.includes('offset');
-      // apply checks only to get operations for now
-      if (resolvedSpec.paths[pathHead].get) {
-        for (const resp in resolvedSpec.paths[pathHead].get.responses) {
-          if (resp.startsWith('2')) {
-            const content =
-              resolvedSpec.paths[pathHead].get.responses[resp].content;
-            if (content && content['application/json']) {
-              const jsonContent = content['application/json'];
-              let arrayOnTop = false;
-              let trueObj;
-              if (
-                (jsonContent.schema && jsonContent.schema.properties) ||
-                (jsonContent.schema.properties.pagination &&
-                  jsonContent.schema.propeerties.pagination.properties)
-              ) {
-                if (!jsonContent.schema.properties.pagination) {
-                  for (const prop in jsonContent.schema.properties) {
-                    if (jsonContent.schema.properties[prop].type === 'array') {
-                      arrayOnTop = true;
-                      trueObj = jsonContent;
-                      //console.log(trueObj);
-                      break;
-                    }
-                  }
-                }
-                const content =
-                  resolvedSpec.paths[pathHead].get.responses[resp].content;
-                const parameterPath =
-                  resolvedSpec.paths[pathHead].get.parameters;
-                parameterChecker(parameterPath, content, isListX, arrayOnTop);
-                if (arrayOnTop && !jsonContent.schema.pagination && isListX) {
-                  const responseSchema = trueObj.schema;
-                  const path = [
-                    'paths',
-                    pathHead,
-                    'get',
-                    'responses',
-                    resp,
-                    'content',
-                    'application/json',
-                    'schema',
-                    'properties'
-                  ];
-                  checkResponseProperties(
-                    responseSchema,
-                    path,
-                    queryParameters,
-                    isListX,
-                    arrayOnTop
-                  );
-                } else if (jsonContent.schema.properties.pagination) {
-                  const paginatedResponse =
-                    jsonContent.schema.properties.pagination;
-                  const path = [
-                    'paths',
-                    pathHead,
-                    'get',
-                    'reponses',
-                    resp,
-                    'content',
-                    'application/json',
-                    'pagination',
-                    'schema',
-                    'properties'
-                  ];
-                  checkResponseProperties(
-                    paginatedResponse,
-                    path,
-                    queryParameters,
-                    isListX
-                  );
-                }
-              }
-            }
-          }
-        }
+    // If no array at top level of response, skip this path
+    if (
+      !Object.values(jsonResponse.schema.properties).some(
+        prop => prop.type === 'array'
+      )
+    ) {
+      continue;
+    }
+
+    // Check for "limit" query param -- if none, skip this path
+    const params = resolvedSpec.paths[path].get.parameters;
+    if (
+      !params ||
+      !params.some(param => param.name === 'limit' && param.in === 'query')
+    ) {
+      continue;
+    }
+
+    // Now we know we have a "paginated list" operation, so lets perform our checks
+
+    // - The `limit` query parameter be type integer, optional, and have default and maximum values.
+
+    const limitParamIndex = params.findIndex(
+      param => param.name === 'limit' && param.in === 'query'
+    );
+    const limitParam = params[limitParamIndex];
+    if (
+      !limitParam.schema ||
+      limitParam.schema.type !== 'integer' ||
+      !!limitParam.required ||
+      !limitParam.schema.default ||
+      !limitParam.schema.maximum
+    ) {
+      result[checkStatus].push({
+        path: ['paths', path, 'get', 'parameters', limitParamIndex],
+        message:
+          'The limit parameter must be of type integer and optional with default and maximum values.'
+      });
+    }
+
+    // - If the operation has an `offset` query parameter, it must be type integer and optional
+
+    const offsetParamIndex = params.findIndex(
+      param => param.name === 'offset' && param.in === 'query'
+    );
+    if (offsetParamIndex !== -1) {
+      const offsetParam = params[offsetParamIndex];
+      if (
+        !offsetParam.schema ||
+        offsetParam.schema.type !== 'integer' ||
+        !!offsetParam.required
+      ) {
+        result[checkStatus].push({
+          path: ['paths', path, 'get', 'parameters', offsetParamIndex],
+          message: 'The offset parameter must be of type integer and optional.'
+        });
+      }
+    }
+
+    // - if the operation has a `start`, `cursor`, or `page_token` query parameter, it must be type string and optional
+
+    const startParamNames = ['start', 'cursor', 'page_token'];
+    const startParamIndex = params.findIndex(
+      param =>
+        param.in === 'query' && startParamNames.indexOf(param.name) !== -1
+    );
+    if (startParamIndex !== -1) {
+      const startParam = params[startParamIndex];
+      if (
+        !startParam.schema ||
+        startParam.schema.type !== 'string' ||
+        !!startParam.required
+      ) {
+        result[checkStatus].push({
+          path: ['paths', path, 'get', 'parameters', startParamIndex],
+          message: `The ${
+            startParam.name
+          } parameter must be of type string and optional.`
+        });
+      }
+    }
+
+    // - The response body must contain a `limit` property that is type integer and required
+
+    const limitProp = jsonResponse.schema.properties.limit;
+    if (!limitProp) {
+      result[checkStatus].push({
+        path: [
+          'paths',
+          path,
+          'get',
+          'responses',
+          resp,
+          'content',
+          'application/json',
+          'schema',
+          'properties'
+        ],
+        message: `The response body of a paginated list operation must contain a "limit" property.`
+      });
+    } else if (
+      limitProp.type !== 'integer' ||
+      !jsonResponse.schema.required ||
+      jsonResponse.schema.required.indexOf('limit') === -1
+    ) {
+      result[checkStatus].push({
+        path: [
+          'paths',
+          path,
+          'get',
+          'responses',
+          resp,
+          'content',
+          'application/json',
+          'schema',
+          'properties',
+          'limit'
+        ],
+        message: `The "limit" property in the response body of a paginated list operation must be of type integer and required.`
+      });
+    }
+
+    // - If the operation has an `offset` query parameter, the response body must contain an `offset` property this is type integer and required
+
+    if (offsetParamIndex !== -1) {
+      const offsetProp = jsonResponse.schema.properties.offset;
+      if (!offsetProp) {
+        result[checkStatus].push({
+          path: [
+            'paths',
+            path,
+            'get',
+            'responses',
+            resp,
+            'content',
+            'application/json',
+            'schema',
+            'properties'
+          ],
+          message: `The response body of a paginated list operation must contain a "offset" property.`
+        });
+      } else if (
+        offsetProp.type !== 'integer' ||
+        !jsonResponse.schema.required ||
+        jsonResponse.schema.required.indexOf('offset') === -1
+      ) {
+        result[checkStatus].push({
+          path: [
+            'paths',
+            path,
+            'get',
+            'responses',
+            resp,
+            'content',
+            'application/json',
+            'schema',
+            'properties',
+            'offset'
+          ],
+          message: `The "offset" property in the response body of a paginated list operation must be of type integer and required.`
+        });
       }
     }
   }
-  function parameterChecker(parameterPath, content, isListX, arrayOnTop) {
-    if (isListX && arrayOnTop) {
-      const jsonContent = content['application/json'];
-      // loop through parameters and make sure that the pagination related parameters follow the correct defintions
-      if (parameterPath.length > 0) {
-        for (let i = 0; i < parameterPath.length; i++) {
-          const param = parameterPath[i];
-          // limit should be an integer, optional, and should have a default and maximum value defined
-          if (
-            param.name === 'limit' &&
-            (param.schema.type !== 'integer' ||
-              param.required === true ||
-              (jsonContent.schema.properties.limit &&
-                (!jsonContent.schema.properties.limit.default ||
-                  !jsonContent.schema.properties.limit.maximum)))
-          ) {
-            const path = ['paths', '/pets', 'get', 'parameters', i];
-            const message =
-              'The limit parameter must be of type integer and must be optional with default and maximum values.';
-            paginationWarning(message, path);
-          }
-          // The `start` and `cursor` parameters must be strings and are required
-          if (
-            (param.name === 'start' || param.name === 'cursor') &&
-            (param.schema.type !== 'integer' || param.required === true)
-          ) {
-            const path = [
-              'paths',
-              '/pets',
-              'get',
-              'responses',
-              '200',
-              'content',
-              'application/json',
-              'schema',
-              'properties'
-            ];
-            const message =
-              'The start or cursor properties must be integers and optional.';
-            paginationWarning(message, path);
-          }
-        }
-      }
-    }
-  }
 
-  // this is the message generating function
-  function paginationWarning(message, path) {
-    result[checkStatus].push({
-      path,
-      message
-    });
-  }
-
-  // this function checks the `offset` property in responses
-  function checkResponseProperties(obj, path, queryParameters, isListX) {
-    if (isListX) {
-      if (
-        queryParameters.includes('offset') &&
-        (!obj.properties.offset ||
-          obj.properties.offset.type !== 'integer' ||
-          !obj.required.includes('offset'))
-      ) {
-        const message =
-          'If a offset exists as a parameter query it must be defined as a property.';
-        paginationWarning(message, path);
-      }
-      // this function checks the `limit` property in responses
-      if (
-        queryParameters.includes('limit') &&
-        (!obj.properties.limit ||
-          obj.properties.limit.type != 'integer' ||
-          !obj.required.includes('limit'))
-      ) {
-        const message =
-          'If a limit exists as a parameter query it must be defined as a property.';
-        paginationWarning(message, path);
-      } // this function checks the `next_token` and `next_cursor` properties in responses
-      if (
-        (queryParameters.includes('start') ||
-          queryParameters.includes('token') ||
-          queryParameters.includes('cursor')) &&
-        (!obj.properties.next_token && !obj.properties.next_cursor)
-      ) {
-        const message =
-          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.';
-        paginationWarning(message, path);
-      }
-      // this function checks the `total_count` property in responses
-      if (
-        obj.properties.total_count &&
-        obj.properties.total_count.type != 'integer'
-      ) {
-        const message =
-          'If total_count is defined, it must be of type integer.';
-        paginationWarning(message, path);
-      }
-      // this function makes sure that there is a `next_url` property
-      if (!obj.properties.next_url) {
-        const message =
-          'A paginated success response must contain the next property.';
-        paginationWarning(message, path);
-      }
-    }
-  }
   return { errors: result.error, warnings: result.warning };
 };
+
+function getJsonResponse(operation) {
+  if (operation.responses) {
+    for (const resp in operation.responses) {
+      if (resp.startsWith('2')) {
+        const content = operation.responses[resp].content;
+        if (content && content['application/json']) {
+          return resp;
+        }
+      }
+    }
+  }
+  return undefined;
+}

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -20,6 +20,12 @@ paths:
           required: false
           schema:
             type: integer
+        - name: start
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: 'integer'
             format: int32
       responses:
         '200':
@@ -103,12 +109,26 @@ components:
         A list of pets
       required:
         - list
+        - next_url
+        - limit
       properties:
         list:
           type: array
           description: "object containing a list of pets"
           items:
             $ref: "#/components/schemas/Pet"
+        next_url:
+          type: string
+          description: this is the url to next page
+        limit:
+          type: integer
+          description: a threshold for results
+          default: 20
+          maximum: 50
+        next_token:
+          type: string
+          description: next token
+ 
     Error:
       description:
         An error in processing a service request

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -111,12 +111,12 @@ components:
       description:
         A list of pets
       required:
-        - list
+        - pets
         - next_url
         - limit
         - offset
       properties:
-        list:
+        pets:
           type: array
           description: "object containing a list of pets"
           items:

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -20,12 +20,15 @@ paths:
           required: false
           schema:
             type: integer
-        - name: start
+            format: int32
+            default: 10
+            maximum: 100
+        - name: offset
           in: query
-          description: How many items to return at one time (max 100)
+          description: Offset of first element to return in results.
           required: false
           schema:
-            type: 'integer'
+            type: integer
             format: int32
       responses:
         '200':
@@ -111,6 +114,7 @@ components:
         - list
         - next_url
         - limit
+        - offset
       properties:
         list:
           type: array
@@ -122,13 +126,16 @@ components:
           description: this is the url to next page
         limit:
           type: integer
-          description: a threshold for results
-          default: 20
-          maximum: 50
+          format: int32
+          description: limit
+        offset:
+          type: integer
+          format: int32
+          description: offset
         next_token:
           type: string
           description: next token
- 
+
     Error:
       description:
         An error in processing a service request

--- a/test/plugins/validation/oas3/pagination-ibm.js
+++ b/test/plugins/validation/oas3/pagination-ibm.js
@@ -5,72 +5,44 @@ const {
 
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
-describe('validation plugin - semantic - responses', function() {
-  describe('inline response schemas', function() {
-    describe('Pagination', function() {
-      it('should complain when the paginated object does not have start, cursor, or token', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: 'Limit on how many items should be returned.',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: 'The human-readable name of the alias.',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
+describe('validation plugin - semantic - pagaination - oas3', function() {
+  describe('only check paginated list operations', function() {
+    it('should skip operations that do not return an array', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
                   }
-                ],
-                responses: {
-                  '201': {
-                    content: {
-                      'application/json': {
-                        description: 'successful operation',
-                        schema: {
-                          type: 'object',
-                          properties: {
-                            stuff: {
-                              type: 'string'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          description: '',
-                          type: 'object',
-                          required: ['next_url', 'resources', 'rows_count'],
-                          properties: {
-                            next_url: {
-                              description: '',
-                              type: 'string'
-                            },
-                            resources: {
-                              description: '',
-                              type: 'array'
-                            },
-                            rows_count: {
-                              description: '',
-                              type: 'number'
-                            }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resource: {
+                            description: 'resource',
+                            type: 'object'
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
                           }
                         }
                       }
@@ -80,513 +52,704 @@ describe('validation plugin - semantic - responses', function() {
               }
             }
           }
-        };
+        }
+      };
 
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(2);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'parameters',
-          0
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'The limit parameter must be of type integer and must be optional with default and maximum values.'
-        );
-        expect(res.warnings[1].message).toEqual(
-          'If a limit exists as a parameter query it must be defined as a property.'
-        );
-      });
-
-      it('should complain when next_token and start are both missing', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'offset',
-                    in: 'query',
-                    description: '',
-                    required: true,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'start',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          description: '',
-                          type: 'object',
-                          required: [
-                            'next_url',
-                            'resources',
-                            'rows_count',
-                            'limit',
-                            'offset'
-                          ],
-                          properties: {
-                            offset: {
-                              description: '',
-                              type: 'integer'
-                            },
-                            limit: {
-                              description: '',
-                              type: 'integer',
-                              default: 20,
-                              maximum: 50
-                            },
-                            next_url: {
-                              description: '',
-                              type: 'string'
-                            },
-                            resources: {
-                              description: '',
-                              type: 'array'
-                            },
-                            rows_count: {
-                              description: '',
-                              type: 'number'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(2);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'responses',
-          '200',
-          'content',
-          'application/json',
-          'schema',
-          'properties'
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'The start or cursor properties must be integers and optional.'
-        );
-        expect(res.warnings[1].message).toEqual(
-          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.'
-        );
-      });
-
-      it('should complain when limit is misdefined', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'start',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'offset',
-                    in: 'query',
-                    description: '',
-                    required: true,
-                    schema: {
-                      type: 'integer'
-                    }
-                  }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          description: '',
-                          type: 'object',
-                          required: [
-                            'next_url',
-                            'resources',
-                            'rows_count',
-                            'limit',
-                            'offset'
-                          ],
-                          properties: {
-                            offset: {
-                              description: '',
-                              type: 'integer'
-                            },
-                            next_url: {
-                              description: '',
-                              type: 'string'
-                            },
-                            resources: {
-                              description: '',
-                              type: 'array'
-                            },
-                            rows_count: {
-                              description: '',
-                              type: 'number'
-                            },
-                            next_token: {
-                              description: '',
-                              type: 'string'
-                            },
-                            limit: {
-                              description: '',
-                              type: 'string',
-                              default: 20,
-                              maximum: 50
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(2);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'responses',
-          '200',
-          'content',
-          'application/json',
-          'schema',
-          'properties'
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'The start or cursor properties must be integers and optional.'
-        );
-        expect(res.warnings[1].message).toEqual(
-          'If a limit exists as a parameter query it must be defined as a property.'
-        );
-      });
-
-      it('should complain when offset is misdefined', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: '',
-                    maximum: 100,
-                    default: 20,
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'start',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'offset',
-                    in: 'query',
-                    description: 'shifts results',
-                    required: true,
-                    schema: {
-                      type: 'integer'
-                    }
-                  }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          description: '',
-                          type: 'object',
-                          required: [
-                            'next_url',
-                            'resources',
-                            'rows_count',
-                            'limit'
-                          ],
-                          properties: {
-                            limit: {
-                              description: '',
-                              type: 'integer'
-                            },
-                            next_url: {
-                              description: '',
-                              type: 'string'
-                            },
-                            resources: {
-                              description: '',
-                              type: 'array'
-                            },
-                            rows_count: {
-                              description: '',
-                              type: 'number'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(4);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'parameters',
-          0
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'The limit parameter must be of type integer and must be optional with default and maximum values.'
-        );
-        expect(res.warnings[1].message).toEqual(
-          'The start or cursor properties must be integers and optional.'
-        );
-        expect(res.warnings[2].message).toEqual(
-          'If a offset exists as a parameter query it must be defined as a property.'
-        );
-        expect(res.warnings[3].message).toEqual(
-          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.'
-        );
-      });
-
-      it('should complain when offset and start are both undefined', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          description: 'A list of resource aliases.',
-                          type: 'object',
-                          required: [
-                            'next_url',
-                            'resources',
-                            'rows_count',
-                            'limit'
-                          ],
-                          properties: {
-                            limit: {
-                              description: '',
-                              type: 'integer'
-                            },
-                            next_url: {
-                              description: '',
-                              type: 'string'
-                            },
-                            resources: {
-                              description: '',
-                              type: 'array'
-                            },
-                            rows_count: {
-                              description: '',
-                              type: 'number'
-                            },
-
-                            next_token: {}
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(1);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'parameters',
-          0
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'The limit parameter must be of type integer and must be optional with default and maximum values.'
-        );
-      });
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(0);
+      expect(res.errors.length).toEqual(0);
     });
 
-    describe('pagination with pagination object', function() {
-      it('should complain when a paginated object doesnt contain the next_url property', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: 'Limit on how many items should be returned.',
-                    maximum: 100,
-                    default: 20,
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: 'The human-readable name of the alias.',
-                    required: false,
-                    schema: {
-                      type: 'string'
+    it('should skip operations that do not have a limit query parameter', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resource: {
+                            description: 'resource',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          }
+                        }
+                      }
                     }
                   }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          properties: {
-                            pagination: {
-                              description: '',
-                              type: 'object',
-                              required: ['resources', 'rows_count', 'limit'],
-                              properties: {
-                                limit: {
-                                  description: '',
-                                  type: 'integer'
-                                },
-                                resources: {
-                                  description: '',
-                                  type: 'array'
-                                },
-                                rows_count: {
-                                  description: '',
-                                  type: 'number'
-                                },
-                                next_token: {}
-                              }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(0);
+      expect(res.errors.length).toEqual(0);
+    });
+
+    it('should skip operations that do not have an application/json response', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/octet-stream': {
+                      schema: {
+                        description: '',
+                        type: 'string'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(0);
+      expect(res.errors.length).toEqual(0);
+    });
+  });
+
+  describe('limit query parameter', function() {
+    it('should complain when limit parameter is not an integer', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'string',
+                    default: '10',
+                    maximum: '50'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        0
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The limit parameter must be of type integer and optional with default and maximum values.'
+      );
+    });
+
+    it('should complain when limit parameter is not optional', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: true,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        0
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The limit parameter must be of type integer and optional with default and maximum values.'
+      );
+    });
+
+    it('should complain when limit parameter does not specify a default value', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  schema: {
+                    type: 'integer',
+                    maximum: 50
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        0
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The limit parameter must be of type integer and optional with default and maximum values.'
+      );
+    });
+
+    it('should complain when limit parameter does not specify a maximum value', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  schema: {
+                    type: 'integer',
+                    default: 10
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        0
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The limit parameter must be of type integer and optional with default and maximum values.'
+      );
+    });
+  });
+
+  describe('offset query parameter', function() {
+    it('should complain when the offset parameter is not an integer', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                },
+                {
+                  name: 'offset',
+                  in: 'query',
+                  description: 'offset',
+                  schema: {
+                    type: 'string'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit', 'offset'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          },
+                          offset: {
+                            description: 'offset',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        1
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The offset parameter must be of type integer and optional.'
+      );
+    });
+
+    it('should complain when the offset parameter is not optional', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                },
+                {
+                  name: 'offset',
+                  in: 'query',
+                  description: 'offset',
+                  required: true,
+                  schema: {
+                    type: 'integer'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit', 'offset'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          },
+                          offset: {
+                            description: 'offset',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        1
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The offset parameter must be of type integer and optional.'
+      );
+    });
+  });
+
+  describe('start|cursor|page_token query parameter', function() {
+    it('should complain when the start parameter is not a string or optional', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                },
+                {
+                  name: 'start',
+                  in: 'query',
+                  description: 'start',
+                  schema: {
+                    type: 'integer'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        1
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The start parameter must be of type string and optional.'
+      );
+    });
+
+    it('should complain when the cursor parameter is not a string or optional', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                },
+                {
+                  name: 'cursor',
+                  in: 'query',
+                  description: 'cursor',
+                  required: true,
+                  schema: {
+                    type: 'string'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'parameters',
+        1
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The cursor parameter must be of type string and optional.'
+      );
+    });
+  });
+
+  describe('limit property in response body', function() {
+    it('should complain when limit property is not defined in response body', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
                             }
                           }
                         }
@@ -597,83 +760,67 @@ describe('validation plugin - semantic - responses', function() {
               }
             }
           }
-        };
+        }
+      };
 
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(1);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'reponses',
-          '200',
-          'content',
-          'application/json',
-          'pagination',
-          'schema',
-          'properties'
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'A paginated success response must contain the next property.'
-        );
-      });
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties'
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The response body of a paginated list operation must contain a "limit" property.'
+      );
+    });
 
-      it('should complain when a paginaed object defined limit as a query parameter but not a response property', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: '',
-                    maximum: 100,
-                    default: 20,
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
+    it('should complain when limit property in response body is not an integer', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
                   }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          properties: {
-                            pagination: {
-                              description: '',
-                              type: 'object',
-                              required: ['resources', 'rows_count', 'limit'],
-                              properties: {
-                                resources: {
-                                  description: '',
-                                  type: 'array'
-                                },
-                                rows_count: {
-                                  description: '',
-                                  type: 'number'
-                                },
-                                next_url: {
-                                  description: '',
-                                  type: 'string'
-                                },
-                                next_token: {}
-                              }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
                             }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'string'
                           }
                         }
                       }
@@ -683,96 +830,68 @@ describe('validation plugin - semantic - responses', function() {
               }
             }
           }
-        };
+        }
+      };
 
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(1);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'reponses',
-          '200',
-          'content',
-          'application/json',
-          'pagination',
-          'schema',
-          'properties'
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'If a limit exists as a parameter query it must be defined as a property.'
-        );
-      });
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'limit'
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The "limit" property in the response body of a paginated list operation must be of type integer and required.'
+      );
+    });
 
-      it('should complain when a paginated object defines offset as a query parameter but not a response property', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: '',
-                    maximum: 100,
-                    default: 20,
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'offset',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
+    it('should complain when limit property in response body is not required', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
                   }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          properties: {
-                            pagination: {
-                              description: '',
-                              type: 'object',
-                              required: ['resources', 'rows_count', 'limit'],
-                              properties: {
-                                limit: {
-                                  description: '',
-                                  type: 'integer'
-                                },
-                                resources: {
-                                  description: '',
-                                  type: 'array'
-                                },
-                                rows_count: {
-                                  description: '',
-                                  type: 'number'
-                                },
-                                next_url: {
-                                  description: '',
-                                  type: 'string'
-                                },
-                                next_token: {}
-                              }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
                             }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
                           }
                         }
                       }
@@ -782,96 +901,78 @@ describe('validation plugin - semantic - responses', function() {
               }
             }
           }
-        };
+        }
+      };
 
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(1);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'reponses',
-          '200',
-          'content',
-          'application/json',
-          'pagination',
-          'schema',
-          'properties'
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'If a offset exists as a parameter query it must be defined as a property.'
-        );
-      });
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'limit'
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The "limit" property in the response body of a paginated list operation must be of type integer and required.'
+      );
+    });
+  });
 
-      it('should complain when a paginated object misdefines total', function() {
-        const spec = {
-          paths: {
-            '/pets': {
-              get: {
-                summary: 'this is a summary',
-                operationId: 'operationId',
-                parameters: [
-                  {
-                    name: 'limit',
-                    in: 'query',
-                    description: '',
-                    maximum: 100,
-                    default: 20,
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
-                  },
-                  {
-                    name: 'name',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'string'
-                    }
-                  },
-                  {
-                    name: 'start',
-                    in: 'query',
-                    description: '',
-                    required: false,
-                    schema: {
-                      type: 'integer'
-                    }
+  describe('offset property in response body', function() {
+    it('should complain when offset property is not defined in response body', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
                   }
-                ],
-                responses: {
-                  '200': {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          properties: {
-                            pagination: {
-                              description: 'A list of resource aliases.',
-                              type: 'object',
-                              required: ['resources', 'rows_count', 'limit'],
-                              properties: {
-                                limit: {
-                                  description: '',
-                                  type: 'integer'
-                                },
-                                resources: {
-                                  description: '',
-                                  type: 'array'
-                                },
-                                rows_count: {
-                                  description: '',
-                                  type: 'number'
-                                },
-                                next_url: {
-                                  description:
-                                    'The URL for requesting the next page of results.',
-                                  type: 'string'
-                                }
-                              }
+                },
+                {
+                  name: 'offset',
+                  in: 'query',
+                  description: 'offset',
+                  schema: {
+                    type: 'integer'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
                             }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
                           }
                         }
                       }
@@ -881,27 +982,192 @@ describe('validation plugin - semantic - responses', function() {
               }
             }
           }
-        };
+        }
+      };
 
-        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-        expect(res.warnings.length).toEqual(1);
-        expect(res.errors.length).toEqual(0);
-        expect(res.warnings[0].path).toEqual([
-          'paths',
-          '/pets',
-          'get',
-          'reponses',
-          '200',
-          'content',
-          'application/json',
-          'pagination',
-          'schema',
-          'properties'
-        ]);
-        expect(res.warnings[0].message).toEqual(
-          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.'
-        );
-      });
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties'
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The response body of a paginated list operation must contain a "offset" property.'
+      );
+    });
+
+    it('should complain when offset property in response body is not an integer', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                },
+                {
+                  name: 'offset',
+                  in: 'query',
+                  description: 'offset',
+                  schema: {
+                    type: 'integer'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit', 'offset'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          },
+                          offset: {
+                            description: 'offset',
+                            type: 'string'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'offset'
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The "offset" property in the response body of a paginated list operation must be of type integer and required.'
+      );
+    });
+
+    it('should complain when offset property in response body is not required', function() {
+      const spec = {
+        paths: {
+          '/pets': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                },
+                {
+                  name: 'offset',
+                  in: 'query',
+                  description: 'offset',
+                  schema: {
+                    type: 'integer'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          },
+                          offset: {
+                            description: 'offset',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/pets',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'offset'
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The "offset" property in the response body of a paginated list operation must be of type integer and required.'
+      );
     });
   });
 });

--- a/test/plugins/validation/oas3/pagination-ibm.js
+++ b/test/plugins/validation/oas3/pagination-ibm.js
@@ -1,0 +1,907 @@
+const expect = require('expect');
+const {
+  validate
+} = require('../../../../src/plugins/validation/oas3/semantic-validators/pagination-ibm');
+
+const config = require('../../../../src/.defaultsForValidator').defaults.shared;
+
+describe('validation plugin - semantic - responses', function() {
+  describe('inline response schemas', function() {
+    describe('Pagination', function() {
+      it('should complain when the paginated object does not have start, cursor, or token', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: 'Limit on how many items should be returned.',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: 'The human-readable name of the alias.',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                ],
+                responses: {
+                  '201': {
+                    content: {
+                      'application/json': {
+                        description: 'successful operation',
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            stuff: {
+                              type: 'string'
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          description: '',
+                          type: 'object',
+                          required: ['next_url', 'resources', 'rows_count'],
+                          properties: {
+                            next_url: {
+                              description: '',
+                              type: 'string'
+                            },
+                            resources: {
+                              description: '',
+                              type: 'array'
+                            },
+                            rows_count: {
+                              description: '',
+                              type: 'number'
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(2);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'parameters',
+          0
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'The limit parameter must be of type integer and must be optional with default and maximum values.'
+        );
+        expect(res.warnings[1].message).toEqual(
+          'If a limit exists as a parameter query it must be defined as a property.'
+        );
+      });
+
+      it('should complain when next_token and start are both missing', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'offset',
+                    in: 'query',
+                    description: '',
+                    required: true,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'start',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          description: '',
+                          type: 'object',
+                          required: [
+                            'next_url',
+                            'resources',
+                            'rows_count',
+                            'limit',
+                            'offset'
+                          ],
+                          properties: {
+                            offset: {
+                              description: '',
+                              type: 'integer'
+                            },
+                            limit: {
+                              description: '',
+                              type: 'integer',
+                              default: 20,
+                              maximum: 50
+                            },
+                            next_url: {
+                              description: '',
+                              type: 'string'
+                            },
+                            resources: {
+                              description: '',
+                              type: 'array'
+                            },
+                            rows_count: {
+                              description: '',
+                              type: 'number'
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(2);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/json',
+          'schema',
+          'properties'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'The start or cursor properties must be integers and optional.'
+        );
+        expect(res.warnings[1].message).toEqual(
+          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.'
+        );
+      });
+
+      it('should complain when limit is misdefined', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'start',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'offset',
+                    in: 'query',
+                    description: '',
+                    required: true,
+                    schema: {
+                      type: 'integer'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          description: '',
+                          type: 'object',
+                          required: [
+                            'next_url',
+                            'resources',
+                            'rows_count',
+                            'limit',
+                            'offset'
+                          ],
+                          properties: {
+                            offset: {
+                              description: '',
+                              type: 'integer'
+                            },
+                            next_url: {
+                              description: '',
+                              type: 'string'
+                            },
+                            resources: {
+                              description: '',
+                              type: 'array'
+                            },
+                            rows_count: {
+                              description: '',
+                              type: 'number'
+                            },
+                            next_token: {
+                              description: '',
+                              type: 'string'
+                            },
+                            limit: {
+                              description: '',
+                              type: 'string',
+                              default: 20,
+                              maximum: 50
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(2);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/json',
+          'schema',
+          'properties'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'The start or cursor properties must be integers and optional.'
+        );
+        expect(res.warnings[1].message).toEqual(
+          'If a limit exists as a parameter query it must be defined as a property.'
+        );
+      });
+
+      it('should complain when offset is misdefined', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: '',
+                    maximum: 100,
+                    default: 20,
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'start',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'offset',
+                    in: 'query',
+                    description: 'shifts results',
+                    required: true,
+                    schema: {
+                      type: 'integer'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          description: '',
+                          type: 'object',
+                          required: [
+                            'next_url',
+                            'resources',
+                            'rows_count',
+                            'limit'
+                          ],
+                          properties: {
+                            limit: {
+                              description: '',
+                              type: 'integer'
+                            },
+                            next_url: {
+                              description: '',
+                              type: 'string'
+                            },
+                            resources: {
+                              description: '',
+                              type: 'array'
+                            },
+                            rows_count: {
+                              description: '',
+                              type: 'number'
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(4);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'parameters',
+          0
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'The limit parameter must be of type integer and must be optional with default and maximum values.'
+        );
+        expect(res.warnings[1].message).toEqual(
+          'The start or cursor properties must be integers and optional.'
+        );
+        expect(res.warnings[2].message).toEqual(
+          'If a offset exists as a parameter query it must be defined as a property.'
+        );
+        expect(res.warnings[3].message).toEqual(
+          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.'
+        );
+      });
+
+      it('should complain when offset and start are both undefined', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          description: 'A list of resource aliases.',
+                          type: 'object',
+                          required: [
+                            'next_url',
+                            'resources',
+                            'rows_count',
+                            'limit'
+                          ],
+                          properties: {
+                            limit: {
+                              description: '',
+                              type: 'integer'
+                            },
+                            next_url: {
+                              description: '',
+                              type: 'string'
+                            },
+                            resources: {
+                              description: '',
+                              type: 'array'
+                            },
+                            rows_count: {
+                              description: '',
+                              type: 'number'
+                            },
+
+                            next_token: {}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'parameters',
+          0
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'The limit parameter must be of type integer and must be optional with default and maximum values.'
+        );
+      });
+    });
+
+    describe('pagination with pagination object', function() {
+      it('should complain when a paginated object doesnt contain the next_url property', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: 'Limit on how many items should be returned.',
+                    maximum: 100,
+                    default: 20,
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: 'The human-readable name of the alias.',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          properties: {
+                            pagination: {
+                              description: '',
+                              type: 'object',
+                              required: ['resources', 'rows_count', 'limit'],
+                              properties: {
+                                limit: {
+                                  description: '',
+                                  type: 'integer'
+                                },
+                                resources: {
+                                  description: '',
+                                  type: 'array'
+                                },
+                                rows_count: {
+                                  description: '',
+                                  type: 'number'
+                                },
+                                next_token: {}
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'reponses',
+          '200',
+          'content',
+          'application/json',
+          'pagination',
+          'schema',
+          'properties'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'A paginated success response must contain the next property.'
+        );
+      });
+
+      it('should complain when a paginaed object defined limit as a query parameter but not a response property', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: '',
+                    maximum: 100,
+                    default: 20,
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          properties: {
+                            pagination: {
+                              description: '',
+                              type: 'object',
+                              required: ['resources', 'rows_count', 'limit'],
+                              properties: {
+                                resources: {
+                                  description: '',
+                                  type: 'array'
+                                },
+                                rows_count: {
+                                  description: '',
+                                  type: 'number'
+                                },
+                                next_url: {
+                                  description: '',
+                                  type: 'string'
+                                },
+                                next_token: {}
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'reponses',
+          '200',
+          'content',
+          'application/json',
+          'pagination',
+          'schema',
+          'properties'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'If a limit exists as a parameter query it must be defined as a property.'
+        );
+      });
+
+      it('should complain when a paginated object defines offset as a query parameter but not a response property', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: '',
+                    maximum: 100,
+                    default: 20,
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'offset',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          properties: {
+                            pagination: {
+                              description: '',
+                              type: 'object',
+                              required: ['resources', 'rows_count', 'limit'],
+                              properties: {
+                                limit: {
+                                  description: '',
+                                  type: 'integer'
+                                },
+                                resources: {
+                                  description: '',
+                                  type: 'array'
+                                },
+                                rows_count: {
+                                  description: '',
+                                  type: 'number'
+                                },
+                                next_url: {
+                                  description: '',
+                                  type: 'string'
+                                },
+                                next_token: {}
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'reponses',
+          '200',
+          'content',
+          'application/json',
+          'pagination',
+          'schema',
+          'properties'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'If a offset exists as a parameter query it must be defined as a property.'
+        );
+      });
+
+      it('should complain when a paginated object misdefines total', function() {
+        const spec = {
+          paths: {
+            '/pets': {
+              get: {
+                summary: 'this is a summary',
+                operationId: 'operationId',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    description: '',
+                    maximum: 100,
+                    default: 20,
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  },
+                  {
+                    name: 'name',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  {
+                    name: 'start',
+                    in: 'query',
+                    description: '',
+                    required: false,
+                    schema: {
+                      type: 'integer'
+                    }
+                  }
+                ],
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          properties: {
+                            pagination: {
+                              description: 'A list of resource aliases.',
+                              type: 'object',
+                              required: ['resources', 'rows_count', 'limit'],
+                              properties: {
+                                limit: {
+                                  description: '',
+                                  type: 'integer'
+                                },
+                                resources: {
+                                  description: '',
+                                  type: 'array'
+                                },
+                                rows_count: {
+                                  description: '',
+                                  type: 'number'
+                                },
+                                next_url: {
+                                  description:
+                                    'The URL for requesting the next page of results.',
+                                  type: 'string'
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+        expect(res.warnings.length).toEqual(1);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings[0].path).toEqual([
+          'paths',
+          '/pets',
+          'get',
+          'reponses',
+          '200',
+          'content',
+          'application/json',
+          'pagination',
+          'schema',
+          'properties'
+        ]);
+        expect(res.warnings[0].message).toEqual(
+          'If start or token or cursor are  defined then responses must have a `next_token` or `next_cursor` property.'
+        );
+      });
+    });
+  });
+});

--- a/test/plugins/validation/oas3/pagination-ibm.js
+++ b/test/plugins/validation/oas3/pagination-ibm.js
@@ -151,7 +151,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when limit parameter is not an integer', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -204,7 +204,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         0
@@ -217,7 +217,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when limit parameter is not optional', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -270,7 +270,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         0
@@ -283,7 +283,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when limit parameter does not specify a default value', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -334,7 +334,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         0
@@ -347,7 +347,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when limit parameter does not specify a maximum value', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -398,7 +398,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         0
@@ -413,7 +413,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when the offset parameter is not an integer', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -477,7 +477,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         1
@@ -490,7 +490,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when the offset parameter is not optional', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -555,7 +555,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         1
@@ -570,7 +570,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when the start parameter is not a string or optional', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -630,7 +630,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         1
@@ -643,7 +643,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when the cursor parameter is not a string or optional', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -704,7 +704,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'parameters',
         1
@@ -719,7 +719,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when limit property is not defined in response body', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -768,7 +768,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'responses',
         '200',
@@ -778,14 +778,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'properties'
       ]);
       expect(res.warnings[0].message).toEqual(
-        'The response body of a paginated list operation must contain a "limit" property.'
+        'A paginated list operation must include a "limit" property in the response body schema.'
       );
     });
 
     it('should complain when limit property in response body is not an integer', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -838,7 +838,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'responses',
         '200',
@@ -856,7 +856,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when limit property in response body is not required', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -909,7 +909,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'responses',
         '200',
@@ -929,7 +929,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when offset property is not defined in response body', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -990,7 +990,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'responses',
         '200',
@@ -1000,14 +1000,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'properties'
       ]);
       expect(res.warnings[0].message).toEqual(
-        'The response body of a paginated list operation must contain a "offset" property.'
+        'A paginated list operation with an "offset" parameter must include an "offset" property in the response body schema.'
       );
     });
 
     it('should complain when offset property in response body is not an integer', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -1072,7 +1072,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'responses',
         '200',
@@ -1090,7 +1090,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     it('should complain when offset property in response body is not required', function() {
       const spec = {
         paths: {
-          '/pets': {
+          '/resources': {
             get: {
               summary: 'this is a summary',
               operationId: 'operationId',
@@ -1155,7 +1155,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings[0].path).toEqual([
         'paths',
-        '/pets',
+        '/resources',
         'get',
         'responses',
         '200',
@@ -1167,6 +1167,90 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       ]);
       expect(res.warnings[0].message).toEqual(
         'The "offset" property in the response body of a paginated list operation must be of type integer and required.'
+      );
+    });
+  });
+
+  describe('collection property in response body', function() {
+    it('should complain when response body does not include an array property whose name matches the final segment of the path', function() {
+      const spec = {
+        paths: {
+          '/resources': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50
+                  }
+                },
+                {
+                  name: 'offset',
+                  in: 'query',
+                  description: 'offset',
+                  schema: {
+                    type: 'integer'
+                  }
+                }
+              ],
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['items', 'limit', 'offset'],
+                        properties: {
+                          items: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object'
+                            }
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer'
+                          },
+                          offset: {
+                            description: 'offset',
+                            type: 'integer'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties'
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'A paginated list operation must include an array property whose name matches the final segment of the path.'
       );
     });
   });


### PR DESCRIPTION
This PR adds a rule that checks paginated list operations for conformance to basic requirements of the API Handbook for paginated collections.  All checks are grouped under a single rule that is set to "warning" by default.

I've only implemented this rule for oas3 schemas.  The oas2 support would require significant additional logic and I considered it not worth the effort, at least for this initial PR.  Support for oas2 could be added later if necessary.