### PR TITLE
feat: list valid types and formats in error messages

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
@@ -8,8 +8,6 @@
 // Header parameters must not define a content-type or an accept-type.
 // http://watson-developer-cloud.github.io/api-guidelines/swagger-coding-style#do-not-explicitly-define-a-content-type-header-parameter
 
-const pick = require('lodash/pick');
-const includes = require('lodash/includes');
 const { checkCase, isParameterObject, walk } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
@@ -107,18 +105,6 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
         }
       }
 
-      const checkStatus = config.invalid_type_format_pair;
-      if (checkStatus !== 'off') {
-        const valid = formatValid(obj, isOAS3);
-        if (!valid) {
-          messages.addMessage(
-            path,
-            'Parameter type+format is not well-defined.',
-            checkStatus
-          );
-        }
-      }
-
       const isParameterRequired = obj.required;
       let isDefaultDefined;
       if (isOAS3) {
@@ -139,46 +125,3 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
 
   return messages;
 };
-
-function formatValid(obj, isOAS3) {
-  // References will be checked when the parameters / definitions / components are scanned.
-  if (obj.$ref || (obj.schema && obj.schema.$ref)) {
-    return true;
-  }
-  const schema = obj.schema || pick(obj, ['type', 'format', 'items']);
-  if (!schema.type) {
-    return false;
-  }
-  switch (schema.type) {
-    case 'integer':
-      return (
-        !schema.format ||
-        includes(['int32', 'int64'], schema.format.toLowerCase())
-      );
-    case 'number':
-      return (
-        !schema.format ||
-        includes(['float', 'double'], schema.format.toLowerCase())
-      );
-    case 'string':
-      return (
-        !schema.format ||
-        includes(
-          ['byte', 'date', 'date-time', 'password'],
-          schema.format.toLowerCase()
-        )
-      );
-    case 'boolean':
-      return schema.format === undefined; // No valid formats for boolean -- should be omitted
-    case 'array':
-      if (!schema.items) {
-        return false;
-      }
-      return formatValid(schema.items);
-    case 'object':
-      return true; // TODO: validate nested schemas
-    case 'file':
-      return !isOAS3 && obj.in === 'formData';
-  }
-  return false;
-}

--- a/test/plugins/validation/2and3/parameters-ibm.js
+++ b/test/plugins/validation/2and3/parameters-ibm.js
@@ -119,40 +119,6 @@ describe('validation plugin - semantic - parameters-ibm', () => {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should return an error when type does not match format', () => {
-      const spec = {
-        paths: {
-          '/pets': {
-            get: {
-              parameters: [
-                {
-                  name: 'good_name',
-                  in: 'query',
-                  description: 'This is a good description.',
-                  type: 'number',
-                  format: 'int32'
-                }
-              ]
-            }
-          }
-        }
-      };
-
-      const res = validate({ jsSpec: spec }, config);
-      expect(res.errors.length).toEqual(1);
-      expect(res.errors[0].path).toEqual([
-        'paths',
-        '/pets',
-        'get',
-        'parameters',
-        '0'
-      ]);
-      expect(res.errors[0].message).toEqual(
-        'Parameter type+format is not well-defined.'
-      );
-      expect(res.warnings.length).toEqual(0);
-    });
-
     it('should not validate within extensions', () => {
       const spec = {
         paths: {
@@ -484,42 +450,6 @@ describe('validation plugin - semantic - parameters-ibm', () => {
       expect(res.errors[0].message).toEqual(
         'Parameter objects must have a `description` field.'
       );
-    });
-
-    it('should return an error when parameter type+format is not well-defined', () => {
-      const spec = {
-        paths: {
-          '/pets': {
-            get: {
-              parameters: [
-                {
-                  name: 'good_name',
-                  in: 'query',
-                  description: 'This is a good description.',
-                  schema: {
-                    type: 'number',
-                    format: 'int32'
-                  }
-                }
-              ]
-            }
-          }
-        }
-      };
-
-      const res = validate({ jsSpec: spec, isOAS3: true }, config);
-      expect(res.errors.length).toEqual(1);
-      expect(res.errors[0].path).toEqual([
-        'paths',
-        '/pets',
-        'get',
-        'parameters',
-        '0'
-      ]);
-      expect(res.errors[0].message).toEqual(
-        'Parameter type+format is not well-defined.'
-      );
-      expect(res.warnings.length).toEqual(0);
     });
 
     it('should flag a required parameter that specifies a default value', () => {


### PR DESCRIPTION
Changes:
- changed function name formatValid to typeFormatErrors
- passed additional arguments (messages and checkStatus) to be able to record errors within the function
- negated the boolean conditions used to determine if the type+format is valid and (instead of using the boolean logic to return the validity of the schema) used the negated logic to record errors
- added descriptive messages to help resolve the type+format errors
- removed the duplicate type+format validation function in parameters-ibm.js
- added parameters to the list of schemas to validate
- moved validation for swagger2 file parameters into 'file' section of typeFormatErrors. I believe this is the only validation that was done in parameters-ibm that is not handled by typeFormatErrors.

Tests:
- added a test to ensure file params without in: formData produces an error
- added a negative test to ensure no error produced file params that use in: form data
- added tests to ensure an error produced when a format paired with type: array or type: object
- added negative test to ensure no error produced when object properties and array items use valid type, format pairs
- added test to ensure an error produced when schema defines a format but not a type

Resolves #117 