### PR TITLE
Fix incorrect property case

### DIFF
--- a/src/plugins/validation/oas3/semantic-validators/security-definitions-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/security-definitions-ibm.js
@@ -131,8 +131,8 @@ module.exports.validate = function({ resolvedSpec }) {
           });
         }
       } else if (flows.password) {
-        const tokenURL = flows.password.tokenURL;
-        if (!tokenURL) {
+        const tokenUrl = flows.password.tokenUrl;
+        if (!tokenUrl) {
           errors.push({
             message:
               "oauth2 authorization password flow must have required 'tokenUrl' property.",


### PR DESCRIPTION
The `tokenUrl` property for the OAuth2 password flow has the `Url` part incorrectly capitalised (`tokenURL`), causing false errors. All other properties tested in this validation have the correct case.