### PR TITLE
fix: dont crash when only a subset of ops contain redundant path params

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
@@ -146,6 +146,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
             const checkStatus = config.duplicate_path_parameter || 'off';
             if (checkStatus.match('error|warning')) {
               operationKeys.forEach(op => {
+                if (!pathObj[op].parameters) return;
                 const index = pathObj[op].parameters.findIndex(
                   p => p.name === parameter
                 );

--- a/test/plugins/validation/2and3/paths-ibm.js
+++ b/test/plugins/validation/2and3/paths-ibm.js
@@ -556,4 +556,53 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);
   });
+
+  it('should catch redundant path parameter that exists in one operation but not the other', function() {
+    const config = {
+      paths: {
+        duplicate_path_parameter: 'warning'
+      }
+    };
+
+    const goodSpec = {
+      paths: {
+        '/v1/api/resources/{id}': {
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              type: 'string',
+              description: 'id of the resource to retrieve'
+            }
+          ],
+          get: {
+            operationId: 'get_resource',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path'
+              }
+            ]
+          },
+          post: {
+            operationId: 'update_resource'
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: goodSpec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings[0].path).toEqual([
+      'paths',
+      '/v1/api/resources/{id}',
+      'get',
+      'parameters',
+      '0'
+    ]);
+    expect(res.warnings[0].message).toEqual(
+      'Common path parameters should be defined on path object'
+    );
+  });
 });

--- a/test/plugins/validation/2and3/schema-ibm.js
+++ b/test/plugins/validation/2and3/schema-ibm.js
@@ -542,7 +542,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        property_case_convention: 'warning'
+        property_case_collision: 'warning'
       }
     };
 
@@ -572,10 +572,10 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'definitions',
       'Thing',
       'properties',
-      'thingString'
+      'thing_string'
     ]);
     expect(res.warnings[0].message).toEqual(
-      'Property name is identical to another property except for the naming convention: thingString'
+      'Property name is identical to another property except for the naming convention: thing_string'
     );
   });
 


### PR DESCRIPTION
Before, if some operations on a path defined redundant path parameters but others didn't define _any_ parameters, the code would crash. This solves that bug.

Also, this fixes a slight mishap in the tests for a recent PR. I came across the happy discovery that our tests were reporting an exit code of `0` regardless of failing tests. So the build from the previous PR didn't fail despite a failing test showing up in the logs. Lots of fun.

In this PR, I'm just fixing the malformed test. In my next PR, I'm going to move the repo to use `jest` instead of `mocha`, as this seems to be a `mocha` bug. All of our tests are cross compatible so it shouldn't be too much effort.