### PR TITLE
feat: flag definitions that are defined but never used

### DIFF
--- a/test/plugins/validation/2and3/refs.js
+++ b/test/plugins/validation/2and3/refs.js
@@ -43,7 +43,7 @@ describe('validation plugin - semantic - refs', function() {
       );
     });
 
-    it('should warn about an unused definition - OpenAPI 3', function() {
+    it('should warn about an unused schema definition - OpenAPI 3', function() {
       const jsSpec = {
         paths: {
           '/CoolPath/{id}': {
@@ -83,7 +83,7 @@ describe('validation plugin - semantic - refs', function() {
       );
     });
 
-    it('should not warn about a used definition - OpenAPI 3', function() {
+    it('should not warn about a used schema definition - OpenAPI 3', function() {
       const jsSpec = {
         paths: {
           '/CoolPath/{id}': {
@@ -123,5 +123,171 @@ describe('validation plugin - semantic - refs', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings.length).toEqual(0);
     });
+  });
+
+  it('should warn about an unused parameter definition - OpenAPI 3', function() {
+    const jsSpec = {
+      paths: {
+        '/CoolPath/{id}': {
+          parameters: [
+            {
+              $ref: '#/components/parameters/one_parameter_definition'
+            }
+          ]
+        }
+      },
+      components: {
+        parameters: {
+          one_parameter_definition: {
+            name: 'id',
+            in: 'path',
+            description: 'An id'
+          },
+          other_parameter_definition: {
+            name: 'other',
+            in: 'query',
+            description: 'another param'
+          }
+        }
+      }
+    };
+
+    const specStr = JSON.stringify(jsSpec, null, 2);
+    const isOAS3 = true;
+
+    const res = validate({ jsSpec, specStr, isOAS3 });
+    expect(res.warnings[0].path).toEqual(
+      'components.parameters.other_parameter_definition'
+    );
+    expect(res.warnings[0].message).toEqual(
+      'Definition was declared but never used in document'
+    );
+    expect(res.warnings.length).toEqual(1);
+  });
+
+  it('should not warn about used parameter definitions - OpenAPI 3', function() {
+    const jsSpec = {
+      paths: {
+        '/CoolPath/{id}': {
+          parameters: [
+            {
+              $ref: '#/components/parameters/one_parameter_definition'
+            },
+            {
+              $ref: '#/components/parameters/other_parameter_definition'
+            }
+          ]
+        }
+      },
+      components: {
+        parameters: {
+          one_parameter_definition: {
+            name: 'id',
+            in: 'path',
+            description: 'An id'
+          },
+          other_parameter_definition: {
+            name: 'other',
+            in: 'query',
+            description: 'another param'
+          }
+        }
+      }
+    };
+
+    const specStr = JSON.stringify(jsSpec, null, 2);
+    const isOAS3 = true;
+
+    const res = validate({ jsSpec, specStr, isOAS3 });
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should warn about an unused response definition - OpenAPI 3', function() {
+    const jsSpec = {
+      paths: {
+        '/CoolPath/{id}': {
+          responses: {
+            '200': {
+              description: '200 response',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string'
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: {
+        responses: {
+          response400: {
+            description: '400 response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const specStr = JSON.stringify(jsSpec, null, 2);
+    const isOAS3 = true;
+
+    const res = validate({ jsSpec, specStr, isOAS3 });
+    expect(res.warnings[0].path).toEqual('components.responses.response400');
+    expect(res.warnings[0].message).toEqual(
+      'Definition was declared but never used in document'
+    );
+    expect(res.warnings.length).toEqual(1);
+  });
+
+  it('should not warn about a used response definition - OpenAPI 3', function() {
+    const jsSpec = {
+      paths: {
+        '/CoolPath/{id}': {
+          responses: {
+            '200': {
+              description: '200 response',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string'
+                  }
+                }
+              }
+            },
+            '400': {
+              $ref: '#/components/responses/response400'
+            }
+          }
+        }
+      },
+      components: {
+        responses: {
+          response400: {
+            description: '400 response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const specStr = JSON.stringify(jsSpec, null, 2);
+    const isOAS3 = true;
+
+    const res = validate({ jsSpec, specStr, isOAS3 });
+    expect(res.warnings.length).toEqual(0);
   });
 });


### PR DESCRIPTION
Changes:
- added checks for parameters, responses, and other definitions in the components section that are not used in the API definition
- updated comments in refs.js
- restructured refs.js as needed to support checking components.parameters and components.responses

Tests:
- added tests to that ensure that a warning is issued when a response or parameter definition is not used
- added tests to ensure a warning is not issued when a response or parameter definition is used