### PR TITLE
fix: spectral file path resolving

### DIFF
--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -242,11 +242,27 @@ const processInput = async function(program) {
       process.chdir(originalWorkingDirectory);
     }
 
-    // run validator & spectral, print the results, and determine if validator passed
+    // run spectral and save the results
+    let spectralResults;
+    try {
+      process.chdir(path.dirname(validFile));
+      // let spectral handle the parsing of the original swagger/oa3 document
+      spectralResults = await spectral.run(originalFile);
+    } catch (err) {
+      printError(chalk, 'There was a problem with spectral.', getError(err));
+      if (debug) {
+        console.log(err.stack);
+      }
+      exitCode = 1;
+      continue;
+    } finally {
+      // return the working directory to its original location
+      process.chdir(originalWorkingDirectory);
+    }
+
+    // run validator, print the results, and determine if validator passed
     let results;
     try {
-      // let spectral handle the parsing of the original swagger/oa3 document
-      const spectralResults = await spectral.run(originalFile);
       results = validator(swagger, configObject, spectralResults, debug);
     } catch (err) {
       printError(chalk, 'There was a problem with a validator.', getError(err));

--- a/test/spectral/mockFiles/oas3/file-resolver/subdir/main.yaml
+++ b/test/spectral/mockFiles/oas3/file-resolver/subdir/main.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: main
+paths:
+  /example:
+    get:
+      summary: Summary
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./schema.yaml#/components/schemas/SchemaDef"

--- a/test/spectral/mockFiles/oas3/file-resolver/subdir/schema.yaml
+++ b/test/spectral/mockFiles/oas3/file-resolver/subdir/schema.yaml
@@ -1,0 +1,6 @@
+openapi: 3.0.0
+paths: {}
+components:
+  schemas:
+    SchemaDef:
+      type: object

--- a/test/spectral/mockFiles/oas3/url-reference-resolver/main.yaml
+++ b/test/spectral/mockFiles/oas3/url-reference-resolver/main.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: main
+paths:
+  /example:
+    get:
+      summary: Summary
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'http://json-schema.org/draft-04/schema#/properties/title'

--- a/test/spectral/mockFiles/swagger/file-resolver/subdir/main.yaml
+++ b/test/spectral/mockFiles/swagger/file-resolver/subdir/main.yaml
@@ -1,0 +1,17 @@
+---
+swagger: '2.0'
+info:
+  title: main
+  version: 1.0.0
+paths:
+  "/example":
+    get:
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: "./schema.yaml#/definitions/SchemaDef"
+      summary: Summary

--- a/test/spectral/mockFiles/swagger/file-resolver/subdir/schema.yaml
+++ b/test/spectral/mockFiles/swagger/file-resolver/subdir/schema.yaml
@@ -1,0 +1,7 @@
+---
+swagger: '2.0'
+paths: {}
+definitions:
+  SchemaDef:
+    type: object
+x-components: {}

--- a/test/spectral/mockFiles/swagger/url-reference-resolver/main.yaml
+++ b/test/spectral/mockFiles/swagger/url-reference-resolver/main.yaml
@@ -1,0 +1,17 @@
+---
+swagger: '2.0'
+info:
+  title: main
+  version: 1.0.0
+paths:
+  "/example":
+    get:
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: 'http://json-schema.org/draft-04/schema#/properties/title'
+      summary: Summary

--- a/test/spectral/tests/path-resolve.test.js
+++ b/test/spectral/tests/path-resolve.test.js
@@ -1,0 +1,122 @@
+const commandLineValidator = require('../../../src/cli-validator/runValidator');
+const { getCapturedText } = require('../../test-utils');
+
+describe('spectral - test file resolve - OAS3', function() {
+  let consoleSpy;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('test no file read error using mockFiles/oas3/file-resolver/subdir/main.yaml', async function() {
+    // set up mock user input
+    const program = {};
+    program.default_mode = true;
+    program.print_validator_modules = true;
+    program.args = [
+      './test/spectral/mockFiles/oas3/file-resolver/subdir/main.yaml'
+    ];
+
+    const exitCode = await commandLineValidator(program);
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    const allOutput = capturedText.join('');
+
+    // No errors should be triggered
+    expect(exitCode).toEqual(0);
+    expect(allOutput).not.toContain('ENOENT: no such file or directory');
+  });
+});
+
+describe('spectral - test file resolve - Swagger', function() {
+  let consoleSpy;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('test no file read error using mockFiles/swagger/file-resolver/subdir/main.yaml', async function() {
+    // set up mock user input
+    const program = {};
+    program.default_mode = true;
+    program.print_validator_modules = true;
+    program.args = [
+      './test/spectral/mockFiles/swagger/file-resolver/subdir/main.yaml'
+    ];
+
+    const exitCode = await commandLineValidator(program);
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    const allOutput = capturedText.join('');
+
+    // No errors should be triggered
+    expect(exitCode).toEqual(0);
+    expect(allOutput).not.toContain('ENOENT: no such file or directory');
+  });
+});
+
+describe('spectral - test url resolve - OAS3', function() {
+  let consoleSpy;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('test no file read error using mockFiles/oas3/url-reference-resolver/main.yaml', async function() {
+    // set up mock user input
+    const program = {};
+    program.default_mode = true;
+    program.print_validator_modules = true;
+    program.args = [
+      './test/spectral/mockFiles/oas3/url-reference-resolver/main.yaml'
+    ];
+
+    const exitCode = await commandLineValidator(program);
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    const allOutput = capturedText.join('');
+
+    // No errors should be triggered
+    expect(exitCode).toEqual(0);
+    expect(allOutput).not.toContain('Error resolving $ref pointer');
+  });
+});
+
+describe('spectral - test url resolve - Swagger', function() {
+  let consoleSpy;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('test no file read error using mockFiles/swagger/url-reference-resolver/main.yaml', async function() {
+    // set up mock user input
+    const program = {};
+    program.default_mode = true;
+    program.print_validator_modules = true;
+    program.args = [
+      './test/spectral/mockFiles/swagger/url-reference-resolver/main.yaml'
+    ];
+
+    const exitCode = await commandLineValidator(program);
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    const allOutput = capturedText.join('');
+
+    // No errors should be triggered
+    expect(exitCode).toEqual(0);
+    expect(allOutput).not.toContain('Error resolving $ref pointer');
+  });
+});


### PR DESCRIPTION
Fixes an issue where Spectral wasn't correctly resolving file references when the file(s) to validate were not in the current working directory the validator was invoked. The fix was to temporarily switch to the directory to the location of the file we're validating, following what our "default" validator does.

Unit tests were also added to test file/remote url resolving

Resolves #199 