### PR TITLE
Add support for "info" and "hint" severity levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ The object will always have `errors` and `warnings` keys that map to arrays. If 
 
 ## Configuration
 The command line validator is built so that each IBM validation can be configured. To get started configuring the validator, [set up](#setup) a [configuration file](#configuration-file) and continue reading this section.
-Specific validation "rules" can be turned off, or configured to trigger either errors or warnings in the validator. Some validations can be configured even further, such as switching the case convention to validate against for parameter names.
+Specific validation "rules" can be turned off, or configured to trigger an error, warning, info, or hint message in the validator output.
+Some validations can be configured even further, such as switching the case convention to validate against for parameter names.
 Additionally, certain files can be ignored by the validator. Any glob placed in a file called `.validateignore` will always be ignored by the validator at runtime. This is set up like a `.gitignore` or a `.eslintignore` file.
 
 ### Setup
@@ -298,7 +299,7 @@ The supported rules are described below:
 
 #### Statuses
 
-Each rule can be assigned a status. The supported statuses are `error`, `warning`, and `off`.
+Each rule can be assigned a status. The supported statuses are `error`, `warning`, `info`, `hint` and `off`.
 Some rules can be configured further with configuration options. The format of this configuration is to provide an array, rather than just a string. e.g.
 `"param_name_case_convention": ["error", "lower_camel_case"]`
 If just a string is provided for these rule, the default configuration option will be used. If only one value is provided in the array, it **MUST** be a status. The default configuration option will be used in this case as well. The rules that support configuration options will have **two** values in the [defaults](#default-values) table.

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -277,12 +277,14 @@ const processInput = async function(program) {
     // if errorsOnly is true, only errors will be returned, so need to force this to false
     if (errorsOnly) {
       results.warning = false;
+      results.info = false;
+      results.hint = false;
     }
 
     if (jsonOutput) {
       printJson(results, originalFile, errorsOnly);
     } else {
-      if (results.error || results.warning) {
+      if (results.error || results.warning || results.info || results.hint) {
         print(
           results,
           chalk,

--- a/src/cli-validator/utils/printResults.js
+++ b/src/cli-validator/utils/printResults.js
@@ -14,10 +14,14 @@ module.exports = function print(
   originalFile,
   errorsOnly
 ) {
-  const types = errorsOnly ? ['errors'] : ['errors', 'warnings'];
+  const types = errorsOnly
+    ? ['errors']
+    : ['errors', 'warnings', 'infos', 'hints'];
   const colors = {
     errors: 'bgRed',
-    warnings: 'bgYellow'
+    warnings: 'bgYellow',
+    infos: 'bgGrey',
+    hints: 'bgGreen'
   };
 
   // define an object template in the case that statistics reporting is turned on
@@ -26,6 +30,12 @@ module.exports = function print(
       total: 0
     },
     warnings: {
+      total: 0
+    },
+    infos: {
+      total: 0
+    },
+    hints: {
       total: 0
     }
   };
@@ -91,8 +101,19 @@ module.exports = function print(
       chalk.cyan(`  Total number of errors   : ${stats.errors.total}`)
     );
     console.log(
-      chalk.cyan(`  Total number of warnings : ${stats.warnings.total}\n`)
+      chalk.cyan(`  Total number of warnings : ${stats.warnings.total}`)
     );
+    if (stats.infos.total > 0) {
+      console.log(
+        chalk.cyan(`  Total number of infos    : ${stats.infos.total}`)
+      );
+    }
+    if (stats.hints.total > 0) {
+      console.log(
+        chalk.cyan(`  Total number of hints    : ${stats.hints.total}`)
+      );
+    }
+    console.log('');
 
     types.forEach(type => {
       // print the type, either error or warning

--- a/src/cli-validator/utils/processConfiguration.js
+++ b/src/cli-validator/utils/processConfiguration.js
@@ -100,8 +100,8 @@ const validateConfigObject = function(configObject, chalk) {
           return; // skip statuses for invalid rule
         }
 
-        // check that all statuses are valid (either 'error', 'warning', or 'off')
-        const allowedStatusValues = ['error', 'warning', 'off'];
+        // check that all statuses are valid (either 'error', 'warning', 'info', 'hint' or 'off')
+        const allowedStatusValues = ['error', 'warning', 'info', 'hint', 'off'];
         let userStatus = configObject[spec][category][rule];
 
         // if the rule supports an array in configuration,

--- a/src/cli-validator/utils/validator.js
+++ b/src/cli-validator/utils/validator.js
@@ -43,8 +43,12 @@ module.exports = function validateSwagger(
   const validationResults = {
     errors: {},
     warnings: {},
+    infos: {},
+    hints: {},
     error: false,
-    warning: false
+    warning: false,
+    info: false,
+    hint: false
   };
 
   // use version specific and shared validations
@@ -65,6 +69,14 @@ module.exports = function validateSwagger(
   if (parsedSpectralResults.warnings.length) {
     validationResults.warnings[key] = [...parsedSpectralResults.warnings];
     validationResults.warning = true;
+  }
+  if (parsedSpectralResults.infos.length) {
+    validationResults.infos[key] = [...parsedSpectralResults.infos];
+    validationResults.info = true;
+  }
+  if (parsedSpectralResults.hints.length) {
+    validationResults.hints[key] = [...parsedSpectralResults.hints];
+    validationResults.hint = true;
   }
 
   // run circular reference validator
@@ -93,6 +105,14 @@ module.exports = function validateSwagger(
       validationResults.warnings[key] = [...problem.warnings];
       validationResults.warning = true;
     }
+    if (problem.infos.length) {
+      validationResults.infos[key] = [...problem.infos];
+      validationResults.info = true;
+    }
+    if (problem.hints.length) {
+      validationResults.hints[key] = [...problem.hints];
+      validationResults.hint = true;
+    }
   });
 
   Object.keys(sharedSemanticValidators).forEach(key => {
@@ -110,6 +130,20 @@ module.exports = function validateSwagger(
         problem.warnings
       );
       validationResults.warning = true;
+    }
+    if (problem.infos.length) {
+      validationResults.infos[key] = [].concat(
+        validationResults.infos[key] || [],
+        problem.infos
+      );
+      validationResults.info = true;
+    }
+    if (problem.hints.length) {
+      validationResults.hints[key] = [].concat(
+        validationResults.hints[key] || [],
+        problem.hints
+      );
+      validationResults.hint = true;
     }
   });
 

--- a/src/plugins/utils/messageCarrier.js
+++ b/src/plugins/utils/messageCarrier.js
@@ -4,7 +4,9 @@ module.exports = class MessageCarrier {
   constructor() {
     this._messages = {
       error: [],
-      warning: []
+      warning: [],
+      info: [],
+      hint: []
     };
   }
 
@@ -20,7 +22,15 @@ module.exports = class MessageCarrier {
     return this._messages.warning;
   }
 
-  // status should be 'off', 'error', or 'warning'
+  get infos() {
+    return this._messages.info;
+  }
+
+  get hints() {
+    return this._messages.hint;
+  }
+
+  // status should be 'off', 'error', 'warning', 'info', or 'hint'
   addMessage(path, message, status) {
     if (this._messages[status]) {
       this._messages[status].push({

--- a/src/spectral/utils/spectral-validator.js
+++ b/src/spectral/utils/spectral-validator.js
@@ -17,20 +17,25 @@ const parseResults = function(results, debug) {
         const message = validationResult['message'];
         const path = validationResult['path'];
 
+        if (code === 'parser') {
+          // Spectral doesn't allow disabling parser rules, so don't include them
+          // in the output (for now)
+          continue;
+        }
+
         if (typeof severity === 'number' && code && message && path) {
-          if (code === 'parser') {
-            // Spectral doesn't allow disabling parser rules, so don't include them
-            // in the output (for now)
-            continue;
-          }
-          // Our validator only supports warning/error level, so only include
-          // those validation results (for now)
-          if (severity === 1) {
-            // warning
-            messages.addMessage(path, message, 'warning');
-          } else if (severity === 0) {
+          if (severity === 0) {
             // error
             messages.addMessage(path, message, 'error');
+          } else if (severity === 1) {
+            // warning
+            messages.addMessage(path, message, 'warning');
+          } else if (severity === 2) {
+            // info
+            messages.addMessage(path, message, 'info');
+          } else if (severity === 3) {
+            // hint
+            messages.addMessage(path, message, 'hint');
           }
         } else {
           if (debug) {

--- a/test/cli-validator/mockFiles/oas3/err-and-warn.yaml
+++ b/test/cli-validator/mockFiles/oas3/err-and-warn.yaml
@@ -1,0 +1,205 @@
+openapi: 3.0.0
+info:
+  description: "This is a sample server Petstore server.  You can find out more
+    about     Swagger at [http://swagger.io](http://swagger.io) or on
+    [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample,
+    you can use the api key `special-key` to test the
+    authorization     filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: post a pet to store
+      operationId: " "
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+      x-codegen-request-body-name: body
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: put new data for existing pet
+      operationId: " "
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+      x-codegen-request-body-name: body
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        "405":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/find_by_status:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: find_pets_by_status
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: http://petstore.swagger.io/v2
+components:
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          description: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      description: string
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: string
+        name:
+          type: string
+          description: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      description: string
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: string
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+          description: string
+        photoUrls:
+          type: array
+          description: string
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          description: string
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    UnusedString:
+      description: string
+      type: string

--- a/test/cli-validator/tests/config-file-validator.test.js
+++ b/test/cli-validator/tests/config-file-validator.test.js
@@ -143,7 +143,7 @@ describe('cli tool - test config file validator', function() {
       '[Error] Invalid configuration in .validaterc file. See below for details.'
     );
     expect(capturedText[1].trim()).toEqual(
-      "- 'nonValidStatus' is not a valid status for the no_produces rule in the operations category.\n   Valid statuses are: error, warning, off"
+      "- 'nonValidStatus' is not a valid status for the no_produces rule in the operations category.\n   Valid statuses are: error, warning, info, hint, off"
     );
   });
 
@@ -254,7 +254,7 @@ describe('cli tool - test config file validator', function() {
       '[Error] Invalid configuration in .validaterc file. See below for details.'
     );
     expect(capturedText[1].trim()).toEqual(
-      "- 'snake_case' is not a valid status for the param_name_case_convention rule in the parameters category.\n   Valid statuses are: error, warning, off"
+      "- 'snake_case' is not a valid status for the param_name_case_convention rule in the parameters category.\n   Valid statuses are: error, warning, info, hint, off"
     );
   });
 
@@ -276,7 +276,7 @@ describe('cli tool - test config file validator', function() {
       '[Error] Invalid configuration in .validaterc file. See below for details.'
     );
     expect(capturedText[1].trim()).toEqual(
-      "- '' is not a valid status for the param_name_case_convention rule in the parameters category.\n   Valid statuses are: error, warning, off"
+      "- '' is not a valid status for the param_name_case_convention rule in the parameters category.\n   Valid statuses are: error, warning, info, hint, off"
     );
   });
 
@@ -318,7 +318,7 @@ describe('cli tool - test config file validator', function() {
       '[Error] Invalid configuration in .validaterc file. See below for details.'
     );
     expect(capturedText[1].trim()).toEqual(
-      "- 'camel_case' is not a valid status for the param_name_case_convention rule in the parameters category.\n   Valid statuses are: error, warning, off"
+      "- 'camel_case' is not a valid status for the param_name_case_convention rule in the parameters category.\n   Valid statuses are: error, warning, info, hint, off"
     );
   });
 
@@ -339,7 +339,7 @@ describe('cli tool - test config file validator', function() {
       '[Error] Invalid configuration in .validaterc file. See below for details.'
     );
     expect(capturedText[1].trim()).toEqual(
-      '- Array-value configuration options are not supported for the no_parameter_description rule in the parameters category.\n   Valid statuses are: error, warning, off'
+      '- Array-value configuration options are not supported for the no_parameter_description rule in the parameters category.\n   Valid statuses are: error, warning, info, hint, off'
     );
   });
 

--- a/test/cli-validator/tests/info-and-hint.test.js
+++ b/test/cli-validator/tests/info-and-hint.test.js
@@ -1,0 +1,58 @@
+const commandLineValidator = require('../../../src/cli-validator/runValidator');
+const config = require('../../../src/cli-validator/utils/processConfiguration');
+const { getCapturedText } = require('../../test-utils');
+
+const defaultConfig = require('../../../src/.defaultsForValidator').defaults;
+
+describe('test info and hint rules - OAS3', function() {
+  it('test info and hint rules', async function() {
+    // Create custom config with some info and hint settings
+    const customConfig = JSON.parse(JSON.stringify(defaultConfig));
+    customConfig['shared']['schemas']['no_schema_description'] = 'info';
+    customConfig['shared']['operations']['unused_tag'] = 'hint';
+    const mockConfig = jest.spyOn(config, 'get').mockReturnValue(customConfig);
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    // set up mock user input
+    const program = {};
+    program.args = ['./test/cli-validator/mockFiles/oas3/err-and-warn.yaml'];
+    program.default_mode = true;
+    program.json = true;
+
+    // Note: validator does not set exitcode for jsonOutput
+    await commandLineValidator(program);
+
+    // Ensure mockConfig was called and revert it to its original state
+    expect(mockConfig).toHaveBeenCalled();
+    mockConfig.mockRestore();
+
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    const jsonOutput = JSON.parse(capturedText);
+
+    consoleSpy.mockRestore();
+
+    // Verify errors
+    expect(jsonOutput['errors']['operation-ids'].length).toBe(1);
+    expect(jsonOutput['errors']['operations-shared'].length).toBe(2);
+    expect(jsonOutput['errors']['schema-ibm'].length).toBe(1);
+
+    // Verify warnings
+    expect(jsonOutput['warnings']['responses'].length).toBe(3);
+    expect(jsonOutput['warnings']['operations-shared'].length).toBe(2);
+    expect(jsonOutput['warnings']['refs'].length).toBe(1);
+    expect(jsonOutput['warnings']['schema-ibm'].length).toBe(1);
+    expect(jsonOutput['warnings']['security-definitions-ibm'].length).toBe(1);
+
+    // Verify infos
+    expect(jsonOutput['infos']['schema-ibm'].length).toBe(1);
+    expect(jsonOutput['infos']['schema-ibm'][0]['message']).toEqual(
+      'Schema must have a non-empty description.'
+    );
+
+    // Verify hints
+    expect(jsonOutput['hints']['operations-shared'].length).toBe(2);
+    expect(jsonOutput['hints']['operations-shared'][0]['message']).toEqual(
+      'A tag is defined but never used: store'
+    );
+  });
+});

--- a/test/cli-validator/tests/option-handling.test.js
+++ b/test/cli-validator/tests/option-handling.test.js
@@ -124,11 +124,8 @@ describe('cli tool - test option handling', function() {
     expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('9');
 
     // errors
-    expect(capturedText[statsSection + 4].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 4].match(/\S+/g)[1]).toEqual('(40%)');
-
-    expect(capturedText[statsSection + 5].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 5].match(/\S+/g)[1]).toEqual('(20%)');
+    expect(capturedText[statsSection + 5].match(/\S+/g)[0]).toEqual('2');
+    expect(capturedText[statsSection + 5].match(/\S+/g)[1]).toEqual('(40%)');
 
     expect(capturedText[statsSection + 6].match(/\S+/g)[0]).toEqual('1');
     expect(capturedText[statsSection + 6].match(/\S+/g)[1]).toEqual('(20%)');
@@ -136,15 +133,15 @@ describe('cli tool - test option handling', function() {
     expect(capturedText[statsSection + 7].match(/\S+/g)[0]).toEqual('1');
     expect(capturedText[statsSection + 7].match(/\S+/g)[1]).toEqual('(20%)');
 
-    // warnings
-    expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(22%)');
+    expect(capturedText[statsSection + 8].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 8].match(/\S+/g)[1]).toEqual('(20%)');
 
+    // warnings
     expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('2');
     expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(22%)');
 
-    expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(11%)');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[0]).toEqual('2');
+    expect(capturedText[statsSection + 12].match(/\S+/g)[1]).toEqual('(22%)');
 
     expect(capturedText[statsSection + 13].match(/\S+/g)[0]).toEqual('1');
     expect(capturedText[statsSection + 13].match(/\S+/g)[1]).toEqual('(11%)');
@@ -157,6 +154,9 @@ describe('cli tool - test option handling', function() {
 
     expect(capturedText[statsSection + 16].match(/\S+/g)[0]).toEqual('1');
     expect(capturedText[statsSection + 16].match(/\S+/g)[1]).toEqual('(11%)');
+
+    expect(capturedText[statsSection + 17].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 17].match(/\S+/g)[1]).toEqual('(11%)');
   });
 
   it('should not print statistics report by default', async function() {

--- a/test/spectral/mockFiles/mockConfig/info-and-hint.yaml
+++ b/test/spectral/mockFiles/mockConfig/info-and-hint.yaml
@@ -1,0 +1,16 @@
+extends: [[spectral:oas, off]]
+formats: [oas2, oas3]
+rules:
+  no-eval-in-markdown: true
+  no-script-tags-in-markdown: info
+  openapi-tags: hint
+  operation-description: true
+  operation-tags: hint
+  operation-tag-defined: info
+  path-keys-no-trailing-slash: true
+  typed-enum: true
+  oas3-api-servers: true
+  oas3-examples-value-or-externalValue: true
+  oas3-server-trailing-slash: true
+  oas3-valid-example: true
+  oas3-valid-schema-example: true

--- a/test/spectral/tests/disabled-rules.test.js
+++ b/test/spectral/tests/disabled-rules.test.js
@@ -5,11 +5,10 @@ const swaggerInMemory = require('../mockFiles/swagger/disabled-rules-in-memory')
 const oas3InMemory = require('../mockFiles/oas3/disabled-rules-in-memory');
 
 describe('spectral - test disabled rules - Swagger 2', function() {
-  let consoleSpy;
   let allOutput;
 
-  beforeEach(async () => {
-    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  beforeAll(async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
     program.args = ['./test/spectral/mockFiles/swagger/disabled-rules.yml'];
@@ -22,10 +21,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     // Since the default validator still has validations that will result in errors, the
     // exit code should equal 1
     expect(exitCode).toEqual(1);
-  });
 
-  afterEach(() => {
-    allOutput = '';
     consoleSpy.mockRestore();
   });
 
@@ -184,14 +180,16 @@ describe('spectral - test disabled rules - Swagger 2', function() {
 });
 
 describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
-  let validationResults;
   let errors;
   let warnings;
 
   beforeAll(async () => {
     // set up mock user input
     const defaultMode = true;
-    validationResults = await inCodeValidator(swaggerInMemory, defaultMode);
+    const validationResults = await inCodeValidator(
+      swaggerInMemory,
+      defaultMode
+    );
 
     // should produce an object with `errors` and `warnings` keys that should
     // both be non-empty
@@ -372,11 +370,10 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
 });
 
 describe(' spectral - test disabled rules - OAS3', function() {
-  let consoleSpy;
   let allOutput;
 
-  beforeEach(async () => {
-    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  beforeAll(async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
     program.args = ['./test/spectral/mockFiles/oas3/disabled-rules.yml'];
@@ -389,10 +386,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     // Since the default validator still has validations that will result in errors, the
     // exit code should equal 1
     expect(exitCode).toEqual(1);
-  });
 
-  afterEach(() => {
-    allOutput = '';
     consoleSpy.mockRestore();
   });
 
@@ -548,14 +542,13 @@ describe(' spectral - test disabled rules - OAS3', function() {
 });
 
 describe('spectral - test disabled rules - OAS3 In Memory', function() {
-  let validationResults;
   let errors;
   let warnings;
 
   beforeAll(async () => {
     // set up mock user input
     const defaultMode = true;
-    validationResults = await inCodeValidator(oas3InMemory, defaultMode);
+    const validationResults = await inCodeValidator(oas3InMemory, defaultMode);
 
     // should produce an object with `errors` and `warnings` keys that should
     // both be non-empty

--- a/test/spectral/tests/enabled-rules.test.js
+++ b/test/spectral/tests/enabled-rules.test.js
@@ -6,11 +6,10 @@ const oas3InMemory = require('../mockFiles/oas3/enabled-rules-in-memory');
 const re = /^Validator: spectral/;
 
 describe('spectral - test enabled rules - Swagger 2', function() {
-  let consoleSpy;
   let allOutput;
 
-  beforeEach(async () => {
-    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  beforeAll(async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
     program.args = ['./test/spectral/mockFiles/swagger/enabled-rules.yml'];
@@ -34,10 +33,7 @@ describe('spectral - test enabled rules - Swagger 2', function() {
     // Since some spectral validations will result in errors, the exit code should equal 1
     expect(exitCode).toEqual(1);
     expect(foundOtherValidator).toBe(false);
-  });
 
-  afterEach(() => {
-    allOutput = '';
     consoleSpy.mockRestore();
   });
 
@@ -117,14 +113,16 @@ describe('spectral - test enabled rules - Swagger 2', function() {
 });
 
 describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
-  let validationResults;
   let errors;
   let warnings;
 
   beforeAll(async () => {
     // set up mock user input
     const defaultMode = true;
-    validationResults = await inCodeValidator(swaggerInMemory, defaultMode);
+    const validationResults = await inCodeValidator(
+      swaggerInMemory,
+      defaultMode
+    );
 
     // should produce an object with `errors` and `warnings` keys that should
     // both be non-empty
@@ -250,11 +248,10 @@ describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
 });
 
 describe('spectral - test enabled rules - OAS3', function() {
-  let consoleSpy;
   let allOutput;
 
-  beforeEach(async () => {
-    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  beforeAll(async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
     program.args = ['./test/spectral/mockFiles/oas3/enabled-rules.yml'];
@@ -279,10 +276,7 @@ describe('spectral - test enabled rules - OAS3', function() {
     // Since some spectral validations will result in errors, the exit code should equal 1
     expect(exitCode).toEqual(1);
     expect(foundOtherValidator).toBe(false);
-  });
 
-  afterEach(() => {
-    allOutput = '';
     consoleSpy.mockRestore();
   });
 
@@ -350,14 +344,13 @@ describe('spectral - test enabled rules - OAS3', function() {
 });
 
 describe('spectral - test enabled rules - OAS3 In Memory', function() {
-  let validationResults;
   let errors;
   let warnings;
 
   beforeAll(async () => {
     // set up mock user input
     const defaultMode = true;
-    validationResults = await inCodeValidator(oas3InMemory, defaultMode);
+    const validationResults = await inCodeValidator(oas3InMemory, defaultMode);
 
     // should produce an object with `errors` and `warnings` keys that should
     // both be non-empty

--- a/test/spectral/tests/info-and-hint.test.js
+++ b/test/spectral/tests/info-and-hint.test.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const commandLineValidator = require('../../../src/cli-validator/runValidator');
+const config = require('../../../src/cli-validator/utils/processConfiguration');
+const { getCapturedText } = require('../../test-utils');
+
+describe(' spectral - test info and hint rules - OAS3', function() {
+  it('test Spectral info and hint rules', async function() {
+    // Set config to mock .spectral.yml file before running
+    const mockPath = path.join(
+      __dirname,
+      '../mockFiles/mockConfig/info-and-hint.yaml'
+    );
+    const mockConfig = jest
+      .spyOn(config, 'getSpectralRuleset')
+      .mockReturnValue(mockPath);
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    // set up mock user input
+    const program = {};
+    program.args = ['./test/spectral/mockFiles/oas3/enabled-rules.yml'];
+    program.default_mode = true;
+    program.json = true;
+
+    // Note: validator does not set exitcode for jsonOutput
+    await commandLineValidator(program);
+
+    // Ensure mockConfig was called and revert it to its original state
+    expect(mockConfig).toHaveBeenCalled();
+    mockConfig.mockRestore();
+
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    const jsonOutput = JSON.parse(capturedText);
+
+    consoleSpy.mockRestore();
+
+    // Verify errors
+    expect(jsonOutput['errors']['spectral'].length).toBe(2);
+
+    // Verify warnings
+    expect(jsonOutput['warnings']['spectral'].length).toBe(10);
+
+    // Verify infos
+    expect(jsonOutput['infos']['spectral'].length).toBe(5);
+    expect(jsonOutput['infos']['spectral'][0]['message']).toEqual(
+      'Markdown descriptions should not contain `<script>` tags.'
+    );
+    expect(jsonOutput['infos']['spectral'][4]['message']).toEqual(
+      'Operation tags should be defined in global tags.'
+    );
+
+    // Verify hints
+    expect(jsonOutput['hints']['spectral'].length).toBe(2);
+    expect(jsonOutput['hints']['spectral'][0]['message']).toEqual(
+      'OpenAPI object should have non-empty `tags` array.'
+    );
+    expect(jsonOutput['hints']['spectral'][1]['message']).toEqual(
+      'Operation should have non-empty `tags` array.'
+    );
+  });
+});


### PR DESCRIPTION
This PR extends the set of severity levels supported by the validator to include "info" and "hint".  This improves the integration with Spectral, which already supports these severity levels, and gives us new options for providing guidance to service teams on their API design.

The second commit is a small but significant change in the Spectral tests that improves performance by avoiding redundant invocations of the validator.  The result is that the time to run the whole test suite is reduced by over 50% -- from 17s to around 8s on my system.