### PR TITLE
Add rule to check response code is 3-digit integer or default

### DIFF
--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -92,3 +92,21 @@ rules:
   oas3-schema: off
   # Turn off - duplicates non-configurable validation in base validator
   oas3-unused-components-schema: off
+
+  #
+  # Custom rules
+  #
+
+  # Response code must be 3-digit integer or "default"
+  # - https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#responses-object
+  # - https://tools.ietf.org/html/rfc7231#section-6)
+  openapi-response-code:
+    description: The response code must be a 3-digit integer or "default".
+    formats: [oas2, oas3]
+    given: '$.paths..responses'
+    severity: warn
+    then:
+      field: '@key'
+      function: pattern
+      functionOptions:
+        match: '^([0-9]{3}|default)$'

--- a/test/spectral/mockFiles/oas3/extended-rules.yml
+++ b/test/spectral/mockFiles/oas3/extended-rules.yml
@@ -1,0 +1,58 @@
+openapi: '3.0.0'
+info:
+  title: Extended rules
+  version: 1.0.0
+  description: API def to exercise extended rules in openapi validator
+  contact:
+    email: support@sdkcodegen.ibm.com
+servers:
+  - url: http://petstore.swagger.io/v1
+tags:
+  - name: pets
+paths:
+  /pet:
+    post:
+      description: Add a new pet to the store
+      summary: Create pet
+      operationId: create_pet
+      tags:
+        - pets
+      requestBody:
+        description: Pet object that needs to be added to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '204':
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '42':
+          description: The answer to life, the universe, and everything
+        '5xx':
+          description: Sumpin bad happened
+        default:
+          description: Error
+
+components:
+  responses:
+    BadRequest:
+      description: The request could not be understood due to malformed syntax.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    Error:
+      description: The error object.
+      type: object
+      properties:
+        code:
+          description: The error code of this error.
+          type: string
+        message:
+          description: The error message of this error.
+          type: string

--- a/test/spectral/tests/extended-rules.test.js
+++ b/test/spectral/tests/extended-rules.test.js
@@ -1,0 +1,35 @@
+const commandLineValidator = require('../../../src/cli-validator/runValidator');
+const { getCapturedText } = require('../../test-utils');
+
+describe('spectral - test extended rules', function() {
+  let jsonOutput;
+
+  beforeAll(async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    // set up mock user input
+    const program = {};
+    program.args = ['./test/spectral/mockFiles/oas3/extended-rules.yml'];
+    program.default_mode = true;
+    program.json = true;
+
+    await commandLineValidator(program);
+
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    jsonOutput = JSON.parse(capturedText);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('test openapi-response-code rule', function() {
+    // Verify warnings
+    expect(jsonOutput['warnings']['spectral'].length).toBeGreaterThan(0);
+    const warnings = jsonOutput['warnings']['spectral'].map(w => w['message']);
+    // This is the new warning -- there should be four occurrences
+    const warning = 'The response code must be a 3-digit integer or "default".';
+    const occurrences = warnings.reduce(
+      (a, v) => (v === warning ? a + 1 : a),
+      0
+    );
+    expect(occurrences).toBe(2);
+  });
+});


### PR DESCRIPTION
This PR adds a custom Spectral rule to validate the status code of responses is a 3-digit integer or "default".

I've added a short test for this.

Something missing from this PR is documentation for this new rule.  This will be the first Spectral rule we add over and above the standard `spectral:oas` rules, so we need to decide where to document such rules.  My current thinking is to create a Wiki page on the repo that documents these in style of the Spectral rules.  Then I suppose we should update the README.md to point to that page.

Fixes #163.