### PR TITLE
Operation id allow hyphens

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -73,7 +73,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
 
     if (!pathEndsWithParam) {
       // operationId for GET should starts with "list"
-      if (opKey === 'get' && !operationId.match(/^list[a-zA-Z0-9_\-]+/m)) {
+      if (opKey === 'get' && !operationId.match(/^list[a-zA-Z0-9_-]+/m)) {
         checkPassed = false;
         verbs.push('list');
       }
@@ -81,7 +81,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for POST should starts with "create" or "add"
       else if (
         opKey === 'post' &&
-        !operationId.match(/^(add|create)[a-zA-Z0-9_\-]+/m)
+        !operationId.match(/^(add|create)[a-zA-Z0-9_-]+/m)
       ) {
         checkPassed = false;
         verbs.push('add');
@@ -89,7 +89,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       }
     } else {
       // operationId for GET should starts with "get"
-      if (opKey === 'get' && !operationId.match(/^get[a-zA-Z0-9_\-]+/m)) {
+      if (opKey === 'get' && !operationId.match(/^get[a-zA-Z0-9_-]+/m)) {
         checkPassed = false;
         verbs.push('get');
       }
@@ -97,7 +97,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for DELETE should starts with "delete"
       else if (
         opKey === 'delete' &&
-        !operationId.match(/^delete[a-zA-Z0-9_\-]+/m)
+        !operationId.match(/^delete[a-zA-Z0-9_-]+/m)
       ) {
         checkPassed = false;
         verbs.push('delete');
@@ -106,7 +106,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for PATCH should starts with "update"
       else if (
         opKey === 'patch' &&
-        !operationId.match(/^update[a-zA-Z0-9_\-]+/m)
+        !operationId.match(/^update[a-zA-Z0-9_-]+/m)
       ) {
         checkPassed = false;
         verbs.push('update');
@@ -114,7 +114,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         // If PATCH operation doesn't exist for path, POST operationId should start with "update"
         if (
           !allPathOperations.includes('patch') &&
-          !operationId.match(/^update[a-zA-Z0-9_\-]+/m)
+          !operationId.match(/^update[a-zA-Z0-9_-]+/m)
         ) {
           checkPassed = false;
           verbs.push('update');
@@ -124,7 +124,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for PUT should starts with "replace"
       else if (
         opKey === 'put' &&
-        !operationId.match(/^replace[a-zA-Z0-9_\-]+/m)
+        !operationId.match(/^replace[a-zA-Z0-9_-]+/m)
       ) {
         checkPassed = false;
         verbs.push('replace');

--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -73,7 +73,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
 
     if (!pathEndsWithParam) {
       // operationId for GET should starts with "list"
-      if (opKey === 'get' && !operationId.match(/^list[a-zA-Z0-9_]+/m)) {
+      if (opKey === 'get' && !operationId.match(/^list[a-zA-Z0-9_\-]+/m)) {
         checkPassed = false;
         verbs.push('list');
       }
@@ -81,7 +81,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for POST should starts with "create" or "add"
       else if (
         opKey === 'post' &&
-        !operationId.match(/^(add|create)[a-zA-Z0-9_]+/m)
+        !operationId.match(/^(add|create)[a-zA-Z0-9_\-]+/m)
       ) {
         checkPassed = false;
         verbs.push('add');
@@ -89,7 +89,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       }
     } else {
       // operationId for GET should starts with "get"
-      if (opKey === 'get' && !operationId.match(/^get[a-zA-Z0-9_]+/m)) {
+      if (opKey === 'get' && !operationId.match(/^get[a-zA-Z0-9_\-]+/m)) {
         checkPassed = false;
         verbs.push('get');
       }
@@ -97,7 +97,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for DELETE should starts with "delete"
       else if (
         opKey === 'delete' &&
-        !operationId.match(/^delete[a-zA-Z0-9_]+/m)
+        !operationId.match(/^delete[a-zA-Z0-9_\-]+/m)
       ) {
         checkPassed = false;
         verbs.push('delete');
@@ -106,7 +106,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for PATCH should starts with "update"
       else if (
         opKey === 'patch' &&
-        !operationId.match(/^update[a-zA-Z0-9_]+/m)
+        !operationId.match(/^update[a-zA-Z0-9_\-]+/m)
       ) {
         checkPassed = false;
         verbs.push('update');
@@ -114,7 +114,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         // If PATCH operation doesn't exist for path, POST operationId should start with "update"
         if (
           !allPathOperations.includes('patch') &&
-          !operationId.match(/^update[a-zA-Z0-9_]+/m)
+          !operationId.match(/^update[a-zA-Z0-9_\-]+/m)
         ) {
           checkPassed = false;
           verbs.push('update');
@@ -124,7 +124,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       // operationId for PUT should starts with "replace"
       else if (
         opKey === 'put' &&
-        !operationId.match(/^replace[a-zA-Z0-9_]+/m)
+        !operationId.match(/^replace[a-zA-Z0-9_\-]+/m)
       ) {
         checkPassed = false;
         verbs.push('replace');

--- a/test/plugins/validation/swagger2/operations-ibm.js
+++ b/test/plugins/validation/swagger2/operations-ibm.js
@@ -518,7 +518,7 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
             consumes: ['application/json'],
             produces: ['application/json'],
             summary: 'this is a summary',
-            operationId: 'list-cool_path',
+            operationId: 'list-cool-path',
             parameters: [
               {
                 name: 'Parameter',

--- a/test/plugins/validation/swagger2/operations-ibm.js
+++ b/test/plugins/validation/swagger2/operations-ibm.js
@@ -503,4 +503,43 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);
   });
+
+  it('should not complain about a get operation id contains a hyphen', function() {
+    const config = {
+      operations: {
+        operation_id_naming_convention: 'warning'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/CoolPath': {
+          get: {
+            consumes: ['application/json'],
+            produces: ['application/json'],
+            summary: 'this is a summary',
+            operationId: 'list-cool_path',
+            parameters: [
+              {
+                name: 'Parameter',
+                in: 'body',
+                schema: {
+                  required: ['Property'],
+                  properties: [
+                    {
+                      name: 'Property'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.warnings.length).toEqual(0);
+    expect(res.errors.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
# Change
Allow operation-id to contain a hyphen.

# Issue
[The rules for operation_id should allow for hyphens.](https://github.com/IBM/openapi-validator/issues/160)