### PR TITLE
feat: Added check for case collsions of property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ The supported rules are described below:
 | array_of_arrays             | Flag any schema with a 'property' of type `array` with items of type `array`. | shared   |
 | inconsistent_property_type  | Flag any properties that have the same name but an inconsistent type.         | shared   |
 | property_case_convention    | Flag any property with a `name` that does not follow a given case convention. snake_case_only must be 'off' to use. | shared |
+| property_case_collision     | Flag any property with a `name` that is identical to another property's `name` except for the naming convention | shared |
 | enum_case_convention        | Flag any enum with a `value` that does not follow a given case convention. snake_case_only must be 'off' to use.    | shared |
 | json_or_param_binary_string | Flag parameters or application/json request/response bodies with schema type: string, format: binary. | oas3 |
 
@@ -445,6 +446,7 @@ The default values for each rule are described below.
 | array_of_arrays             | warning |
 | inconsistent_property_type  | warning |
 | property_case_convention    | error, lower_snake_case |
+| property_case_collision     | error   |
 | enum_case_convention        | error, lower_snake_case |
 
 ###### walker

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -66,6 +66,7 @@ const defaults = {
       'array_of_arrays': 'warning',
       'inconsistent_property_type': 'warning',
       'property_case_convention': [ 'error', 'lower_snake_case'],
+      'property_case_collision': 'error',
       'enum_case_convention': [ 'error', 'lower_snake_case']
     },
     'walker': {

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -537,6 +537,48 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     expect(res.warnings.length).toEqual(0);
   });
 
+  // tests for explicit name collisions
+  it('should return a warning when two property names of different case conventions are identical if converted to a single case', () => {
+    const customConfig = {
+      schemas: {
+        snake_case_only: 'off',
+        property_case_convention: 'warning'
+      }
+    };
+
+    const spec = {
+      definitions: {
+        Thing: {
+          type: 'object',
+          description: 'thing',
+          properties: {
+            thingString: {
+              type: 'string',
+              description: 'thing string'
+            },
+            thing_string: {
+              type: 'string',
+              description: 'thing string'
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, customConfig);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(1);
+    expect(res.warnings[0].path).toEqual([
+      'definitions',
+      'Thing',
+      'properties',
+      'thingString'
+    ]);
+    expect(res.warnings[0].message).toEqual(
+      'Property name is identical to another property except for the naming convention: thingString'
+    );
+  });
+
   it('should not return a case_convention error when property is deprecated', () => {
     const spec = {
       definitions: {


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1653

When there are two property names of different conventions but equivalent names, an error with be reported. (e.g. `propName` and `prop_name` exist)