### PR TITLE
fix: config option for operationId naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The supported rules are described below:
 | no_summary                   | Flag any operations that do not have a `summary` field.                             | shared   |
 | no_array_responses           | Flag any operations with a top-level array response.                                | shared   |
 | parameter_order              | Flag any operations with optional parameters before a required param.               | shared   |
+| operation_id_naming_convention | Flag any `operationId` that does not follow consistent naming convention.         | shared   |
 | no_request_body_content      | [Flag any operations with a `requestBody` that does not have a `content` field.][3] | oas3     |
 | no_request_body_name         | Flag any operations with a non-form `requestBody` that does not have a name set with `x-codegen-request-body-name`. | oas3|
 
@@ -379,6 +380,7 @@ The default values for each rule are described below.
 | no_summary                   | warning |
 | no_array_responses           | error   |
 | parameter_order              | warning |
+| operation_id_naming_convention | warning |
 
 ###### pagination
 | Rule                        | Default |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -26,7 +26,8 @@ const defaults = {
       'no_summary': 'warning',
       'no_array_responses': 'error',
       'parameter_order': 'warning',
-      'unused_tag': 'warning'
+      'unused_tag': 'warning',
+      'operation_id_naming_convention': 'warning'
     },
     'pagination': {
       'pagination_style': 'warning'

--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -8,8 +8,10 @@ const merge = require('lodash/merge');
 const each = require('lodash/each');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }) {
+module.exports.validate = function({ resolvedSpec }, config) {
   const messages = new MessageCarrier();
+
+  config = config.operations;
 
   const validOperationKeys = [
     'get',
@@ -160,7 +162,7 @@ module.exports.validate = function({ resolvedSpec }) {
               ',',
               ' or '
             ),
-            'warning'
+            config.operation_id_naming_convention
           );
         }
       }

--- a/test/plugins/validation/2and3/operation-ids.js
+++ b/test/plugins/validation/2and3/operation-ids.js
@@ -3,6 +3,7 @@ const resolver = require('json-schema-ref-parser');
 const {
   validate
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/operation-ids');
+const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
 describe('validation plugin - semantic - operation-ids', function() {
   it('should complain about a repeated operationId in the same path', function() {
@@ -21,7 +22,7 @@ describe('validation plugin - semantic - operation-ids', function() {
       }
     };
 
-    const res = validate({ resolvedSpec: spec });
+    const res = validate({ resolvedSpec: spec }, config);
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./coolPath.get.operationId');
     expect(res.errors[0].message).toEqual('operationIds must be unique');
@@ -50,7 +51,7 @@ describe('validation plugin - semantic - operation-ids', function() {
       }
     };
 
-    const res = validate({ resolvedSpec: spec });
+    const res = validate({ resolvedSpec: spec }, config);
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./greatPath.put.operationId');
     expect(res.errors[0].message).toEqual('operationIds must be unique');
@@ -91,7 +92,7 @@ describe('validation plugin - semantic - operation-ids', function() {
 
     const resolvedSpec = await resolver.dereference(spec);
 
-    const res = validate({ resolvedSpec });
+    const res = validate({ resolvedSpec }, config);
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./greatPath.get.operationId');
     expect(res.errors[0].message).toEqual('operationIds must be unique');
@@ -164,7 +165,7 @@ describe('validation plugin - semantic - operation-ids', function() {
     };
 
     const resolvedSpec = await resolver.dereference(spec);
-    const res = validate({ resolvedSpec });
+    const res = validate({ resolvedSpec }, config);
 
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(12);
@@ -243,7 +244,7 @@ describe('validation plugin - semantic - operation-ids', function() {
     };
 
     const resolvedSpec = await resolver.dereference(spec);
-    const res = validate({ resolvedSpec });
+    const res = validate({ resolvedSpec }, config);
 
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);


### PR DESCRIPTION
Naming conventions for operationId should be configurable. 

Change:
- added config option to README.md and .defaultsForValidator.js
- added config logic to operation-ids.js 
- added a test case to exercise the new behavior

Related: [Issue 148](https://github.com/IBM/openapi-validator/issues/148)