### PR TITLE
Issue 170 tag checks refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The supported rules are described below:
 ##### operations
 | Rule                         | Description                                                                         | Spec     |
 | ---------------------------- | ----------------------------------------------------------------------------------- | -------- |
-| unused_tag                   | Flag a tag that is in operations and not listed in `tags` on the top level.         | shared   |
+| undefined_tag                | Flag a tag that is in operations and not listed in `tags` on the top level.         | shared   |
 | no_consumes_for_put_or_post  | Flag `put` or `post` operations that do not have a `consumes` field.                | swagger2 |
 | get_op_has_consumes          | Flag `get` operations that contain a `consumes` field.                              | swagger2 |
 | no_produces                  | Flag operations that do not have a `produces` field (except for `head` and operations that return a 204). | swagger2 |
@@ -388,7 +388,7 @@ The default values for each rule are described below.
 ###### operations
 | Rule                         | Default |
 | ---------------------------- | ------- |
-| unused_tag                   | warning |
+| undefined_tag                | warning |
 | no_operation_id              | warning |
 | operation_id_case_convention | warning, lower_snake_case |
 | no_summary                   | warning |

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ The supported rules are described below:
 | Rule                         | Description                                                                         | Spec     |
 | ---------------------------- | ----------------------------------------------------------------------------------- | -------- |
 | undefined_tag                | Flag a tag that is in operations and not listed in `tags` on the top level.         | shared   |
+| unused_tag                   | Flag a tag that is listed in `tags` on the top level that is not used in the spec.  | shared   |
 | no_consumes_for_put_or_post  | Flag `put` or `post` operations that do not have a `consumes` field.                | swagger2 |
 | get_op_has_consumes          | Flag `get` operations that contain a `consumes` field.                              | swagger2 |
 | no_produces                  | Flag operations that do not have a `produces` field (except for `head` and operations that return a 204). | swagger2 |
@@ -389,6 +390,7 @@ The default values for each rule are described below.
 | Rule                         | Default |
 | ---------------------------- | ------- |
 | undefined_tag                | warning |
+| unused_tag                   | warning |
 | no_operation_id              | warning |
 | operation_id_case_convention | warning, lower_snake_case |
 | no_summary                   | warning |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -26,7 +26,7 @@ const defaults = {
       'no_summary': 'warning',
       'no_array_responses': 'error',
       'parameter_order': 'warning',
-      'unused_tag': 'warning',
+      'undefined_tag': 'warning',
       'operation_id_naming_convention': 'warning'
     },
     'pagination': {

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -27,6 +27,7 @@ const defaults = {
       'no_array_responses': 'error',
       'parameter_order': 'warning',
       'undefined_tag': 'warning',
+      'unused_tag': 'warning',
       'operation_id_naming_convention': 'warning'
     },
     'pagination': {

--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -145,7 +145,7 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
             messages.addMessage(
               `paths.${pathKey}.${opKey}.tags`,
               'tag is not defined at the global level: ' + op.tags[i],
-              config.unused_tag
+              config.undefined_tag
             );
           }
         }

--- a/test/cli-validator/mockFiles/clean-with-tabs.yml
+++ b/test/cli-validator/mockFiles/clean-with-tabs.yml
@@ -17,13 +17,6 @@ tags:
 	externalDocs:
 		description: "Find out more"
 		url: "http://swagger.io"
-- name: "store"
-	description: "Access to Petstore orders"
-- name: "user"
-	description: "Operations about user"
-	externalDocs:
-		description: "Find out more about our store"
-		url: "http://swagger.io"
 schemes:
 - "http"
 paths:

--- a/test/cli-validator/mockFiles/clean.yml
+++ b/test/cli-validator/mockFiles/clean.yml
@@ -17,13 +17,6 @@ tags:
   externalDocs:
     description: "Find out more"
     url: "http://swagger.io"
-- name: "store"
-  description: "Access to Petstore orders"
-- name: "user"
-  description: "Operations about user"
-  externalDocs:
-    description: "Find out more about our store"
-    url: "http://swagger.io"
 schemes:
 - "http"
 paths:

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -79,11 +79,13 @@ describe('cli tool - test expected output - Swagger 2', function() {
     // warnings
     expect(capturedText[25].match(/\S+/g)[2]).toEqual('36');
     expect(capturedText[29].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[33].match(/\S+/g)[2]).toEqual('197');
-    expect(capturedText[37].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[41].match(/\S+/g)[2]).toEqual('131');
-    expect(capturedText[45].match(/\S+/g)[2]).toEqual('134');
-    expect(capturedText[49].match(/\S+/g)[2]).toEqual('126');
+    expect(capturedText[33].match(/\S+/g)[2]).toEqual('15');
+    expect(capturedText[37].match(/\S+/g)[2]).toEqual('15');
+    expect(capturedText[41].match(/\S+/g)[2]).toEqual('197');
+    expect(capturedText[45].match(/\S+/g)[2]).toEqual('108');
+    expect(capturedText[49].match(/\S+/g)[2]).toEqual('131');
+    expect(capturedText[53].match(/\S+/g)[2]).toEqual('134');
+    expect(capturedText[57].match(/\S+/g)[2]).toEqual('126');
   });
 
   it('should return exit code of 0 if there are only warnings', async function() {

--- a/test/cli-validator/tests/option-handling.test.js
+++ b/test/cli-validator/tests/option-handling.test.js
@@ -121,7 +121,7 @@ describe('cli tool - test option handling', function() {
 
     // totals
     expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('5');
-    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('7');
+    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('9');
 
     // errors
     expect(capturedText[statsSection + 4].match(/\S+/g)[0]).toEqual('2');
@@ -138,22 +138,25 @@ describe('cli tool - test option handling', function() {
 
     // warnings
     expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(29%)');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(22%)');
 
-    expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('2');
+    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(22%)');
 
     expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(11%)');
 
     expect(capturedText[statsSection + 13].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(11%)');
 
     expect(capturedText[statsSection + 14].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 14].match(/\S+/g)[1]).toEqual('(11%)');
 
     expect(capturedText[statsSection + 15].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(14%)');
+    expect(capturedText[statsSection + 15].match(/\S+/g)[1]).toEqual('(11%)');
+
+    expect(capturedText[statsSection + 16].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 16].match(/\S+/g)[1]).toEqual('(11%)');
   });
 
   it('should not print statistics report by default', async function() {
@@ -250,7 +253,7 @@ describe('cli tool - test option handling', function() {
         }
       }
     });
-    expect(warningCount).toEqual(1); // without the config this value is 5
+    expect(warningCount).toEqual(3); // without the config this value is 5
     expect(errorCount).toEqual(3); // without the config this value is 0
   });
 

--- a/test/plugins/validation/2and3/operations-shared.test.js
+++ b/test/plugins/validation/2and3/operations-shared.test.js
@@ -811,14 +811,11 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should complain about an unused tag', function() {
+    it('should complain about an undefined tag', function() {
       const spec = {
         tags: [
           {
             name: 'some tag'
-          },
-          {
-            name: 'some other tag'
           }
         ],
         paths: {
@@ -827,6 +824,22 @@ describe('validation plugin - semantic - operations-shared', function() {
               operationId: 'get_everything',
               tags: ['not a tag'],
               summary: 'get everything as a string',
+              responses: {
+                '200': {
+                  content: {
+                    'text/plain': {
+                      schema: {
+                        type: 'string'
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            post: {
+              operationId: 'post_everything',
+              tags: ['some tag'],
+              summary: 'post everything as a string',
               responses: {
                 '200': {
                   content: {

--- a/test/plugins/validation/2and3/operations-shared.test.js
+++ b/test/plugins/validation/2and3/operations-shared.test.js
@@ -811,6 +811,48 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
+    it('should complain about an unused tag', function() {
+      const spec = {
+        tags: [
+          {
+            name: 'some tag'
+          },
+          {
+            name: 'some unused tag'
+          }
+        ],
+        paths: {
+          '/': {
+            get: {
+              operationId: 'get_everything',
+              tags: ['some tag'],
+              summary: 'get everything as a string',
+              responses: {
+                '200': {
+                  content: {
+                    'text/plain': {
+                      schema: {
+                        type: 'string'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings.length).toEqual(1);
+
+      expect(res.warnings[0].path).toEqual('tags');
+      expect(res.warnings[0].message).toEqual(
+        'A tag is defined but never used: some unused tag'
+      );
+    });
+
     it('should complain about an undefined tag', function() {
       const spec = {
         tags: [


### PR DESCRIPTION
## Breaking change

- The current `unused_tag` now checks for tags defined in `tags` section but not used in any operation.
- The new `undefined_tag` checks for tags used in operations but not defined in `tags` section (previous `unused_tag` behaviour)

> Discussed in #170 