### PR TITLE
fix: add command name for improved usage output

### DIFF
--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -13,6 +13,7 @@ const version = require('../../package.json').version;
 // set up the command line options
 /* prettier-ignore */
 program
+  .name('lint-openapi')
   .version(version, '-v, --version')
   .description('Run the validator on a specified file')
   .arguments('[<file>]')


### PR DESCRIPTION
Making the change @BigBlueHat suggested in #120 :

Was:
> Usage: index [options] [command] [<file>]

Now:
> Usage: lint-openapi [options] [command] [<file>]