### PR TITLE
feat: catch inline parameters that appear on multiple operations

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
@@ -8,6 +8,10 @@
 // Header parameters must not define a content-type or an accept-type.
 // http://watson-developer-cloud.github.io/api-guidelines/swagger-coding-style#do-not-explicitly-define-a-content-type-header-parameter
 
+// Assertation 4:
+// Parameters that are defined inline to an operation but appear on multiple operations should be defined
+// in the Parameters section (once) and then referenced from any operation that includes them.
+
 const pick = require('lodash/pick');
 const includes = require('lodash/includes');
 const { checkCase, isParameterObject, walk } = require('../../../utils');
@@ -15,6 +19,8 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 
 module.exports.validate = function({ jsSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
+
+  const parameterNames = [];
 
   config = config.parameters;
 
@@ -134,6 +140,10 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
           config.required_param_has_default
         );
       }
+
+      if (isOAS3) {
+        checkInlineParameters(obj, isRef, parameterNames, messages, path);
+      }
     }
   });
 
@@ -181,4 +191,18 @@ function formatValid(obj, isOAS3) {
       return !isOAS3 && obj.in === 'formData';
   }
   return false;
+}
+
+function checkInlineParameters(obj, isRef, parameterNames, messages, path) {
+  if (!isRef) {
+    if (!parameterNames.includes(obj.name)) {
+      parameterNames.push(obj.name);
+    } else {
+      messages.addMessage(
+        path,
+        'Inline parameters that appear on multiple operations should be defined in the Parameters section and then referenced.',
+        'warning'
+      );
+    }
+  }
 }

--- a/test/cli-validator/mockFiles/inlineParameters.json
+++ b/test/cli-validator/mockFiles/inlineParameters.json
@@ -1,0 +1,135 @@
+ {
+    "openapi":"3.0.0",
+    "info":{
+        "version":"1.0.0",
+        "title":"Duplicate properties",
+        "description":"This is a type related to duplicate keys",
+        "x-alternate-name":"DuplicateProperties",
+        "x-codegen-config" : {
+            "java": {
+                "apiPackage": "com.ibm.watson"
+            }
+        }
+    },
+    "paths":{
+	"/person":{
+	    "get":{
+                "operationId":"list_person",
+                "summary":"Retrieve a Person",
+                "description":"Retrieve a person",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "description": "ID parameter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"Successful request.",
+                        "content":{
+                            "application/json":{
+                                "schema":{
+                                    "$ref":"#/components/schemas/person"
+                                },
+                                "examples":{
+                                    "response":{
+                                        "value":{
+                                            "text":"Howdy!"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Uh oh."
+                    }
+                }
+            }
+	},
+	"/kid":{
+	    "get":{
+                "operationId":"list_kid",
+                "summary":"Retrieve a kid",
+                "description":"Retrieve a kid",
+                 "parameters": [
+                    {
+                        "$ref": "#/components/parameters/Id"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"Successful request.",
+                        "content":{
+                            "application/json":{
+                                "schema":{
+                                    "$ref":"#/components/schemas/kid"
+                                },
+                                "examples":{
+                                    "response":{
+                                        "value":{
+                                            "text":"Howdy!"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400":{
+                         "description":"Uh oh."
+                    }
+                }
+            }
+	}
+    },
+     "components":{
+        "parameters": {
+            "Id": {
+                "name": "id",
+                "in": "query",
+                "description": "The ID associated with invoking the request.",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            }
+        },
+        "schemas":{
+            "person":{
+		"description" : "Person's info",
+                "properties":{
+		    "name":{
+			"description": "Person's name",
+			"type": "string"
+		    },
+		    "age": {
+			"description": "Person's age",
+			"type": "number",
+			"minimum": 18,
+			"maximum": 64
+		    }
+                }
+            },
+	    "kid":{
+		"description" : "Kid's info",
+                "properties":{
+		    "name":{
+			"type": "string",
+                        "description": "Kid's name"
+ 		    },
+		    "age": {
+			"description": "Kid's age",
+			"type": "number",
+			"minimum": 18,
+			"maximum": 64
+		    }  
+                }
+		
+	    }
+        }
+    }
+}


### PR DESCRIPTION
To encourage "DRY" style in API documents, check for inline parameters that appear on multiple operations. Such parameters should be defined in the Parameters section and then referenced from any operation that includes them.

Change:

- added a function to parameters-ibm.js to find inline parameter that appear on multiple operations.
- added an API definition and a test to exercise the new behavior