### PR TITLE
Operation id allow any chars.

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -24,30 +24,25 @@ module.exports.validate = function({ resolvedSpec }, config) {
     'trace'
   ];
 
-  const validOperationIdPrefixWithoutParam = new Map(
-    [
-      // operationId for GET should starts with "list"
-      ['get', ['list']],
-      // operationId for POST should starts with "create" or "add"
-      ['post', ['add', 'create']]
-    ]
-  )
+  const validOperationIdPrefixWithoutParam = new Map([
+    // operationId for GET should starts with "list"
+    ['get', ['list']],
+    // operationId for POST should starts with "create" or "add"
+    ['post', ['add', 'create']]
+  ]);
 
-  const validOperationIdPrefixWithParam = new Map(
-    [
-      // operationId for GET should starts with "get"
-      ['get', ['get']],
-      // operationId for DELETE should starts with "delete"
-      ['delete', ['delete']],
-      // operationId for PATCH should starts with "update"
-      ['patch', ['update']],
-      // If PATCH operation doesn't exist for path, POST operationId should start with "update"
-      ['post', ['update']],
-      // operationId for PUT should starts with "replace"
-      ['put', ['replace']]
-    ]
-  )
-
+  const validOperationIdPrefixWithParam = new Map([
+    // operationId for GET should starts with "get"
+    ['get', ['get']],
+    // operationId for DELETE should starts with "delete"
+    ['delete', ['delete']],
+    // operationId for PATCH should starts with "update"
+    ['patch', ['update']],
+    // If PATCH operation doesn't exist for path, POST operationId should start with "update"
+    ['post', ['update']],
+    // operationId for PUT should starts with "replace"
+    ['put', ['replace']]
+  ]);
 
   const operations = reduce(
     resolvedSpec.paths,
@@ -96,20 +91,25 @@ module.exports.validate = function({ resolvedSpec }, config) {
     let checkPassed = true;
     const verbs = [];
 
-
     if (!pathEndsWithParam) {
-      let whitelistPrefixes = validOperationIdPrefixWithoutParam.get(opKey)
-      if (whitelistPrefixes && !whitelistPrefixes.find((x) => operationId.startsWith(x))) {
+      const whitelistPrefixes = validOperationIdPrefixWithoutParam.get(opKey);
+      if (
+        whitelistPrefixes &&
+        !whitelistPrefixes.find(x => operationId.startsWith(x))
+      ) {
         checkPassed = false;
-        verbs.push(whitelistPrefixes)
+        verbs.push(whitelistPrefixes);
       }
     } else {
-      let whitelistPrefixes = validOperationIdPrefixWithParam.get(opKey)
-      if (whitelistPrefixes && !whitelistPrefixes.find((x) => operationId.startsWith(x))) {
+      const whitelistPrefixes = validOperationIdPrefixWithParam.get(opKey);
+      if (
+        whitelistPrefixes &&
+        !whitelistPrefixes.find(x => operationId.startsWith(x))
+      ) {
         // If PATCH operation doesn't exist for path, POST operationId should start with "update"
         if (opKey !== 'post' || !allPathOperations.includes('patch')) {
           checkPassed = false;
-          verbs.push(whitelistPrefixes)
+          verbs.push(whitelistPrefixes);
         }
       }
     }

--- a/test/plugins/validation/swagger2/operations-ibm.js
+++ b/test/plugins/validation/swagger2/operations-ibm.js
@@ -503,4 +503,43 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);
   });
+
+  it('If meet the prefix provision, should not complain about any characters in operation ID.', function() {
+    const config = {
+      operations: {
+        operation_id_naming_convention: 'warning'
+      }
+    };
+
+    const spec = {
+      paths: {
+        '/CoolPath': {
+          get: {
+            consumes: ['application/json'],
+            produces: ['application/json'],
+            summary: 'this is a summary',
+            operationId: 'list!"#$%&\'()0123456789=~|{}<>?/_[]@*+;:¥^-A',
+            parameters: [
+              {
+                name: 'Parameter',
+                in: 'body',
+                schema: {
+                  required: ['Property'],
+                  properties: [
+                    {
+                      name: 'Property'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.warnings.length).toEqual(0);
+    expect(res.errors.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
# Change
- Allow operation-id to contain a any charactors.
- The inspection process for operationID was made even tighter by separating the prefix check from the code that determines the appropriate prefix.

# Discussion
https://github.com/IBM/openapi-validator/pull/161

# Issue
[The rules for operation_id should allow for hyphens.](https://github.com/IBM/openapi-validator/issues/160)