### PR TITLE
fix: display the usage menu for an unknown command-line argument

### DIFF
--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -6,7 +6,8 @@
 require('./utils/checkVersion')('8.9.0');
 require('./utils/updateNotifier');
 
-const program = require('commander');
+// include the modified commander module
+const program = require('./utils/unsupportedOptionError.js');
 const cliValidator = require('./runValidator');
 const version = require('../../package.json').version;
 

--- a/src/cli-validator/utils/unsupportedOptionError.js
+++ b/src/cli-validator/utils/unsupportedOptionError.js
@@ -1,0 +1,23 @@
+var program = require('commander');
+
+// This module is used to modify the commander code. When
+// an unsupported option is given, only a single-line error
+// is printed. Now, it will also print out the usage menu.
+
+// deletes the function in order to reimplement it
+delete program['unknownOption'];
+
+// reimplementing the funciton
+program.unknownOption = function(flag) {
+  if (this._allowUnknownOption) return;
+  console.error();
+  console.error("  error: unknown option `%s'", flag);
+  console.error();
+
+  // this is the extra code added to the function
+  this.outputHelp();
+
+  process.exit(1);
+};
+
+module.exports = program;


### PR DESCRIPTION
When an unsupported option is given, a single-line error is printed. Now, the usage menu is printed along with the single-line error. 

Change:
- unsupportedOptionError.js modifies the commander code
- modified index.js file to include the unsupportedOptionError.js file.

Commander code was:
`Command.prototype.unknownOption = function(flag) {`
`if (this._allowUnknownOption) return;`
`console.error();`
`console.error("  error: unknown option %s'", flag);`
`console.error();`
`process.exit(1);`
`};`

Now:
`program.unknownOption = function(flag) {`
 ` if (this._allowUnknownOption) return;`
  `console.error();`
 `console.error("  error: unknown option %s'", flag);`
  `console.error();`
  `// this is the extra code added to the function`
  `this.outputHelp();`
 ` process.exit(1);`
`};`


Resolves: [issue-272](https://github.ibm.com/arf/planning-sdk-squad/issues/272)