### PR TITLE
fix: print error message and the usage menu for an unknown command line argument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1415,6 +1415,38 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^4.2.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+      "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/events/-/events-3.0.0.tgz",
@@ -4807,6 +4839,11 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4913,8 +4950,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -4985,6 +5021,14 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "longest": {
       "version": "1.0.1",
@@ -5444,6 +5488,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -9589,6 +9646,21 @@
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -10886,6 +10958,40 @@
         "pkg-conf": "^2.1.0"
       }
     },
+    "sinon": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.1.tgz",
+      "integrity": "sha512-E+tWr3acRdoe1nXbHMu86SSqA1WGM7Yw3jZRLvlCMnXwTHP8lgFFVn5BnKnF26uc5SfZ3D7pA9sN7S3Y2jG4Ew==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/samsam": "^4.2.2",
+        "diff": "^4.0.2",
+        "lolex": "^5.1.2",
+        "nise": "^3.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -11535,6 +11641,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pad": "^2.2.1",
     "require-all": "^3.0.0",
     "semver": "^5.5.1",
+    "sinon": "^8.1.1",
     "update-notifier": "^2.5.0",
     "validator": "^11.0.0",
     "yaml-js": "^0.2.3"

--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -6,7 +6,7 @@
 require('./utils/checkVersion')('8.9.0');
 require('./utils/updateNotifier');
 
-const program = require('commander');
+const program = require('./utils/modified-commander');
 const cliValidator = require('./runValidator');
 const version = require('../../package.json').version;
 

--- a/src/cli-validator/utils/modified-commander.js
+++ b/src/cli-validator/utils/modified-commander.js
@@ -1,0 +1,23 @@
+const program = require('commander');
+
+// This module is used to modify the commander code. When
+// an unsupported option is given, only a single-line error
+// is printed. Now, it will also print out the usage menu.
+
+// deletes the function in order to reimplement it
+delete program['unknownOption'];
+
+// reimplementing the funciton
+program.unknownOption = function(flag) {
+  if (this._allowUnknownOption) return;
+  console.error();
+  console.error("  error: unknown option `%s'", flag);
+  console.error();
+
+  // this is the extra code added to the function
+  this.outputHelp();
+
+  process.exit(1);
+};
+
+module.exports = program;

--- a/test/cli-validator/tests/optionHandling.js
+++ b/test/cli-validator/tests/optionHandling.js
@@ -2,6 +2,8 @@ const intercept = require('intercept-stdout');
 const expect = require('expect');
 const stripAnsiFrom = require('strip-ansi');
 const commandLineValidator = require('../../../src/cli-validator/runValidator');
+const modifiedCommander = require('../../../src/cli-validator/utils/modified-commander');
+const sinon = require('sinon');
 
 // for an explanation of the text interceptor,
 // see the comments for the first test in expectedOutput.js
@@ -315,5 +317,22 @@ describe('cli tool - test option handling', function() {
     });
     expect(warningCount).toEqual(3); // without the config this value is 5
     expect(errorCount).toEqual(3); // without the config this value is 0
+  });
+
+  it('should return an error and usage menu when there is an unknown option', async function() {
+    const errorStub = sinon.stub(console, 'error');
+    const helpStub = sinon.stub(modifiedCommander, 'outputHelp');
+    const exitStub = sinon.stub(process, 'exit');
+
+    modifiedCommander.unknownOption('r');
+
+    expect(errorStub.called).toEqual(true);
+    expect(errorStub.secondCall.args[0].trim()).toEqual(
+      "error: unknown option `%s'"
+    );
+    expect(errorStub.secondCall.args[1].trim()).toEqual('r');
+    expect(helpStub.called).toEqual(true);
+    expect(exitStub.called).toEqual(true);
+    expect(exitStub.firstCall.args[0]).toEqual(1);
   });
 });


### PR DESCRIPTION
When an unsupported option is given, a single-line error is printed. Now, the usage menu is printed along with the single-line error.

Change: 

- unsupportedOptionError.js modifies the commander code
- modified index.js file to include the unsupportedOptionError.js file.

Commander code was:
```
Command.prototype.unknownOption = function(flag) {
if (this._allowUnknownOption) return;
console.error();
console.error(" error: unknown option %s'", flag);
console.error();
process.exit(1);
};
```

Now:
```
program.unknownOption = function(flag) {
if (this._allowUnknownOption) return;
console.error();
console.error(" error: unknown option %s'", flag);
console.error();
// this is the extra code added to the function
this.outputHelp();
process.exit(1);
};
```