### PR TITLE
Reduce default severity of enum case convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ The default values for each rule are described below.
 | inconsistent_property_type  | warning |
 | property_case_convention    | error, lower_snake_case |
 | property_case_collision     | error   |
-| enum_case_convention        | error, lower_snake_case |
+| enum_case_convention        | warning, lower_snake_case |
 
 ###### walker
 | Rule                          | Default |

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -68,7 +68,7 @@ const defaults = {
       'inconsistent_property_type': 'warning',
       'property_case_convention': [ 'error', 'lower_snake_case'],
       'property_case_collision': 'error',
-      'enum_case_convention': [ 'error', 'lower_snake_case']
+      'enum_case_convention': [ 'warning', 'lower_snake_case']
     },
     'walker': {
       'no_empty_descriptions': 'error',


### PR DESCRIPTION
This PR reduces the default severity of the messages issued for enum case convention check from error to warning.