### PR TITLE
feat: add warning for binary string in "application/json" or parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ The supported rules are described below:
 | array_of_arrays             | Flag any schema with a 'property' of type `array` with items of type `array`. | shared   |
 | property_case_convention    | Flag any property with a `name` that does not follow a given case convention. snake_case_only must be 'off' to use. | shared |
 | enum_case_convention        | Flag any enum with a `value` that does not follow a given case convention. snake_case_only must be 'off' to use.    | shared |
+| json_or_param_binary_string | Flag parameters or application/json request/response bodies with schema type: string, format: binary. | oas3 |
 
 ##### security_definitions
 | Rule                        | Description                                                                           | Spec   |
@@ -361,6 +362,11 @@ The default values for each rule are described below.
 | no_success_response_codes | warning |
 | no_response_body          | warning |
 
+##### schemas
+
+| Rule                        | Default |
+| --------------------------- | ------- |
+| json_or_param_binary_string | warning |
 
 ##### shared
 

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -96,6 +96,9 @@ const defaults = {
       'no_response_codes': 'error',
       'no_success_response_codes': 'warning',
       'no_response_body': 'warning'
+    },
+    'schemas': {
+      'json_or_param_binary_string': 'warning'
     }
   }
 };

--- a/src/plugins/utils/findOctetSequencePaths.js
+++ b/src/plugins/utils/findOctetSequencePaths.js
@@ -1,0 +1,75 @@
+// Finds octet sequences (type: string, format: binary) in schemas including
+// nested arrays, objects, nested arrays of type object, objects with properties
+// that are nested arrays, and objects with properties that are objects This
+// function takes a resolved schema object (no refs) and returns a list of
+// paths to octet sequences (empty list if none found). The function accepts
+// the path both as an array and a string and returns the path in the same
+// format received:
+// typeof(path) === 'array' => [[path1, get], [path2, get], ...]
+// typeof(path) === 'string' => ['path1.get', path2.get, ...]
+
+const findOctetSequencePaths = (resolvedSchema, path) => {
+  if (!resolvedSchema) {
+    // schema is empty, no octet sequence
+    return [];
+  }
+
+  const pathsToOctetSequence = [];
+
+  if (resolvedSchema.type === 'string' && resolvedSchema.format === 'binary') {
+    pathsToOctetSequence.push(path);
+  } else if (resolvedSchema.type === 'array') {
+    pathsToOctetSequence.push(...arrayOctetSequences(resolvedSchema, path));
+  } else if (resolvedSchema.type === 'object') {
+    pathsToOctetSequence.push(...objectOctetSequences(resolvedSchema, path));
+  }
+
+  return pathsToOctetSequence;
+};
+
+function arrayOctetSequences(resolvedSchema, path) {
+  const arrayPathsToOctetSequence = [];
+  const arrayItems = resolvedSchema.items;
+  if (arrayItems !== undefined) {
+    // supports both array and string (delimited by .) paths
+    const pathToSchema = Array.isArray(path)
+      ? path.concat('items')
+      : `${path}.items`;
+    if (arrayItems.type === 'string' && arrayItems.format === 'binary') {
+      arrayPathsToOctetSequence.push(pathToSchema);
+    } else if (arrayItems.type === 'object' || arrayItems.type === 'array') {
+      arrayPathsToOctetSequence.push(
+        ...findOctetSequencePaths(arrayItems, pathToSchema)
+      );
+    }
+  }
+  return arrayPathsToOctetSequence;
+}
+
+function objectOctetSequences(resolvedSchema, path) {
+  const objectPathsToOctetSequence = [];
+  const objectProperties = resolvedSchema.properties;
+  if (objectProperties) {
+    Object.keys(objectProperties).forEach(function(prop) {
+      const propPath = Array.isArray(path)
+        ? path.concat(['properties', prop])
+        : `${path}.properties.${prop}`;
+      if (
+        objectProperties[prop].type === 'string' &&
+        objectProperties[prop].format === 'binary'
+      ) {
+        objectPathsToOctetSequence.push(propPath);
+      } else if (
+        objectProperties[prop].type === 'object' ||
+        objectProperties[prop].type === 'array'
+      ) {
+        objectPathsToOctetSequence.push(
+          ...findOctetSequencePaths(objectProperties[prop], propPath)
+        );
+      }
+    });
+  }
+  return objectPathsToOctetSequence;
+}
+
+module.exports.findOctetSequencePaths = findOctetSequencePaths;

--- a/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
@@ -181,7 +181,7 @@ function formatValid(obj, isOAS3) {
       return (
         !schema.format ||
         includes(
-          ['byte', 'binary', 'date', 'date-time', 'password'],
+          ['byte', 'date', 'date-time', 'password'],
           schema.format.toLowerCase()
         )
       );

--- a/src/plugins/validation/oas3/semantic-validators/parameters.js
+++ b/src/plugins/validation/oas3/semantic-validators/parameters.js
@@ -7,13 +7,20 @@
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject
 
+// Assertation 3:
+// A paramater should not use schema type: string, format: binary because there is now well-
+// defined way to encode an octet sequence in a URL.
+
 const { isParameterObject, walk } = require('../../../utils');
+const findOctetSequencePaths = require('../../../utils/findOctetSequencePaths')
+  .findOctetSequencePaths;
 
 module.exports.validate = function({ jsSpec }, config) {
   const result = {};
   result.error = [];
   result.warning = [];
 
+  const configSchemas = config.schemas;
   config = config.parameters;
 
   walk(jsSpec, [], function(obj, path) {
@@ -63,6 +70,40 @@ module.exports.validate = function({ jsSpec }, config) {
             path,
             message:
               'Parameters MUST NOT have both a `schema` and `content` property.'
+          });
+        }
+      }
+
+      const binaryStringStatus = configSchemas.json_or_param_binary_string;
+      if (binaryStringStatus !== 'off') {
+        const octetSequencePaths = [];
+        octetSequencePaths.push(
+          ...findOctetSequencePaths(obj.schema, path.concat(['schema']))
+        );
+        if (obj.content) {
+          Object.keys(obj.content).forEach(function(mimeType) {
+            if (mimeType === 'application/json') {
+              const paramContentPath = path.concat([
+                'content',
+                mimeType,
+                'schema'
+              ]);
+              octetSequencePaths.push(
+                ...findOctetSequencePaths(
+                  obj.content[mimeType].schema,
+                  paramContentPath
+                )
+              );
+            }
+          });
+        }
+
+        for (const p of octetSequencePaths) {
+          const message =
+            'Parameters should not contain binary (type: string, format: binary) values.';
+          result[binaryStringStatus].push({
+            path: p,
+            message
           });
         }
       }

--- a/test/plugins/validation/2and3/parameters-ibm.js
+++ b/test/plugins/validation/2and3/parameters-ibm.js
@@ -594,7 +594,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                 in: 'query',
                 schema: {
                   type: 'string',
-                  format: 'binary'
+                  format: 'byte'
                 }
               }
             ]

--- a/test/plugins/validation/oas3/responses.js
+++ b/test/plugins/validation/oas3/responses.js
@@ -5,16 +5,273 @@ const {
   validate
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/responses');
 
+const config = require('../../../../src/.defaultsForValidator').defaults.oas3;
+
 describe('validation plugin - semantic - responses - oas3', function() {
-  it('should complain when response object only has a default', function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
+  it('should not complain for valid use of type:string, format: binary', function() {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              '200': {
+                description: '200 response',
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'string',
+                      format: 'binary'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     };
 
+    const res = validate({ resolvedSpec: spec }, config);
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should complain when response body uses json and schema type: string, format: binary', function() {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              '200': {
+                description: '200 response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                        format: 'binary'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec }, config);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      '200',
+      'content',
+      'application/json',
+      'schema',
+      'items'
+    ]);
+    expect(res.warnings[0].message).toEqual(
+      'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
+    );
+  });
+
+  it('should complain when default response body uses json as second mime type and uses schema type: string, format: binary', function() {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              default: {
+                description: 'the default response',
+                content: {
+                  'text/plain': {
+                    schema: {
+                      type: 'string'
+                    }
+                  },
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        prop1: {
+                          type: 'string',
+                          format: 'binary'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec }, config);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      'default',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1'
+    ]);
+    expect(res.warnings[0].message).toEqual(
+      'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
+    );
+  });
+
+  it('should complain multiple times when multiple json response bodies use type: string, format: binary', function() {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              '200': {
+                description: '200 response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                        format: 'binary'
+                      }
+                    }
+                  }
+                }
+              },
+              '201': {
+                description: '201 response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        prop1: {
+                          type: 'string',
+                          format: 'binary'
+                        },
+                        prop2: {
+                          type: 'array',
+                          items: {
+                            type: 'string',
+                            format: 'binary'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              '204': {
+                description: '204 response'
+              },
+              default: {
+                description: 'the default response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        prop1: {
+                          type: 'string',
+                          format: 'binary'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec }, config);
+    expect(res.warnings.length).toEqual(4);
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      '200',
+      'content',
+      'application/json',
+      'schema',
+      'items'
+    ]);
+    expect(res.warnings[0].message).toEqual(
+      'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
+    );
+    expect(res.warnings[1].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      '201',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1'
+    ]);
+    expect(res.warnings[1].message).toEqual(
+      'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
+    );
+    expect(res.warnings[2].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      '201',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop2',
+      'items'
+    ]);
+    expect(res.warnings[2].message).toEqual(
+      'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
+    );
+    expect(res.warnings[3].path).toEqual([
+      'paths',
+      '/pets',
+      'get',
+      'responses',
+      'default',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1'
+    ]);
+    expect(res.warnings[3].message).toEqual(
+      'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
+    );
+  });
+
+  it('should complain when response object only has a default', function() {
     const spec = {
       paths: {
         '/pets': {
@@ -41,14 +298,6 @@ describe('validation plugin - semantic - responses - oas3', function() {
   });
 
   it('should complain when no response codes are valid', function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
-      }
-    };
-
     const spec = {
       paths: {
         '/pets': {
@@ -75,14 +324,6 @@ describe('validation plugin - semantic - responses - oas3', function() {
   });
 
   it('should not complain when there are no problems', function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
-      }
-    };
-
     const spec = {
       paths: {
         '/pets': {
@@ -105,14 +346,6 @@ describe('validation plugin - semantic - responses - oas3', function() {
   });
 
   it('should complain when a non-204 success does not have response body', function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
-      }
-    };
-
     const spec = {
       paths: {
         '/example': {
@@ -144,14 +377,6 @@ describe('validation plugin - semantic - responses - oas3', function() {
   });
 
   it('should issue multiple warnings when multiple non-204 successes do not have response bodies', function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
-      }
-    };
-
     const spec = {
       paths: {
         '/example1': {
@@ -217,15 +442,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
   });
 
   it('should not complain when a non-204 success has a ref to a response with content', async function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
-      }
-    };
-
-    const resolvedSpec = {
+    const jsSpec = {
       paths: {
         '/comments': {
           post: {
@@ -255,21 +472,13 @@ describe('validation plugin - semantic - responses - oas3', function() {
       }
     };
 
-    const spec = await resolver.dereference(resolvedSpec);
+    const spec = await resolver.dereference(jsSpec);
 
     const res = validate({ resolvedSpec: spec }, config);
     expect(res.warnings.length).toEqual(0);
   });
 
   it('should complain about having only error responses', function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
-      }
-    };
-
     const spec = {
       paths: {
         '/pets': {
@@ -310,14 +519,6 @@ describe('validation plugin - semantic - responses - oas3', function() {
   });
 
   it('should complain about 204 response that defines a response body', function() {
-    const config = {
-      responses: {
-        no_response_codes: 'error',
-        no_success_response_codes: 'warning',
-        no_response_body: 'warning'
-      }
-    };
-
     const spec = {
       paths: {
         '/pets': {


### PR DESCRIPTION
Changes:
- added a findOctetSequencePaths function to handle the logic of finding schema type: string, format: binary for cases of nested arrays, objects, nested arrays of type object, objects with properties that are nested arrays, and objects with properties that are objects, and the simple case where a schema uses type: string, format: binary directly. This function takes a resolved schema and returns a list of paths to octet sequences (empty list if none found). The function accepts the path both as an array and a string and returns the path in the same format received.
- added logic to handle application/json request bodies that use schema type: string, format: binary
- added logic to handle application/json response bodies of type: string, format: binary
- added logic to handle parameters of type: string, format: binary
- removed 'binary' as a valid format for type: string parameters. parameters of type: string, format: binary will result in "type+format not well-defined" error
- added "json_or_param_binary_string" as to .defaultsForValidator as a warning in the shared.schemas section
- added "json_or_param_binary_string" configuration option to the README.md rules and defaults sections in the schemas section
- changed findOctetSequencePaths to accept the path both as a string and an array.

Refactoring in responses.js:
- moved the check for 204-response with content to be part of the other success code checks
- added a function to get all response codes, all status codes, and all success codes

Tests:
- added tests to ensure warnings are issued for request bodies, response bodies, and parameters with schema, type: string, format: binary
- added complex tests to exercise combinations of nested arrays and objects that contain schema type: string, format: binary (complex tests done on response bodies)