### PR TITLE
fix(src/plugins/utils/findOctetSequencePaths.js): Show path to erring…

### DIFF
--- a/src/plugins/utils/findOctetSequencePaths.js
+++ b/src/plugins/utils/findOctetSequencePaths.js
@@ -45,7 +45,7 @@ function arrayOctetSequences(resolvedSchema, path) {
       }
     } catch (err) {
       if (err instanceof TypeError) {
-        let escapedPaths = [];
+        const escapedPaths = [];
         const strEscaper = function(strToEscape) {
           let newStr = '';
           for (let i = 0; i < strToEscape.length; i++) {
@@ -58,9 +58,11 @@ function arrayOctetSequences(resolvedSchema, path) {
           escapedPaths.push(newStr);
         };
         path.forEach(strEscaper);
-        let e = new TypeError('items.type and items.format must resolve for the path "' +
+        const e = new TypeError(
+          'items.type and items.format must resolve for the path "' +
             escapedPaths.join('/') +
-            '"');
+            '"'
+        );
         e.stack = err.stack;
         e.original = err;
         throw e;

--- a/src/plugins/utils/findOctetSequencePaths.js
+++ b/src/plugins/utils/findOctetSequencePaths.js
@@ -6,7 +6,7 @@
 // the path both as an array and a string and returns the path in the same
 // format received:
 // typeof(path) === 'array' => [[path1, get], [path2, get], ...]
-// typeof(path) === 'string' => ['path1.get', path2.get, ...]
+// typeof(path) === 'string' => ['path1.get', 'path2.get', ...]
 
 const findOctetSequencePaths = (resolvedSchema, path) => {
   if (!resolvedSchema) {
@@ -47,10 +47,10 @@ function arrayOctetSequences(resolvedSchema, path) {
       if (err instanceof TypeError) {
         var escapedPaths = [];
         const strEscaper = function(strToEscape) {
-          var newStr = "";
+          var newStr = '';
           for (i=0;i<strToEscape.length;i++) {
-            if (strToEscape.charAt(i) == "/") {
-              newStr = newStr + "\\/";
+            if (strToEscape.charAt(i) == '/') {
+              newStr = newStr + '\\/';
             } else {
               newStr = newStr + strToEscape.charAt(i);
             }
@@ -58,7 +58,7 @@ function arrayOctetSequences(resolvedSchema, path) {
           escapedPaths.push(newStr);
         };
         path.forEach(strEscaper);
-        var e = new TypeError("items.type and items.format must resolve for the path \"" + escapedPaths.join("/") + "\"");
+        var e = new TypeError('items.type and items.format must resolve for the path \"' + escapedPaths.join('/') + '\"');
         e.stack = err.stack;
         e.original = err;
         throw e;

--- a/src/plugins/utils/findOctetSequencePaths.js
+++ b/src/plugins/utils/findOctetSequencePaths.js
@@ -43,12 +43,12 @@ function arrayOctetSequences(resolvedSchema, path) {
           ...findOctetSequencePaths(arrayItems, pathToSchema)
         );
       }
-    } catch(err) {
+    } catch (err) {
       if (err instanceof TypeError) {
-        var escapedPaths = [];
+        let escapedPaths = [];
         const strEscaper = function(strToEscape) {
-          var newStr = '';
-          for (i=0;i<strToEscape.length;i++) {
+          let newStr = '';
+          for (let i = 0; i < strToEscape.length; i++) {
             if (strToEscape.charAt(i) == '/') {
               newStr = newStr + '\\/';
             } else {
@@ -58,7 +58,9 @@ function arrayOctetSequences(resolvedSchema, path) {
           escapedPaths.push(newStr);
         };
         path.forEach(strEscaper);
-        var e = new TypeError('items.type and items.format must resolve for the path \"' + escapedPaths.join('/') + '\"');
+        let e = new TypeError('items.type and items.format must resolve for the path "' +
+            escapedPaths.join('/') +
+            '"');
         e.stack = err.stack;
         e.original = err;
         throw e;

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -92,3 +92,27 @@ describe('object-type schemas must extract values from the resolved schema', fun
     expect(arrayEquals(findOctetSequencePaths(schemaObj, path), expectedOut));
   });
 });
+
+describe('array-type schemas require the proper values in proper fields', function() {
+  const schemaObj = { type: 'array', items: null };
+
+  it('should throw with a full path if the proper structure is not provided', function() {
+    const path = ['path1.get'];
+
+    expect(function() {
+      findOctetSequencePaths(schemaObj, path);
+    }).toThrow(
+      'items.type and items.format must resolve for the path "path1.get"'
+    );
+  });
+
+  it('should escape forward-slashes in the path', function() {
+    const path = ['path1/get'];
+
+    expect(function() {
+      findOctetSequencePaths(schemaObj, path);
+    }).toThrow(
+      'items.type and items.format must resolve for the path "path1\\/get"'
+    );
+  });
+});

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -60,6 +60,35 @@ describe('binary format string schemas should return the passed path', function(
   });
 });
 
-describe('array-type schemas must extract values from the resolved schema', function() {
-  describe('', function() {});
+describe('object-type schemas must extract values from the resolved schema', function() {
+  const schemaObj = { type: 'object' };
+  const path = ['path1.get'];
+  it('falsy properties should not append to the path', function() {
+    schemaObj.properties = false;
+
+    expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));
+  });
+
+  it('truthy properties should be added to the octet paths', function() {
+    schemaObj.properties = { one: { type: 'string', format: 'binary' } };
+    const expectedOut = ['path1.get', 'path1.get.properties.one'];
+
+    expect(arrayEquals(findOctetSequencePaths(schemaObj, path), expectedOut));
+  });
+
+  it('truthy properties should be recursively added to the octet paths', function() {
+    schemaObj.properties = {
+      one: {
+        type: 'object',
+        properties: { two: { type: 'string', format: 'binary' } }
+      }
+    };
+    const expectedOut = [
+      'path1.get',
+      'path1.get.properties.one',
+      'path1.get.properties.one.properties.two'
+    ];
+
+    expect(arrayEquals(findOctetSequencePaths(schemaObj, path), expectedOut));
+  });
 });

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -4,7 +4,7 @@ const findOctetSequencePaths = require('../../../src/plugins/utils/findOctetSequ
 
 function arrayEquals(a, b) {
   return (
-   Array.isArray(a) &&
+    Array.isArray(a) &&
     Array.isArray(b) &&
     a.length === b.length &&
     a.every((val, index) => val === b[index])
@@ -51,8 +51,8 @@ describe('falsy values should return an empty array', function() {
 
 describe('binary format string schemas should return the passed path', function() {
   describe('binary format strings should include the path in string form', function() {
-  it('should return an array with string elements', function() {
-      const schemaObj = {'type': 'string', 'format': 'binary'};
+    it('should return an array with string elements', function() {
+      const schemaObj = {type: 'string', format: 'binary'};
       const path = ['path1.get'];
 
       expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -1,0 +1,63 @@
+const expect = require('expect');
+const findOctetSequencePaths = require('../../../src/plugins/utils/findOctetSequencePaths').findOctetSequencePaths;
+
+function arrayEquals(a, b) {
+    return Array.isArray(a) &&
+        Array.isArray(b) &&
+        a.length === b.length &&
+        a.every((val, index) => val === b[index]);
+};
+
+describe('falsy values should return an empty array', function() {
+    describe('undefined should return an empty array', function() {
+        it('undefined is falsy', function() {
+            expect(arrayEquals(findOctetSequencePaths(undefined, []), []));
+        });
+    });
+
+    describe('null should return an empty array', function() {
+        it('null is falsy', function() {
+            expect(arrayEquals(findOctetSequencePaths(null, []), []));
+        });
+    });
+
+    describe('NaN should return an empty array', function() {
+        it('NaN is falsy', function() {
+            expect(arrayEquals(findOctetSequencePaths(NaN, []), []));
+        });
+    });
+
+    describe('0 should return an empty array', function() {
+        it('0 is falsy', function() {
+            expect(arrayEquals(findOctetSequencePaths(0, []), []));
+        });
+    });
+
+    describe('The Empty String should return an empty array', function() {
+        it('The Empty String is falsy', function() {
+            expect(arrayEquals(findOctetSequencePaths('', []), []));
+        });
+    });
+
+    describe('false should return an empty array', function() {
+        it('false is falsy', function() {
+            expect(findOctetSequencePaths(false, [])).toEqual([]);
+        });
+    });
+});
+
+describe('binary format string schemas should return the passed path', function() {
+    describe('binary format strings should include the path in string form', function() {
+        it('should return an array with string elements', function() {
+            const schemaObj = {'type': 'string', 'format': 'binary'};
+            const path = ['path1.get'];
+
+            expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));
+        });
+    });
+});
+
+describe('array-type schemas must extract values from the resolved schema', function() {
+    describe('', function() {});
+});
+

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -1,12 +1,15 @@
 const expect = require('expect');
-const findOctetSequencePaths = require('../../../src/plugins/utils/findOctetSequencePaths').findOctetSequencePaths;
+const findOctetSequencePaths = require('../../../src/plugins/utils/findOctetSequencePaths')
+  .findOctetSequencePaths;
 
 function arrayEquals(a, b) {
-  return Array.isArray(a) &&
+  return (
+   Array.isArray(a) &&
     Array.isArray(b) &&
     a.length === b.length &&
-    a.every((val, index) => val === b[index]);
-};
+    a.every((val, index) => val === b[index])
+  );
+}
 
 describe('falsy values should return an empty array', function() {
   describe('undefined should return an empty array', function() {
@@ -49,11 +52,11 @@ describe('falsy values should return an empty array', function() {
 describe('binary format string schemas should return the passed path', function() {
   describe('binary format strings should include the path in string form', function() {
   it('should return an array with string elements', function() {
-    const schemaObj = {'type': 'string', 'format': 'binary'};
-    const path = ['path1.get'];
+      const schemaObj = {'type': 'string', 'format': 'binary'};
+      const path = ['path1.get'];
 
-    expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));
-  });
+      expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));
+    });
   });
 });
 

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -52,7 +52,7 @@ describe('falsy values should return an empty array', function() {
 describe('binary format string schemas should return the passed path', function() {
   describe('binary format strings should include the path in string form', function() {
     it('should return an array with string elements', function() {
-      const schemaObj = {type: 'string', format: 'binary'};
+      const schemaObj = { type: 'string', format: 'binary' };
       const path = ['path1.get'];
 
       expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -2,62 +2,61 @@ const expect = require('expect');
 const findOctetSequencePaths = require('../../../src/plugins/utils/findOctetSequencePaths').findOctetSequencePaths;
 
 function arrayEquals(a, b) {
-    return Array.isArray(a) &&
-        Array.isArray(b) &&
-        a.length === b.length &&
-        a.every((val, index) => val === b[index]);
+  return Array.isArray(a) &&
+    Array.isArray(b) &&
+    a.length === b.length &&
+    a.every((val, index) => val === b[index]);
 };
 
 describe('falsy values should return an empty array', function() {
-    describe('undefined should return an empty array', function() {
-        it('undefined is falsy', function() {
-            expect(arrayEquals(findOctetSequencePaths(undefined, []), []));
-        });
+  describe('undefined should return an empty array', function() {
+    it('undefined is falsy', function() {
+      expect(arrayEquals(findOctetSequencePaths(undefined, []), []));
     });
+  });
 
-    describe('null should return an empty array', function() {
-        it('null is falsy', function() {
-            expect(arrayEquals(findOctetSequencePaths(null, []), []));
-        });
+  describe('null should return an empty array', function() {
+    it('null is falsy', function() {
+      expect(arrayEquals(findOctetSequencePaths(null, []), []));
     });
+  });
 
-    describe('NaN should return an empty array', function() {
-        it('NaN is falsy', function() {
-            expect(arrayEquals(findOctetSequencePaths(NaN, []), []));
-        });
+  describe('NaN should return an empty array', function() {
+    it('NaN is falsy', function() {
+      expect(arrayEquals(findOctetSequencePaths(NaN, []), []));
     });
+  });
 
-    describe('0 should return an empty array', function() {
-        it('0 is falsy', function() {
-            expect(arrayEquals(findOctetSequencePaths(0, []), []));
-        });
+  describe('0 should return an empty array', function() {
+    it('0 is falsy', function() {
+      expect(arrayEquals(findOctetSequencePaths(0, []), []));
     });
+  });
 
-    describe('The Empty String should return an empty array', function() {
-        it('The Empty String is falsy', function() {
-            expect(arrayEquals(findOctetSequencePaths('', []), []));
-        });
+  describe('The Empty String should return an empty array', function() {
+    it('The Empty String is falsy', function() {
+      expect(arrayEquals(findOctetSequencePaths('', []), []));
     });
+  });
 
-    describe('false should return an empty array', function() {
-        it('false is falsy', function() {
-            expect(findOctetSequencePaths(false, [])).toEqual([]);
-        });
+  describe('false should return an empty array', function() {
+    it('false is falsy', function() {
+      expect(findOctetSequencePaths(false, [])).toEqual([]);
     });
+  });
 });
 
 describe('binary format string schemas should return the passed path', function() {
-    describe('binary format strings should include the path in string form', function() {
-        it('should return an array with string elements', function() {
-            const schemaObj = {'type': 'string', 'format': 'binary'};
-            const path = ['path1.get'];
+  describe('binary format strings should include the path in string form', function() {
+  it('should return an array with string elements', function() {
+    const schemaObj = {'type': 'string', 'format': 'binary'};
+    const path = ['path1.get'];
 
-            expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));
-        });
-    });
+    expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));
+  });
+  });
 });
 
 describe('array-type schemas must extract values from the resolved schema', function() {
-    describe('', function() {});
+  describe('', function() {});
 });
-


### PR DESCRIPTION
… element on exception

Recently, I ran across an issue where [if the validator throws an
exception in a specific part of the code, the path to the
exception-causing code is swallowed](https://github.com/IBM/openapi-validator/issues/180).

After a moderate amount of digging, I decided that an
option for providing more information about this code
would be to put the path to the problematic element or
elements into the exception message. This exception
message is displayed whenever the code crashes out. So,
for example, the previous error message output by
lint-openapi was the following:

```
Validation Results for epic_tenant.json:

[Error] There was a problem with a validator.
Cannot read property 'type' of null

TypeError: Cannot read property 'type' of null
    at arrayOctetSequences (/usr/local/lib/node_modules/
                             ibm-openapi-validator/src/
                             plugins/utils/
                             findOctetSequencePaths.js:39:20)
    at findOctetSequencePaths (/usr/local/lib/node_modules/
                             ibm-openapi-validator/src/
                             plugins/utils/
                             findOctetSequencePaths.js:22:34)
    at /usr/local/lib/node_modules/ibm-openapi-validator/
                             src/plugins/utils/
                             findOctetSequencePaths.js:72:14
    at Array.forEach (<anonymous>)
    at objectOctetSequences (/usr/local/lib/node_modules/
                             ibm-openapi-validator/src/
                             plugins/utils/
                             findOctetSequencePaths.js:58:35)
    at findOctetSequencePaths (/usr/local/lib/node_modules/
                             ibm-openapi-validator/src/
                             plugins/utils/
                             findOctetSequencePaths.js:24:34)
    at /usr/local/lib/node_modules/
                             ibm-openapi-validator/src/
                             plugins/utils/
                             findOctetSequencePaths.js:72:14
    at Array.forEach (<anonymous>)
    at objectOctetSequences (/usr/local/lib/node_modules/
                             ibm-openapi-validator/src/
                             plugins/utils/
                             findOctetSequencePaths.js:58:35)
    at findOctetSequencePaths (/usr/local/lib/node_modules/
                             ibm-openapi-validator/src/
                             plugins/utils/
                             findOctetSequencePaths.js:24:34)
```

After this change, the output should be the following:

```
[Error] There was a problem with a validator.
items.type and items.format must resolve for the path "paths/my/datatype/path/etc/etc"

TypeError: Cannot read property 'type' of null
    at arrayOctetSequences (/usr/local/lib/node_modules/
                            ibm-openapi-validator/src/
                            plugins/utils/
                            findOctetSequencePaths.js:39:22)
    (same stack as above, I would rather not edit it again)
```

re #180