### PR TITLE
fix: Fix crashes found on real API docs

### DIFF
--- a/src/cli-validator/utils/circular-references-ibm.js
+++ b/src/cli-validator/utils/circular-references-ibm.js
@@ -72,25 +72,29 @@ const convertPaths = function(jsSpec, resolvedPaths) {
       //  (i.e. "definitions.QueryAggregation")
       // instead of the path to where the circular reference occurs
       const lastKey = i === path.length - 1;
-      if (current.$ref && !lastKey) {
-        // locationArray holds the keys to the references object in the spec
-        const locationArray = current.$ref
-          .split('/')
-          .filter(refKey => refKey !== '#');
-        // since we are following a ref to the first object level,
-        // realPath needs to be reset
-        realPath = [...locationArray];
+      if (!lastKey) {
+        const nextKey = path[i + 1];
+        // Only follow $ref if the next key is not present
+        if (!current[nextKey] && current.$ref) {
+          // locationArray holds the keys to the references object in the spec
+          const locationArray = current.$ref
+            .split('/')
+            .filter(refKey => refKey !== '#');
+          // since we are following a ref to the first object level,
+          // realPath needs to be reset
+          realPath = [...locationArray];
 
-        // to follow the keys to the ref object we need to start looking in,
-        // a mini-version of the parent loop is necessary
-        let refPrevious = jsSpec;
-        for (const refKey of locationArray) {
-          const refCurrent = refPrevious[refKey];
-          refPrevious = refCurrent;
+          // to follow the keys to the ref object we need to start looking in,
+          // a mini-version of the parent loop is necessary
+          let refPrevious = jsSpec;
+          for (const refKey of locationArray) {
+            const refCurrent = refPrevious[refKey];
+            refPrevious = refCurrent;
+          }
+          // set the parent current object to the object found at the
+          // referenced path to continue using the keys in the parent loop
+          current = refPrevious;
         }
-        // set the parent current object to the object found at the
-        // referenced path to continue using the keys in the parent loop
-        current = refPrevious;
       }
 
       previous = current;

--- a/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
@@ -93,7 +93,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
           if (checkStatus != 'off') {
             missingParameters.forEach(name => {
               messages.addMessage(
-                `paths.${pathName}.${opName}.parameters`,
+                ['paths', pathName, opName, 'parameters'],
                 `Operation must include a path parameter with name: ${name}.`,
                 checkStatus
               );
@@ -116,7 +116,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
           if (checkStatus != 'off') {
             missingParameters.forEach(name => {
               messages.addMessage(
-                `paths.${pathName}`,
+                ['paths', pathName],
                 `Path parameter must be defined at the path or the operation level: ${name}.`,
                 checkStatus
               );
@@ -150,7 +150,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
                   p => p.name === parameter
                 );
                 messages.addMessage(
-                  `paths.${pathName}.${op}.parameters.${index}`,
+                  ['paths', pathName, op, 'parameters', `${index}`],
                   'Common path parameters should be defined on path object',
                   checkStatus
                 );
@@ -173,7 +173,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         }
         if (!checkCase(segment, 'lower_snake_case')) {
           messages.addMessage(
-            `paths.${pathName}`,
+            ['paths', pathName],
             `Path segments must be lower snake case.`,
             checkStatus
           );
@@ -197,7 +197,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
             const isCorrectCase = checkCase(segment, caseConvention);
             if (!isCorrectCase) {
               messages.addMessage(
-                `paths.${pathName}`,
+                ['paths', pathName],
                 `Path segments must follow case convention: ${caseConvention}`,
                 checkStatusPath
               );

--- a/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
@@ -41,7 +41,7 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
             }
           });
         }
-      } else {
+      } else if (scheme.scopes) {
         Object.keys(scheme.scopes).forEach(scope => {
           definedScopes[scope] = {};
           definedScopes[scope].used = false;

--- a/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
@@ -35,6 +35,7 @@ module.exports.validate = function({ jsSpec, resolvedSpec }, config) {
       if (obj.$ref) {
         const referencedSchema = at(resolvedSpec, [path])[0];
         if (
+          referencedSchema &&
           referencedSchema.description &&
           referencedSchema.description === description
         ) {

--- a/src/plugins/validation/2and3/semantic-validators/walker.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker.js
@@ -85,7 +85,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
     }
 
     ///// Restricted $refs -- only check internal refs
-    if (obj.$ref && obj.$ref.startsWith('#')) {
+    if (obj.$ref && typeof obj.$ref === 'string' && obj.$ref.startsWith('#')) {
       const blacklistPayload = getRefPatternBlacklist(path, isOAS3);
       const refBlacklist = blacklistPayload.blacklist || [];
       const matches = match([obj.$ref], refBlacklist);

--- a/test/plugins/validation/2and3/paths-ibm.js
+++ b/test/plugins/validation/2and3/paths-ibm.js
@@ -56,19 +56,30 @@ describe('validation plugin - semantic - paths-ibm', function() {
     const res = validate({ resolvedSpec: spec }, config);
     expect(res.errors.length).toEqual(3);
     expect(res.warnings.length).toEqual(0);
-    expect(res.errors[0].path).toEqual('paths./cool_path/{id}.post.parameters');
+    expect(res.errors[0].path).toEqual([
+      'paths',
+      '/cool_path/{id}',
+      'post',
+      'parameters'
+    ]);
     expect(res.errors[0].message).toEqual(
       'Operation must include a path parameter with name: id.'
     );
-    expect(res.errors[1].path).toEqual(
-      'paths./bogus/{id}/foo/{foo}/bar.post.parameters'
-    );
+    expect(res.errors[1].path).toEqual([
+      'paths',
+      '/bogus/{id}/foo/{foo}/bar',
+      'post',
+      'parameters'
+    ]);
     expect(res.errors[1].message).toEqual(
       'Operation must include a path parameter with name: id.'
     );
-    expect(res.errors[2].path).toEqual(
-      'paths./bogus/{id}/foo/{foo}/bar.post.parameters'
-    );
+    expect(res.errors[2].path).toEqual([
+      'paths',
+      '/bogus/{id}/foo/{foo}/bar',
+      'post',
+      'parameters'
+    ]);
     expect(res.errors[2].message).toEqual(
       'Operation must include a path parameter with name: foo.'
     );
@@ -232,7 +243,7 @@ describe('validation plugin - semantic - paths-ibm', function() {
       {
         message:
           'Path parameter must be defined at the path or the operation level: id.',
-        path: 'paths./cool_path/{id}'
+        path: ['paths', '/cool_path/{id}']
       }
     ]);
     expect(res.warnings).toEqual([]);
@@ -265,7 +276,7 @@ describe('validation plugin - semantic - paths-ibm', function() {
       {
         message:
           'Path parameter must be defined at the path or the operation level: id.',
-        path: 'paths./cool_path/{id}/more_path/{other_param}'
+        path: ['paths', '/cool_path/{id}/more_path/{other_param}']
       }
     ]);
     expect(res.warnings).toEqual([]);
@@ -297,9 +308,10 @@ describe('validation plugin - semantic - paths-ibm', function() {
     const res = validate({ resolvedSpec: spec }, config);
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(1);
-    expect(res.warnings[0].path).toEqual(
-      'paths./v1/api/NotGoodSegment/{shouldntMatter}/resource'
-    );
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/v1/api/NotGoodSegment/{shouldntMatter}/resource'
+    ]);
     expect(res.warnings[0].message).toEqual(
       'Path segments must be lower snake case.'
     );
@@ -331,9 +343,10 @@ describe('validation plugin - semantic - paths-ibm', function() {
     const res = validate({ resolvedSpec: spec }, config);
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(1);
-    expect(res.warnings[0].path).toEqual(
-      'paths./v1/api/not.good_.segment/{id}/resource'
-    );
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/v1/api/not.good_.segment/{id}/resource'
+    ]);
     expect(res.warnings[0].message).toEqual(
       'Path segments must follow case convention: lower_snake_case'
     );
@@ -366,9 +379,10 @@ describe('validation plugin - semantic - paths-ibm', function() {
     const res = validate({ resolvedSpec: badSpec }, config);
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(1);
-    expect(res.warnings[0].path).toEqual(
-      'paths./v1/api/NotGoodSegment/{shouldntMatter}/resource'
-    );
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/v1/api/NotGoodSegment/{shouldntMatter}/resource'
+    ]);
     expect(res.warnings[0].message).toEqual(
       'Path segments must follow case convention: lower_camel_case'
     );
@@ -444,15 +458,23 @@ describe('validation plugin - semantic - paths-ibm', function() {
     const res = validate({ resolvedSpec: badSpec }, config);
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(2);
-    expect(res.warnings[0].path).toEqual(
-      'paths./v1/api/resources/{id}.get.parameters.0'
-    );
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/v1/api/resources/{id}',
+      'get',
+      'parameters',
+      '0'
+    ]);
     expect(res.warnings[0].message).toEqual(
       'Common path parameters should be defined on path object'
     );
-    expect(res.warnings[1].path).toEqual(
-      'paths./v1/api/resources/{id}.post.parameters.0'
-    );
+    expect(res.warnings[1].path).toEqual([
+      'paths',
+      '/v1/api/resources/{id}',
+      'post',
+      'parameters',
+      '0'
+    ]);
     expect(res.warnings[1].message).toEqual(
       'Common path parameters should be defined on path object'
     );

--- a/test/plugins/validation/2and3/security-definitions-ibm.js
+++ b/test/plugins/validation/2and3/security-definitions-ibm.js
@@ -119,6 +119,35 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
       expect(res.errors.length).toEqual(0);
       expect(res.warnings.length).toEqual(0);
     });
+
+    it('should gracefully handle Oauth security definition with no scopes', function() {
+      const spec = {
+        securityDefinitions: {
+          OauthSecurity: {
+            type: 'oauth2',
+            flow: 'implicit',
+            authorizationUrl: '/auth/v1/login'
+          }
+        },
+        security: [
+          {
+            OauthSecurity: []
+          }
+        ],
+        paths: {
+          '/pcloud/v1/images': {
+            get: {
+              operationId: 'pcloud.images.getall',
+              summary: 'List all available stock images'
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec }, config);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings.length).toEqual(0);
+    });
   });
 
   describe('OpenAPI 3', function() {

--- a/test/plugins/validation/2and3/walker.js
+++ b/test/plugins/validation/2and3/walker.js
@@ -134,6 +134,35 @@ describe('validation plugin - semantic - spec walker', () => {
     });
   });
 
+  describe('$ref as property name', () => {
+    it('should gracefully handle a property named $ref', function() {
+      const spec = {
+        definitions: {
+          JSONSchemaProps: {
+            description: 'A JSON-Schema following Specification Draft 4.',
+            properties: {
+              $ref: {
+                type: 'string'
+              },
+              maximum: {
+                type: 'integer',
+                format: 'int64'
+              },
+              minimum: {
+                type: 'integer',
+                format: 'int64'
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ jsSpec: spec, isOAS3: true }, config);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings.length).toEqual(0);
+    });
+  });
+
   describe('Minimums and maximums', () => {
     it('should return an error when minimum is more than maximum', () => {
       const spec = {


### PR DESCRIPTION
This PR fixes a few crashes I encountered when running the validator against the OpenShift API doc and an API doc for the Power IaaS service.

One problem was caused by a schema with a property named "$ref", which the validator mistook for an actual "$ref" in a couple of places.

Another problem was the way paths were represented as strings for messages in `paths-ibm.js`. The problem is that OpenShift uses periods in some of its path segments, so the line number resolution was failing for any problems reported on one of these paths.  Switching to representing the paths as an array of path elements fixes that problem.

Then there was a crash attempting to reference `scopes` within an "oauth2" security definition when it was not present.  In fairness, `scopes` is required when `type` is "oauth2", but it's still not acceptable to crash when the API doc doesn't comply.

I've added tests that reproduce these problems in the first commit, followed by the fixes.