### PR TITLE
fix: swagger2 validator should only report error if there's body parameter but no consume

### DIFF
--- a/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
+++ b/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
@@ -77,7 +77,7 @@ module.exports.validate = function({ jsSpec }, config) {
             result[checkStatus].push({
               path: `paths.${pathKey}.${opKey}.consumes`,
               message:
-                'PUT and POST operations with body parameter must have a non-empty `consumes` field.'
+                'PUT and POST operations with a body parameter must have a non-empty `consumes` field.'
             });
           }
         }

--- a/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
+++ b/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
@@ -48,19 +48,23 @@ module.exports.validate = function({ jsSpec }, config) {
 
         // Check for body parameter in path
         let hasBodyParamInPath = false;
-        path.parameters.forEach(parameter => {
-          if (parameter.in === 'body') {
-            hasBodyParamInPath = true;
-          }
-        });
+        if (path.parameters) {
+          path.parameters.forEach(parameter => {
+            if (parameter.in === 'body') {
+              hasBodyParamInPath = true;
+            }
+          });
+        }
 
         // Check for body parameter in operation
         let hasBodyParamInOps = false;
-        op.parameters.forEach(parameter => {
-          if (parameter.in === 'body') {
-            hasBodyParamInOps = true;
-          }
-        });
+        if (op.parameters) {
+          op.parameters.forEach(parameter => {
+            if (parameter.in === 'body') {
+              hasBodyParamInOps = true;
+            }
+          });
+        }
 
         if (
           !hasLocalConsumes &&

--- a/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
+++ b/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
@@ -1,5 +1,5 @@
 // Assertation 1:
-// PUT and POST operations must have a non-empty `consumes` field
+// PUT and POST operations with body parameter must have a non-empty `consumes` field
 
 // Assertation 2:
 // GET operations should not specify a consumes field.
@@ -46,14 +46,30 @@ module.exports.validate = function({ jsSpec }, config) {
           !!op.consumes.join('').trim();
         const hasGlobalConsumes = !!jsSpec.consumes;
 
-        if (!hasLocalConsumes && !hasGlobalConsumes) {
+        // Check for body parameter in path
+        let hasBodyParamInPath = false
+        path.parameters.forEach((parameter) => {
+          if (parameter.in === 'body') {
+            hasBodyParamInPath = true
+          }
+        })
+
+        // Check for body parameter in operation
+        let hasBodyParamInOps = false
+        op.parameters.forEach((parameter) => {
+          if (parameter.in === 'body') {
+            hasBodyParamInOps = true
+          }
+        })
+
+        if (!hasLocalConsumes && !hasGlobalConsumes && (hasBodyParamInOps || hasBodyParamInPath)) {
           const checkStatus = config.no_consumes_for_put_or_post;
 
           if (checkStatus !== 'off') {
             result[checkStatus].push({
               path: `paths.${pathKey}.${opKey}.consumes`,
               message:
-                'PUT and POST operations must have a non-empty `consumes` field.'
+                'PUT and POST operations with body parameter must have a non-empty `consumes` field.'
             });
           }
         }

--- a/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
+++ b/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
@@ -47,22 +47,26 @@ module.exports.validate = function({ jsSpec }, config) {
         const hasGlobalConsumes = !!jsSpec.consumes;
 
         // Check for body parameter in path
-        let hasBodyParamInPath = false
-        path.parameters.forEach((parameter) => {
+        let hasBodyParamInPath = false;
+        path.parameters.forEach(parameter => {
           if (parameter.in === 'body') {
-            hasBodyParamInPath = true
+            hasBodyParamInPath = true;
           }
-        })
+        });
 
         // Check for body parameter in operation
-        let hasBodyParamInOps = false
-        op.parameters.forEach((parameter) => {
+        let hasBodyParamInOps = false;
+        op.parameters.forEach(parameter => {
           if (parameter.in === 'body') {
-            hasBodyParamInOps = true
+            hasBodyParamInOps = true;
           }
-        })
+        });
 
-        if (!hasLocalConsumes && !hasGlobalConsumes && (hasBodyParamInOps || hasBodyParamInPath)) {
+        if (
+          !hasLocalConsumes &&
+          !hasGlobalConsumes &&
+          (hasBodyParamInOps || hasBodyParamInPath)
+        ) {
           const checkStatus = config.no_consumes_for_put_or_post;
 
           if (checkStatus !== 'off') {

--- a/test/plugins/validation/swagger2/operations-ibm.js
+++ b/test/plugins/validation/swagger2/operations-ibm.js
@@ -41,7 +41,7 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./CoolPath.put.consumes');
     expect(res.errors[0].message).toEqual(
-      'PUT and POST operations must have a non-empty `consumes` field.'
+      'PUT and POST operations with body parameter must have a non-empty `consumes` field.'
     );
     expect(res.warnings.length).toEqual(0);
   });
@@ -84,7 +84,7 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./CoolPath.post.consumes');
     expect(res.errors[0].message).toEqual(
-      'PUT and POST operations must have a non-empty `consumes` field.'
+      'PUT and POST operations with body parameter must have a non-empty `consumes` field.'
     );
     expect(res.warnings.length).toEqual(0);
   });

--- a/test/plugins/validation/swagger2/operations-ibm.js
+++ b/test/plugins/validation/swagger2/operations-ibm.js
@@ -4,7 +4,7 @@ const {
 } = require('../../../../src/plugins/validation/swagger2/semantic-validators/operations-ibm');
 
 describe('validation plugin - semantic - operations-ibm - swagger2', function() {
-  it('should complain about a missing consumes with content', function() {
+  it('should complain about PUT operation with body parameter and a missing consumes', function() {
     const config = {
       operations: {
         no_consumes_for_put_or_post: 'error'
@@ -41,12 +41,12 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./CoolPath.put.consumes');
     expect(res.errors[0].message).toEqual(
-      'PUT and POST operations with body parameter must have a non-empty `consumes` field.'
+      'PUT and POST operations with a body parameter must have a non-empty `consumes` field.'
     );
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain about an empty consumes', function() {
+  it('should complain about POST operation with body parameter and a missing consumes', function() {
     const config = {
       operations: {
         no_consumes_for_put_or_post: 'error'
@@ -84,8 +84,118 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./CoolPath.post.consumes');
     expect(res.errors[0].message).toEqual(
-      'PUT and POST operations with body parameter must have a non-empty `consumes` field.'
+      'PUT and POST operations with a body parameter must have a non-empty `consumes` field.'
     );
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should complain about PUT opeartion with body parameter in path and a missing consumes', function() {
+    const config = {
+      operations: {
+        no_consumes_for_put_or_post: 'error'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/CoolPath': {
+          parameters: [
+            {
+              name: 'BadParameter',
+              in: 'body',
+              schema: {
+                required: ['Property'],
+                properties: [
+                  {
+                    name: 'Property'
+                  }
+                ]
+              }
+            }
+          ],
+          put: {
+            consumes: [' '],
+            produces: ['application/json'],
+            summary: 'this is a summary',
+            operationId: 'operationId'
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].path).toEqual('paths./CoolPath.put.consumes');
+    expect(res.errors[0].message).toEqual(
+      'PUT and POST operations with a body parameter must have a non-empty `consumes` field.'
+    );
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should complain about POST opeartion with body parameter in path and a missing consumes', function() {
+    const config = {
+      operations: {
+        no_consumes_for_put_or_post: 'error'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/CoolPath': {
+          parameters: [
+            {
+              name: 'BadParameter',
+              in: 'body',
+              schema: {
+                required: ['Property'],
+                properties: [
+                  {
+                    name: 'Property'
+                  }
+                ]
+              }
+            }
+          ],
+          post: {
+            consumes: [' '],
+            produces: ['application/json'],
+            summary: 'this is a summary',
+            operationId: 'operationId'
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].path).toEqual('paths./CoolPath.post.consumes');
+    expect(res.errors[0].message).toEqual(
+      'PUT and POST operations with a body parameter must have a non-empty `consumes` field.'
+    );
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should not complain about missing consumes when there is no body parameter', function() {
+    const config = {
+      operations: {
+        no_consumes_for_put_or_post: 'error'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/CoolPath': {
+          put: {
+            produces: ['application/json'],
+            summary: 'this is a summary',
+            operationId: 'operationId'
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);
   });
 


### PR DESCRIPTION
Currently, swagger2 validator reports error on all PUT or POST operations that has no consume field. This is technically incorrect because a POST operation is not required to have a request body and if there is no request body, there does not need to be a consumes field.

The fix now checks for body parameters on the path level and also operation level, and will only report error when there is body parameter, but no consume field.