### PR TITLE
feat: adds a default warning for 422 and 302 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ The supported rules are described below:
 | no_response_codes         | Flag any response object that has no valid response codes.   | oas3 |
 | no_success_response_codes | Flag any response object that has no success response codes. | oas3 |
 | no_response_body          | Flag any non-204 success responses without a response body.  | oas3 |
+| ibm_status_code_guidelines| Flag any violations of status code conventions per IBM API Handbook  | oas3 |
 
 ##### schemas
 | Rule                        | Description                                                                   | Spec     |
@@ -373,6 +374,7 @@ The default values for each rule are described below.
 | no_response_codes         | error   |
 | no_success_response_codes | warning |
 | no_response_body          | warning |
+| ibm_status_code_guidelines| warning |
 
 ##### schemas
 

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -97,7 +97,8 @@ const defaults = {
     'responses': {
       'no_response_codes': 'error',
       'no_success_response_codes': 'warning',
-      'no_response_body': 'warning'
+      'no_response_body': 'warning',
+      'ibm_status_code_guidelines': 'warning'
     },
     'schemas': {
       'json_or_param_binary_string': 'warning'

--- a/src/plugins/validation/oas3/semantic-validators/responses.js
+++ b/src/plugins/validation/oas3/semantic-validators/responses.js
@@ -49,27 +49,45 @@ module.exports.validate = function({ resolvedSpec }, config) {
           'Each `responses` object MUST have at least one response code.',
           config.no_response_codes
         );
-      } else if (!successCodes.length) {
-        messages.addMessage(
-          path,
-          'Each `responses` object SHOULD have at least one code for a successful response.',
-          config.no_success_response_codes
-        );
       } else {
-        // validate success codes
-        for (const successCode of successCodes) {
-          if (successCode !== '204' && !obj[successCode].content) {
+        // default warnings for discouraged status code per IBM API Handbook
+        for (const statusCode of statusCodes) {
+          if (statusCode === '422') {
             messages.addMessage(
-              path.concat([successCode]),
-              `A ${successCode} response should include a response body. Use 204 for responses without content.`,
-              config.no_response_body
+              path.concat(['422']),
+              'Should use status code 400 instead of 422 for invalid request payloads.',
+              config.ibm_status_code_guidelines
             );
-          } else if (successCode === '204' && obj[successCode].content) {
+          } else if (statusCode === '302') {
             messages.addMessage(
-              path.concat(['204', 'content']),
-              `A 204 response MUST NOT include a message-body.`,
-              'error'
+              path.concat(['302']),
+              'Should use status codes 303 or 307 instead of 302.',
+              config.ibm_status_code_guidelines
             );
+          }
+        }
+        // validate all success codes
+        if (!successCodes.length) {
+          messages.addMessage(
+            path,
+            'Each `responses` object SHOULD have at least one code for a successful response.',
+            config.no_success_response_codes
+          );
+        } else {
+          for (const statusCode of successCodes) {
+            if (statusCode !== '204' && !obj[statusCode].content) {
+              messages.addMessage(
+                path.concat([statusCode]),
+                `A ${statusCode} response should include a response body. Use 204 for responses without content.`,
+                config.no_response_body
+              );
+            } else if (statusCode === '204' && obj[statusCode].content) {
+              messages.addMessage(
+                path.concat(['204', 'content']),
+                `A 204 response MUST NOT include a message-body.`,
+                'error'
+              );
+            }
           }
         }
       }

--- a/test/plugins/validation/oas3/responses.js
+++ b/test/plugins/validation/oas3/responses.js
@@ -83,6 +83,76 @@ describe('validation plugin - semantic - responses - oas3', function() {
     );
   });
 
+  it('should complain when 422 response code used', function() {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              '200': {
+                description: '200 response',
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'string',
+                      format: 'binary'
+                    }
+                  }
+                }
+              },
+              '422': {
+                description: '422 response discouraged'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec }, config);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].message).toEqual(
+      'Should use status code 400 instead of 422 for invalid request payloads.'
+    );
+  });
+
+  it('should complain when 302 response code used', function() {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            responses: {
+              '200': {
+                description: '200 response',
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'string',
+                      format: 'binary'
+                    }
+                  }
+                }
+              },
+              '302': {
+                description: '302 response discouraged'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec }, config);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].message).toEqual(
+      'Should use status codes 303 or 307 instead of 302.'
+    );
+  });
+
   it('should complain when default response body uses json as second mime type and uses schema type: string, format: binary', function() {
     const spec = {
       paths: {


### PR DESCRIPTION
Reason:
- IBM Handbook says 400 response should be used instead of 422
- IBM Handbook prefers 303 and 307 responses over 302

Changes:
- added warning for 422 response codes
- added warning for 302 response codes
- added ibm_status_code_guidelines config option with default warning

Tests
- added a test to ensure warning issued for 422 response
- added a test to ensure warning issued for 302 response