### PR TITLE
fix: Required properties warning now checked in child refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ The supported rules are described below:
 | property_case_collision     | Flag any property with a `name` that is identical to another property's `name` except for the naming convention | shared |
 | enum_case_convention        | Flag any enum with a `value` that does not follow a given case convention. snake_case_only must be 'off' to use.    | shared |
 | json_or_param_binary_string | Flag parameters or application/json request/response bodies with schema type: string, format: binary. | oas3 |
+| undefined_required_properties| Flag any schema with undefined required properties                       | shared   |
 
 ##### security_definitions
 | Rule                        | Description                                                                           | Spec   |
@@ -383,6 +384,7 @@ The default values for each rule are described below.
 | Rule                        | Default |
 | --------------------------- | ------- |
 | json_or_param_binary_string | warning |
+| undefined_required_properties    | warning |
 
 ##### shared
 

--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -68,7 +68,8 @@ const defaults = {
       'inconsistent_property_type': 'warning',
       'property_case_convention': [ 'error', 'lower_snake_case'],
       'property_case_collision': 'error',
-      'enum_case_convention': [ 'warning', 'lower_snake_case']
+      'enum_case_convention': [ 'warning', 'lower_snake_case'],
+      'undefined_required_properties': 'warning'
     },
     'walker': {
       'no_empty_descriptions': 'error',


### PR DESCRIPTION
Required property definitions are now checked for in objects that have allOfs, anyOfs, and refs. Also if they are not defined it is only a warning since "required" properties are not required to be defined anywhere.

I added an extra util function for reducing an object (resolving it's refs) since I did not see an easy way of getting an object in the jsSpec using only the ref path. Let me know if there is an easier way.