### PR TITLE
fix: no inline schema warning for array with items that are refs

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -39,7 +39,11 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                     ) {
                       const hasInlineSchema = !mediaType.schema[schemaType][i]
                         .$ref;
-                      if (hasInlineSchema) {
+                      const arrItemsIsRef =
+                        mediaType.schema[schemaType][i].items &&
+                        mediaType.schema[schemaType][i].items.$ref;
+
+                      if (hasInlineSchema && !arrItemsIsRef) {
                         messages.addMessage(
                           [
                             ...path,
@@ -57,7 +61,10 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                     }
                   }
                 });
-              } else if (!mediaType.schema.$ref) {
+              } else if (
+                !mediaType.schema.$ref &&
+                !(mediaType.schema.items && mediaType.schema.items.$ref)
+              ) {
                 messages.addMessage(
                   [...path, responseKey, 'content', mediaTypeKey, 'schema'],
                   INLINE_SCHEMA_MESSAGE,
@@ -71,7 +78,11 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
           if (responseKey.startsWith('x-')) return;
 
           const hasInlineSchema = response.schema && !response.schema.$ref;
-          if (hasInlineSchema) {
+          const arrItemsIsRef =
+            response.schema &&
+            response.schema.items &&
+            response.schema.items.$ref;
+          if (hasInlineSchema && !arrItemsIsRef) {
             messages.addMessage(
               [...path, responseKey, 'schema'],
               INLINE_SCHEMA_MESSAGE,

--- a/test/cli-validator/tests/expectedOutput.js
+++ b/test/cli-validator/tests/expectedOutput.js
@@ -101,10 +101,9 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(capturedText[33].match(/\S+/g)[2]).toEqual('36');
     expect(capturedText[37].match(/\S+/g)[2]).toEqual('59');
     expect(capturedText[41].match(/\S+/g)[2]).toEqual('197');
-    expect(capturedText[45].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[49].match(/\S+/g)[2]).toEqual('131');
-    expect(capturedText[53].match(/\S+/g)[2]).toEqual('134');
-    expect(capturedText[57].match(/\S+/g)[2]).toEqual('126');
+    expect(capturedText[45].match(/\S+/g)[2]).toEqual('131');
+    expect(capturedText[49].match(/\S+/g)[2]).toEqual('134');
+    expect(capturedText[53].match(/\S+/g)[2]).toEqual('126');
   });
 
   it('should return exit code of 0 if there are only warnings', async function() {

--- a/test/cli-validator/tests/optionHandling.js
+++ b/test/cli-validator/tests/optionHandling.js
@@ -152,7 +152,7 @@ describe('cli tool - test option handling', function() {
 
     // totals
     expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('5');
-    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('9');
+    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('8');
 
     // errors
     expect(capturedText[statsSection + 4].match(/\S+/g)[0]).toEqual('2');
@@ -169,28 +169,25 @@ describe('cli tool - test option handling', function() {
 
     // warnings
     expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(22%)');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(25%)');
 
     expect(capturedText[statsSection + 13].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 14].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 15].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(13%)');
 
     expect(capturedText[statsSection + 16].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 16].match(/\S+/g)[1]).toEqual('(11%)');
-
-    expect(capturedText[statsSection + 17].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 17].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 16].match(/\S+/g)[1]).toEqual('(13%)');
   });
 
   it('should not print statistics report by default', async function() {


### PR DESCRIPTION
Changes:
- in 2and3/response.js, avoid adding a warning for inline schemas if the items field exists and the items use a $ref to a schema

Tests:
- 1 test to ensure warning issued for anyOf schema with an array element with items that use inline schema
- 1 test to ensure no warning for anyOf schema with an array element with items that use ref
- 1 test to ensure no warning for schema with array elements with items that use ref
- 1 test to ensure warning issued swagger2 response with array items that use inline schema
- 1 test to ensure no warning issued for swagger2 response with array items that use ref