### PR TITLE
Rework operationId naming convention checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The supported rules are described below:
 | no_summary                   | Flag any operations that do not have a `summary` field.                             | shared   |
 | no_array_responses           | Flag any operations with a top-level array response.                                | shared   |
 | parameter_order              | Flag any operations with optional parameters before a required param.               | shared   |
-| operation_id_naming_convention | Flag any `operationId` that does not follow consistent naming convention.         | shared   |
+| operation_id_naming_convention | Flag any `operationId` that does not follow naming convention.                    | shared   |
 | no_request_body_content      | [Flag any operations with a `requestBody` that does not have a `content` field.][3] | oas3     |
 | no_request_body_name         | Flag any operations with a non-form `requestBody` that does not have a name set with `x-codegen-request-body-name`. | oas3|
 

--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -158,7 +158,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         if (checkPassed === false) {
           messages.addMessage(
             op.path + '.operationId',
-            `operationIds should follow consistent naming convention. operationId verb should be ${verbs}`.replace(
+            `operationIds should follow naming convention: operationId verb should be ${verbs}`.replace(
               ',',
               ' or '
             ),

--- a/test/cli-validator/tests/expectedOutput.js
+++ b/test/cli-validator/tests/expectedOutput.js
@@ -97,14 +97,12 @@ describe('cli tool - test expected output - Swagger 2', function() {
 
     // warnings
     expect(capturedText[25].match(/\S+/g)[2]).toEqual('36');
-    expect(capturedText[29].match(/\S+/g)[2]).toEqual('87');
-    expect(capturedText[33].match(/\S+/g)[2]).toEqual('36');
-    expect(capturedText[37].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[41].match(/\S+/g)[2]).toEqual('197');
-    expect(capturedText[45].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[49].match(/\S+/g)[2]).toEqual('131');
-    expect(capturedText[53].match(/\S+/g)[2]).toEqual('134');
-    expect(capturedText[57].match(/\S+/g)[2]).toEqual('126');
+    expect(capturedText[29].match(/\S+/g)[2]).toEqual('59');
+    expect(capturedText[33].match(/\S+/g)[2]).toEqual('197');
+    expect(capturedText[37].match(/\S+/g)[2]).toEqual('108');
+    expect(capturedText[41].match(/\S+/g)[2]).toEqual('131');
+    expect(capturedText[45].match(/\S+/g)[2]).toEqual('134');
+    expect(capturedText[49].match(/\S+/g)[2]).toEqual('126');
   });
 
   it('should return exit code of 0 if there are only warnings', async function() {

--- a/test/cli-validator/tests/optionHandling.js
+++ b/test/cli-validator/tests/optionHandling.js
@@ -152,7 +152,7 @@ describe('cli tool - test option handling', function() {
 
     // totals
     expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('5');
-    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('9');
+    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('7');
 
     // errors
     expect(capturedText[statsSection + 4].match(/\S+/g)[0]).toEqual('2');
@@ -168,29 +168,23 @@ describe('cli tool - test option handling', function() {
     expect(capturedText[statsSection + 7].match(/\S+/g)[1]).toEqual('(20%)');
 
     // warnings
-    expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('2');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(29%)');
 
     expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(14%)');
 
-    expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(22%)');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(14%)');
 
     expect(capturedText[statsSection + 13].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(14%)');
 
     expect(capturedText[statsSection + 14].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(14%)');
 
     expect(capturedText[statsSection + 15].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(11%)');
-
-    expect(capturedText[statsSection + 16].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 16].match(/\S+/g)[1]).toEqual('(11%)');
-
-    expect(capturedText[statsSection + 17].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 17].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(14%)');
   });
 
   it('should not print statistics report by default', async function() {
@@ -315,7 +309,7 @@ describe('cli tool - test option handling', function() {
         }
       }
     });
-    expect(warningCount).toEqual(3); // without the config this value is 5
+    expect(warningCount).toEqual(1); // without the config this value is 5
     expect(errorCount).toEqual(3); // without the config this value is 0
   });
 

--- a/test/plugins/validation/2and3/operation-ids.js
+++ b/test/plugins/validation/2and3/operation-ids.js
@@ -171,7 +171,7 @@ describe('validation plugin - semantic - operation-ids', function() {
     expect(res.warnings.length).toEqual(12);
     expect(res.warnings[0].path).toEqual('paths./books.get.operationId');
     expect(res.warnings[0].message).toEqual(
-      'operationIds should follow consistent naming convention. operationId verb should be list'
+      'operationIds should follow naming convention: operationId verb should be list'
     );
   });
 

--- a/test/plugins/validation/2and3/operation-ids.js
+++ b/test/plugins/validation/2and3/operation-ids.js
@@ -26,7 +26,7 @@ describe('validation plugin - semantic - operation-ids', function() {
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./coolPath.get.operationId');
     expect(res.errors[0].message).toEqual('operationIds must be unique');
-    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings.length).toEqual(0);
   });
 
   it('should complain about a repeated operationId in a different path', function() {
@@ -55,7 +55,7 @@ describe('validation plugin - semantic - operation-ids', function() {
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./greatPath.put.operationId');
     expect(res.errors[0].message).toEqual('operationIds must be unique');
-    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings.length).toEqual(0);
   });
 
   it('should complain about a repeated operationId in a shared path item', async function() {
@@ -96,7 +96,7 @@ describe('validation plugin - semantic - operation-ids', function() {
     expect(res.errors.length).toEqual(1);
     expect(res.errors[0].path).toEqual('paths./greatPath.get.operationId');
     expect(res.errors[0].message).toEqual('operationIds must be unique');
-    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings.length).toEqual(0);
   });
 
   it('should complain about operationId naming convention', async function() {


### PR DESCRIPTION
This PR makes two small changes to operationId naming convention validation.  First, it makes a small change to the message generated (replacing a period with a colon) so that all the operationId naming convention errors are summarized together in the summary display. It also restricts the naming convention check to only be applied to "resource-oriented" operations.  This is to prevent false positives on operations such as Watson Language Translator `translate` (`POST` on `/v3/translate`).