### PR TITLE
feat: add warning, non-204 success response should have response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The `-g` flag installs the tool globally so that the validator can be run from a
 3. Install the dependencies using `npm install`
 4. Build the command line tool by running `npm run link`.
 
+_If you installed the validator using `npm install -g ibm-openapi-validator`, you will need to run `npm uninstall -g ibm-openapi-validator` before running `npm run link`._
+
 ### Platform specific binaries
 It is possible to build platform specific binaries for Linux, MacOS, and Windows that do not depend on having node.js installed.
 
@@ -202,6 +204,7 @@ The supported rules are described below:
 | no_request_body_content      | [Flag any operations with a `requestBody` that does not have a `content` field.][3] | oas3     |
 | no_request_body_name         | Flag any operations with a non-form `requestBody` that does not have a name set with `x-codegen-request-body-name`. | oas3|
 
+
 ##### pagination
 | Rule                        | Description                                                              | Spec   |
 | --------------------------- | ------------------------------------------------------------------------ | ------ |
@@ -237,6 +240,7 @@ The supported rules are described below:
 | inline_response_schema    | Flag any response object with a schema that doesn't reference a named model. | shared |
 | no_response_codes         | Flag any response object that has no valid response codes.   | oas3 |
 | no_success_response_codes | Flag any response object that has no success response codes. | oas3 |
+| no_response_body          | Flag any non-204 success responses without a response body.  | oas3 |
 
 ##### schemas
 | Rule                        | Description                                                                   | Spec     |
@@ -355,6 +359,7 @@ The default values for each rule are described below.
 | ------------------------- | ------- |
 | no_response_codes         | error   |
 | no_success_response_codes | warning |
+| no_response_body          | warning |
 
 
 ##### shared

--- a/package-lock.json
+++ b/package-lock.json
@@ -3760,6 +3760,7 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
       "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -3770,7 +3771,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -5274,7 +5276,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -5421,7 +5424,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "nerf-dart": {
       "version": "1.0.0",
@@ -9317,6 +9321,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -9325,7 +9330,8 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },
@@ -11540,6 +11546,7 @@
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.17.1",
@@ -11550,6 +11557,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
           "optional": true
         }
       }

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -94,7 +94,8 @@ const defaults = {
     },
     'responses': {
       'no_response_codes': 'error',
-      'no_success_response_codes': 'warning'
+      'no_success_response_codes': 'warning',
+      'no_response_body': 'warning'
     }
   }
 };

--- a/src/plugins/validation/oas3/semantic-validators/responses.js
+++ b/src/plugins/validation/oas3/semantic-validators/responses.js
@@ -9,6 +9,9 @@
 // A 204 response MUST not define a response body
 // https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5
 
+// Assertation 4:
+// A non-204 success response MUST define a response body
+
 const { walk } = require('../../../utils');
 
 module.exports.validate = function({ jsSpec }, config) {
@@ -56,6 +59,23 @@ module.exports.validate = function({ jsSpec }, config) {
               path,
               message
             });
+          }
+        } else {
+          const checkStatus = config.no_response_body;
+          // if response body rule is on, loops through success codes and issues warning (by default)
+          // for non-204 success responses without a response body
+          if (checkStatus !== 'off') {
+            for (const successCode of successCodes) {
+              if (successCode != '204' && !obj[successCode].content) {
+                result[checkStatus].push({
+                  path: path.concat([successCode]),
+                  message:
+                    `A ` +
+                    successCode +
+                    ` response should include a response body. Use 204 for responses without content.`
+                });
+              }
+            }
           }
         }
       }

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -54,7 +54,7 @@ paths:
       tags:
         - pets
       responses:
-        '201':
+        '204':
           description: Null response
         default:
           description: unexpected error

--- a/test/plugins/validation/oas3/responses.js
+++ b/test/plugins/validation/oas3/responses.js
@@ -8,7 +8,8 @@ describe('validation plugin - semantic - responses - oas3', function() {
     const config = {
       responses: {
         no_response_codes: 'error',
-        no_success_response_codes: 'warning'
+        no_success_response_codes: 'warning',
+        no_response_body: 'warning'
       }
     };
 
@@ -41,7 +42,8 @@ describe('validation plugin - semantic - responses - oas3', function() {
     const config = {
       responses: {
         no_response_codes: 'error',
-        no_success_response_codes: 'warning'
+        no_success_response_codes: 'warning',
+        no_response_body: 'warning'
       }
     };
 
@@ -74,7 +76,8 @@ describe('validation plugin - semantic - responses - oas3', function() {
     const config = {
       responses: {
         no_response_codes: 'error',
-        no_success_response_codes: 'warning'
+        no_success_response_codes: 'warning',
+        no_response_body: 'warning'
       }
     };
 
@@ -85,8 +88,8 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
-                description: 'successful operation call'
+              '204': {
+                description: 'successful operation call with no response body'
               }
             }
           }
@@ -99,11 +102,124 @@ describe('validation plugin - semantic - responses - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
+  it('should complain when a non-204 success does not have response body', function() {
+    const config = {
+      responses: {
+        no_response_codes: 'error',
+        no_success_response_codes: 'warning',
+        no_response_body: 'warning'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/example': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              '200': {
+                description: 'successful operation call with no response body'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/example',
+      'get',
+      'responses',
+      '200'
+    ]);
+    expect(res.warnings[0].message).toEqual(
+      `A 200 response should include a response body. Use 204 for responses without content.`
+    );
+  });
+
+  it('should issue multiple warnings when multiple non-204 successes do not have response bodies', function() {
+    const config = {
+      responses: {
+        no_response_codes: 'error',
+        no_success_response_codes: 'warning',
+        no_response_body: 'warning'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/example1': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId_1',
+            responses: {
+              '200': {
+                description: 'first successful response with no response body'
+              },
+              '202': {
+                description: 'second successful response with no response body'
+              }
+            }
+          }
+        },
+        '/example2': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId_2',
+            responses: {
+              '203': {
+                description: 'third successful response with no response body'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.warnings.length).toEqual(3);
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/example1',
+      'get',
+      'responses',
+      '200'
+    ]);
+    expect(res.warnings[0].message).toEqual(
+      `A 200 response should include a response body. Use 204 for responses without content.`
+    );
+    expect(res.warnings[1].path).toEqual([
+      'paths',
+      '/example1',
+      'get',
+      'responses',
+      '202'
+    ]);
+    expect(res.warnings[1].message).toEqual(
+      `A 202 response should include a response body. Use 204 for responses without content.`
+    );
+    expect(res.warnings[2].path).toEqual([
+      'paths',
+      '/example2',
+      'get',
+      'responses',
+      '203'
+    ]);
+    expect(res.warnings[2].message).toEqual(
+      `A 203 response should include a response body. Use 204 for responses without content.`
+    );
+  });
+
   it('should complain about having only error responses', function() {
     const config = {
       responses: {
         no_response_codes: 'error',
-        no_success_response_codes: 'warning'
+        no_success_response_codes: 'warning',
+        no_response_body: 'warning'
       }
     };
 
@@ -150,7 +266,8 @@ describe('validation plugin - semantic - responses - oas3', function() {
     const config = {
       responses: {
         no_response_codes: 'error',
-        no_success_response_codes: 'warning'
+        no_success_response_codes: 'warning',
+        no_response_body: 'warning'
       }
     };
 


### PR DESCRIPTION
Related Issue: [arf/planning-sdk-squad/issues/560](https://github.ibm.com/arf/planning-sdk-squad/issues/560)

Changes:
- added logic to check for response bodies in non-204 success responses in the oas3 plugin
- added a test to check that a non-204 success response without response body generates a warning
- added a test to check that multiple non-204 success responses without response bodies generates multiple warnings
- updated the README.md to help users resolve potential issue with `npm run link`
- fixed API definitions and tests that define a non-204 success without adding a response body