### PR TITLE
Display rule names for messages in verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,16 @@ Once pulled, the container can be run directly, but mount a volume containing th
 ##### [options]
 -  -s (--report_statistics) : Print a simple report at the end of the output showing the frequency, in percentage, of each error/warning.
 -  -e (--errors_only) : Only print the errors, ignore the warnings.
+-  -j (--json) : Output results as a JSON object
 -  -d (--default_mode) : This option turns off [configuration](#configuration) and runs the validator in [default mode](#default-mode).
 -  -p (--print_validator_modules) : Print the name of the validator source file the error/warning was caught it. This can be helpful for developing validations.
 -  -n (--no_colors) : The output is colored by default. If this bothers you, this flag will turn off the coloring.
--  -v (--version) : Print the current semantic version of the validator
+-  -v (--verbose) : Increase verbosity of reported results.  Use this option to display the rule for each reported result.
 -  -h (--help) : This option prints the usage menu.
 -  -c (--config) <path/to/your/config> : Path to a validator configuration file.  If provided, this is used instead of .validaterc.
 -  -r (--ruleset) <path/to/your/ruleset> : Path to Spectral ruleset file, used instead of .spectral.yaml if provided.
 -  --debug : Enable debugging output.
+-  --version : Print the current semantic version of the validator
 
 _These options only apply to running the validator on a file, not to any commands._
 
@@ -177,10 +179,16 @@ The object will always have `errors` and `warnings` keys that map to arrays. If 
 The command line validator is built so that each IBM validation can be configured. To get started configuring the validator, [set up](#setup) a [configuration file](#configuration-file) and continue reading this section.
 Specific validation "rules" can be turned off, or configured to trigger an error, warning, info, or hint message in the validator output.
 Some validations can be configured even further, such as switching the case convention to validate against for parameter names.
+There are also currently some validations that cannot be disabled or configured to a different severity.
+You can see the rule associated with each message produced by the validator with the `-v` command line option.
+Rules that are not configurable will show the name `builtin`.
+
 Additionally, certain files can be ignored by the validator. Any glob placed in a file called `.validateignore` will always be ignored by the validator at runtime. This is set up like a `.gitignore` or a `.eslintignore` file.
 
 The validator also employs the [`Spectral`](https://github.com/stoplightio/spectral) validation/linting engine to detect certain issues in the API document.
 Spectral rules can also be configured to trigger an error, warning, info, or hint message in the validator output with the `.spectral.yaml` configuration file.
+When the validator issues a message as the result of a Spectral rule, the rule name displayed will correspond to the Spectral rule.
+Spectral rules must be configured in `.spectral.yaml` rather than in `.validaterc`.
 Spectral further supports the creation of custom rules using a simple but powerful yaml syntax or custom Javascript functions.
 See the [Spectral configuration](#spectral-configuration) section for more details.
 
@@ -223,6 +231,7 @@ The supported categories are described below:
 #### Rules
 
 Each category contains a group of rules. The spec that each rule applies to is marked in the third column. For the actual configuration structure, see the [default values](#default-values).
+You can use the `-v` option of the CLI validator to display the rule for each reported result.
 The supported rules are described below:
 
 ##### operations

--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -22,6 +22,10 @@ program
     'print the validators that catch each error/warning (helpful for development)'
   )
   .option(
+    '-r, --print_rule_names',
+    'print the configuration option names associated with each error and warning'
+  )
+  .option(
     '-n, --no_colors',
     'turn off output coloring'
   )

--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -14,16 +14,12 @@ const version = require('../../package.json').version;
 /* prettier-ignore */
 program
   .name('lint-openapi')
-  .version(version, '-v, --version')
+  .version(version, '--version')
   .description('Run the validator on a specified file')
   .arguments('[<file>]')
   .option(
     '-p, --print_validator_modules',
     'print the validators that catch each error/warning (helpful for development)'
-  )
-  .option(
-    '-r, --print_rule_names',
-    'print the configuration option names associated with each error and warning'
   )
   .option(
     '-n, --no_colors',
@@ -51,10 +47,19 @@ program
     '-e, --errors_only',
     'only print the errors, ignore the warnings'
   )
+  .option('-v, --verbose',
+    'increase the verbosity of reported results',
+    increaseVerbosity,
+    0
+  )
   .option(
     '--debug',
     'enable debugging output'
   );
+
+function increaseVerbosity(dummyValue, previous) {
+  return previous + 1;
+}
 
 /* prettier-ignore */
 program

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -33,6 +33,7 @@ const processInput = async function(program) {
 
   // interpret the options
   const printValidators = !!program.print_validator_modules;
+  const printRuleNames = !!program.print_rule_names;
   const reportingStats = !!program.report_statistics;
 
   const turnOffColoring = !!program.no_colors;
@@ -290,6 +291,7 @@ const processInput = async function(program) {
           results,
           chalk,
           printValidators,
+          printRuleNames,
           reportingStats,
           originalFile,
           errorsOnly

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -33,7 +33,6 @@ const processInput = async function(program) {
 
   // interpret the options
   const printValidators = !!program.print_validator_modules;
-  const printRuleNames = !!program.print_rule_names;
   const reportingStats = !!program.report_statistics;
 
   const turnOffColoring = !!program.no_colors;
@@ -46,6 +45,8 @@ const processInput = async function(program) {
   const rulesetFileOverride = program.ruleset;
 
   const limitsFileOverride = program.limits;
+
+  const printRuleNames = program.verbose > 0;
 
   // turn off coloring if explicitly requested
   if (turnOffColoring) {

--- a/src/cli-validator/utils/printResults.js
+++ b/src/cli-validator/utils/printResults.js
@@ -10,6 +10,7 @@ module.exports = function print(
   results,
   chalk,
   printValidators,
+  printRuleNames,
   reportingStats,
   originalFile,
   errorsOnly
@@ -85,9 +86,13 @@ module.exports = function print(
         const lineNumber = getLineNumberForPath(originalFile, path);
 
         // print the path array as a dot-separated string
+
         console.log(chalk[color](`  Message :   ${problem.message}`));
         console.log(chalk[color](`  Path    :   ${path.join('.')}`));
         console.log(chalk[color](`  Line    :   ${lineNumber}`));
+        if (printRuleNames) {
+          console.log(chalk[color](`  Rule    :   ${problem.rule}`));
+        }
         console.log();
       });
     });

--- a/src/cli-validator/utils/printResults.js
+++ b/src/cli-validator/utils/printResults.js
@@ -88,18 +88,24 @@ module.exports = function print(
         // print the path array as a dot-separated string
 
         console.log(chalk[color](`  Message :   ${problem.message}`));
-        console.log(chalk[color](`  Path    :   ${path.join('.')}`));
-        console.log(chalk[color](`  Line    :   ${lineNumber}`));
         if (printRuleNames) {
           console.log(chalk[color](`  Rule    :   ${problem.rule}`));
         }
+        console.log(chalk[color](`  Path    :   ${path.join('.')}`));
+        console.log(chalk[color](`  Line    :   ${lineNumber}`));
         console.log();
       });
     });
   });
 
   // print the stats here, if applicable
-  if (reportingStats && (stats.errors.total || stats.warnings.total)) {
+  if (
+    reportingStats &&
+    (stats.errors.total ||
+      stats.warnings.total ||
+      stats.infos.total ||
+      stats.hints.total)
+  ) {
     console.log(chalk.bgCyan('statistics\n'));
 
     console.log(

--- a/src/plugins/utils/messageCarrier.js
+++ b/src/plugins/utils/messageCarrier.js
@@ -31,21 +31,26 @@ module.exports = class MessageCarrier {
   }
 
   // status should be 'off', 'error', 'warning', 'info', or 'hint'
-  addMessage(path, message, status) {
-    if (this._messages[status]) {
-      this._messages[status].push({
-        path,
-        message
-      });
-    }
-  }
-
-  addMessageWithAuthId(path, message, authId, status) {
+  // rule is the name of the configOption, 'builtin' by default
+  addMessage(path, message, status, rule = 'builtin') {
     if (this._messages[status]) {
       this._messages[status].push({
         path,
         message,
-        authId
+        rule
+      });
+    }
+  }
+
+  // status should be 'off', 'error', 'warning'
+  // rule is the name of the configOption, 'builtin' by default
+  addMessageWithAuthId(path, message, authId, status, rule = 'builtin') {
+    if (this._messages[status]) {
+      this._messages[status].push({
+        path,
+        message,
+        authId,
+        rule
       });
     }
   }

--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -145,7 +145,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
             messages.addMessage(
               `paths.${pathKey}.${opKey}.tags`,
               'tag is not defined at the global level: ' + op.tags[i],
-              config.undefined_tag
+              config.undefined_tag,
+              'undefined_tag'
             );
           } else {
             unusedTags.delete(op.tags[i]);
@@ -159,7 +160,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
         messages.addMessage(
           `paths.${pathKey}.${opKey}.summary`,
           'Operations must have a non-empty `summary` field.',
-          config.no_summary
+          config.no_summary,
+          'no_summary'
         );
       }
 
@@ -180,7 +182,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
                 messages.addMessage(
                   `paths.${pathKey}.${opKey}.parameters[${indx}]`,
                   'Required parameters should appear before optional parameters.',
-                  checkStatusParamOrder
+                  checkStatusParamOrder,
+                  'parameter_order'
                 );
               }
             }

--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -95,7 +95,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
                 messages.addMessage(
                   `paths.${pathKey}.${opKey}.responses.${name}.content.${contentType}.schema`,
                   'Arrays MUST NOT be returned as the top-level structure in a response body.',
-                  checkStatusArrRes
+                  checkStatusArrRes,
+                  'no_array_responses'
                 );
               }
             });
@@ -108,7 +109,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
               messages.addMessage(
                 `paths.${pathKey}.${opKey}.responses.${name}.schema`,
                 'Arrays MUST NOT be returned as the top-level structure in a response body.',
-                checkStatusArrRes
+                checkStatusArrRes,
+                'no_array_responses'
               );
             }
           }
@@ -123,7 +125,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
         messages.addMessage(
           `paths.${pathKey}.${opKey}.operationId`,
           'Operations must have a non-empty `operationId`.',
-          config.no_operation_id
+          config.no_operation_id,
+          'no_operation_id'
         );
       } else {
         // check operationId for case convention
@@ -134,7 +137,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
           messages.addMessage(
             `paths.${pathKey}.${opKey}.operationId`,
             `operationIds must follow case convention: ${caseConvention}`,
-            checkStatus
+            checkStatus,
+            'operation_id_case_convention'
           );
         }
       }
@@ -197,7 +201,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
     messages.addMessage(
       `tags`,
       `A tag is defined but never used: ${tagName}`,
-      config.unused_tag
+      config.unused_tag,
+      'unused_tag'
     );
   });
 

--- a/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
@@ -33,7 +33,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
         messages.addMessage(
           path,
           'Parameter objects must have a `description` field.',
-          config.no_parameter_description
+          config.no_parameter_description,
+          'no_parameter_description'
         );
       }
 
@@ -57,7 +58,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
             messages.addMessage(
               path,
               `Parameter names must follow case convention: ${caseConvention}`,
-              checkStatus
+              checkStatus,
+              'param_name_case_convention'
             );
           }
         }
@@ -72,7 +74,12 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
           ? `${messageCT} Rely on the \`content\` field of a request body or response object to specify content-type.`
           : `${messageCT} Rely on the \`consumes\` field to specify content-type.`;
         if (definesContentType) {
-          messages.addMessage(path, messageCT, checkStatusCT);
+          messages.addMessage(
+            path,
+            messageCT,
+            checkStatusCT,
+            'content_type_parameter'
+          );
         }
 
         // check for accept-type defined in a header parameter (AT = accept-type)
@@ -83,7 +90,12 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
           ? `${messageAT} Rely on the \`content\` field of a response object to specify accept-type.`
           : `${messageAT} Rely on the \`produces\` field to specify accept-type.`;
         if (definesAcceptType) {
-          messages.addMessage(path, messageAT, checkStatusAT);
+          messages.addMessage(
+            path,
+            messageAT,
+            checkStatusAT,
+            'accept_type_parameter'
+          );
         }
 
         // check for accept-type defined in a header parameter (AT = accept-type)
@@ -101,7 +113,12 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
             ' This check will be converted to an `error` in an upcoming release.';
         }
         if (definesAuth) {
-          messages.addMessage(path, messageAuth, checkStatusAuth);
+          messages.addMessage(
+            path,
+            messageAuth,
+            checkStatusAuth,
+            'authorization_parameter'
+          );
         }
       }
 
@@ -117,7 +134,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
         messages.addMessage(
           path,
           'Required parameters should not specify default values.',
-          config.required_param_has_default
+          config.required_param_has_default,
+          'required_param_has_default'
         );
       }
     }

--- a/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
@@ -95,7 +95,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
               messages.addMessage(
                 ['paths', pathName, opName, 'parameters'],
                 `Operation must include a path parameter with name: ${name}.`,
-                checkStatus
+                checkStatus,
+                'missing_path_parameter'
               );
             });
           }
@@ -118,7 +119,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
               messages.addMessage(
                 ['paths', pathName],
                 `Path parameter must be defined at the path or the operation level: ${name}.`,
-                checkStatus
+                checkStatus,
+                'missing_path_parameter'
               );
             });
           }
@@ -153,7 +155,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
                 messages.addMessage(
                   ['paths', pathName, op, 'parameters', `${index}`],
                   'Common path parameters should be defined on path object',
-                  checkStatus
+                  checkStatus,
+                  'duplicate_path_parameter'
                 );
               });
             }
@@ -176,7 +179,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
           messages.addMessage(
             ['paths', pathName],
             `Path segments must be lower snake case.`,
-            checkStatus
+            checkStatus,
+            'snake_case_only'
           );
         }
       });
@@ -200,7 +204,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
               messages.addMessage(
                 ['paths', pathName],
                 `Path segments must follow case convention: ${caseConvention}`,
-                checkStatusPath
+                checkStatusPath,
+                'paths_case_convention'
               );
             }
           });

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -50,7 +50,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                             i
                           ],
                           INLINE_SCHEMA_MESSAGE,
-                          config.inline_response_schema
+                          config.inline_response_schema,
+                          'inline_response_schema'
                         );
                       }
                     }
@@ -60,7 +61,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                 messages.addMessage(
                   [...path, responseKey, 'content', mediaTypeKey, 'schema'],
                   INLINE_SCHEMA_MESSAGE,
-                  config.inline_response_schema
+                  config.inline_response_schema,
+                  'inline_response_schema'
                 );
               }
             }
@@ -74,7 +76,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
             messages.addMessage(
               [...path, responseKey, 'schema'],
               INLINE_SCHEMA_MESSAGE,
-              config.inline_response_schema
+              config.inline_response_schema,
+              'inline_response_schema'
             );
           }
         }

--- a/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -180,7 +180,8 @@ function generateFormatErrors(schema, contextPath, config, isOAS3, messages) {
       messages.addMessage(
         contextPath.concat(['items', 'type']),
         'Array properties should avoid having items of type array.',
-        checkStatus
+        checkStatus,
+        'array_of_arrays'
       );
     }
   }
@@ -197,7 +198,8 @@ function typeFormatErrors(obj, path, isOAS3, messages, checkStatus) {
     messages.addMessage(
       path.concat(['format']),
       'Format defined without a type.',
-      checkStatus
+      checkStatus,
+      'invalid_type_format_pair'
     );
   }
 
@@ -360,7 +362,8 @@ function generateDescriptionWarnings(
     messages.addMessage(
       contextPath,
       'Schema must have a non-empty description.',
-      config.no_schema_description
+      config.no_schema_description,
+      'no_schema_description'
     );
   }
 
@@ -384,7 +387,8 @@ function generateDescriptionWarnings(
       messages.addMessage(
         path,
         'Schema properties must have a description with content in it.',
-        config.no_property_description
+        config.no_property_description,
+        'no_property_description'
       );
     } else {
       // if the property does have a description, "Avoid describing a model as a 'JSON object' since this will be incorrect for some SDKs."
@@ -393,7 +397,8 @@ function generateDescriptionWarnings(
         messages.addMessage(
           path,
           'Not all languages use JSON, so descriptions should not state that the model is a JSON object.',
-          config.description_mentions_json
+          config.description_mentions_json,
+          'description_mentions_json'
         );
       }
     }
@@ -419,7 +424,8 @@ function checkPropNames(schema, contextPath, config, messages) {
         messages.addMessage(
           contextPath.concat(['properties', propName]),
           'Property names must be lower snake case.',
-          checkStatus
+          checkStatus,
+          'snake_case_only'
         );
       }
     }
@@ -497,7 +503,8 @@ function checkPropNamesCaseConvention(
         messages.addMessage(
           contextPath.concat(['properties', propName]),
           `Property names must follow case convention: ${caseConventionValue}`,
-          checkStatus
+          checkStatus,
+          'property_case_convention'
         );
       }
     }
@@ -518,7 +525,8 @@ function checkEnumValues(schema, contextPath, config, messages) {
           messages.addMessage(
             contextPath.concat(['enum', i.toString()]),
             'Enum values must be lower snake case.',
-            checkStatus
+            checkStatus,
+            'snake_case_only'
           );
         }
       }
@@ -554,7 +562,8 @@ function checkEnumCaseConvention(
           messages.addMessage(
             contextPath.concat(['enum', i.toString()]),
             `Enum values must follow case convention: ${caseConventionValue}`,
-            checkStatus
+            checkStatus,
+            'enum_case_convention'
           );
         }
       }

--- a/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
@@ -104,7 +104,8 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
       messages.addMessage(
         `${location}.${name}`,
         `A security scheme is defined but never used: ${name}`,
-        config.unused_security_schemes
+        config.unused_security_schemes,
+        'unused_security_schemes'
       );
     }
   });
@@ -119,7 +120,8 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
       messages.addMessage(
         path,
         `A security scope is defined but never used: ${name}`,
-        config.unused_security_scopes
+        config.unused_security_scopes,
+        'unused_security_scopes'
       );
     }
   });

--- a/src/plugins/validation/2and3/semantic-validators/security-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/security-ibm.js
@@ -88,7 +88,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
               `For security scheme types other than ${schemesWithNonEmptyArrays.join(
                 ' or '
               )}, the value must be an empty array.`,
-              config.invalid_non_empty_security_array
+              config.invalid_non_empty_security_array,
+              'invalid_non_empty_security_array'
             );
           }
 

--- a/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
@@ -24,7 +24,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec }, config) {
         messages.addMessage(
           [...path, 'description'],
           'Items with a description must have content in it.',
-          config.no_empty_descriptions
+          config.no_empty_descriptions,
+          'no_empty_descriptions'
         );
       }
 
@@ -42,7 +43,8 @@ module.exports.validate = function({ jsSpec, resolvedSpec }, config) {
           messages.addMessage(
             [...path, 'description'],
             'Description sibling to $ref matches that of the referenced schema. This is redundant and should be removed.',
-            config.duplicate_sibling_description
+            config.duplicate_sibling_description,
+            'duplicate_sibling_description'
           );
         }
       }

--- a/src/plugins/validation/2and3/semantic-validators/walker.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker.js
@@ -98,7 +98,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
           `${
             blacklistPayload.location
           } $refs must follow this format: ${refBlacklist[0].slice(1)}`,
-          config.incorrect_ref_pattern
+          config.incorrect_ref_pattern,
+          'incorrect_ref_pattern'
         );
       }
     }
@@ -109,7 +110,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
         messages.addMessage(
           path.concat([k]),
           'Values alongside a $ref will be ignored.',
-          config.$ref_siblings
+          config.$ref_siblings,
+          '$ref_siblings'
         );
       }
     });

--- a/src/plugins/validation/oas3/semantic-validators/dummy-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/dummy-ibm.js
@@ -4,7 +4,7 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 
 module.exports.validate = function({ jsSpec }, config) {
 
-  const messages = new MessageCarrier();
+  const messages = new MessageCarrier(config);
 
   // use the appropriate validation category object
   // ex) `config = config.operations` for the operations validator
@@ -23,9 +23,10 @@ module.exports.validate = function({ jsSpec }, config) {
 
 /*
   messages.addMessage(
-    path to error either as an array or string,
-    message about the error/warning,
-    config.custom_rule_name OR 'error' OR 'warning
+    path,
+    message,
+    config.custom_rule_name,
+    'custom_rule_name'
   )
 */
 

--- a/src/plugins/validation/oas3/semantic-validators/operations.js
+++ b/src/plugins/validation/oas3/semantic-validators/operations.js
@@ -41,7 +41,8 @@ module.exports.validate = function({ resolvedSpec, jsSpec }, config) {
           messages.addMessage(
             `paths.${pathName}.${opName}.requestBody`,
             'Request bodies MUST specify a `content` property',
-            config.no_request_body_content
+            config.no_request_body_content,
+            'no_request_body_content'
           );
         } else {
           // request body has content
@@ -80,7 +81,8 @@ module.exports.validate = function({ resolvedSpec, jsSpec }, config) {
             messages.addMessage(
               `paths.${pathName}.${opName}`,
               'Operations with non-form request bodies should set a name with the x-codegen-request-body-name annotation.',
-              config.no_request_body_name
+              config.no_request_body_name,
+              'no_request_body_name'
             );
           }
 
@@ -98,7 +100,8 @@ module.exports.validate = function({ resolvedSpec, jsSpec }, config) {
                   messages.addMessage(
                     p,
                     'JSON request/response bodies should not contain binary (type: string, format: binary) values.',
-                    binaryStringStatus
+                    binaryStringStatus,
+                    'json_or_param_binary_string'
                   );
                 }
               }

--- a/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
@@ -91,7 +91,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
       messages.addMessage(
         ['paths', path, 'get', 'parameters', limitParamIndex],
         'The limit parameter must be of type integer and optional with default and maximum values.',
-        checkStatus
+        checkStatus,
+        'pagination_style'
       );
     }
 
@@ -110,7 +111,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
         messages.addMessage(
           ['paths', path, 'get', 'parameters', offsetParamIndex],
           'The offset parameter must be of type integer and optional.',
-          checkStatus
+          checkStatus,
+          'pagination_style'
         );
       }
     }
@@ -134,7 +136,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
           `The ${
             startParam.name
           } parameter must be of type string and optional.`,
-          checkStatus
+          checkStatus,
+          'pagination_style'
         );
       }
     }
@@ -158,7 +161,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
       messages.addMessage(
         propertiesPath,
         `A paginated list operation must include a "limit" property in the response body schema.`,
-        checkStatus
+        checkStatus,
+        'pagination_style'
       );
     } else if (
       limitProp.type !== 'integer' ||
@@ -168,7 +172,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
       messages.addMessage(
         [...propertiesPath, 'limit'],
         `The "limit" property in the response body of a paginated list operation must be of type integer and required.`,
-        checkStatus
+        checkStatus,
+        'pagination_style'
       );
     }
 
@@ -180,7 +185,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
         messages.addMessage(
           propertiesPath,
           `A paginated list operation with an "offset" parameter must include an "offset" property in the response body schema.`,
-          checkStatus
+          checkStatus,
+          'pagination_style'
         );
       } else if (
         offsetProp.type !== 'integer' ||
@@ -190,7 +196,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
         messages.addMessage(
           [...propertiesPath, 'offset'],
           `The "offset" property in the response body of a paginated list operation must be of type integer and required.`,
-          checkStatus
+          checkStatus,
+          'pagination_style'
         );
       }
     }
@@ -203,7 +210,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
       messages.addMessage(
         propertiesPath,
         `A paginated list operation must include an array property whose name matches the final segment of the path.`,
-        checkStatus
+        checkStatus,
+        'pagination_style'
       );
     }
   }

--- a/src/plugins/validation/oas3/semantic-validators/parameters.js
+++ b/src/plugins/validation/oas3/semantic-validators/parameters.js
@@ -34,7 +34,8 @@ module.exports.validate = function({ jsSpec }, config) {
         messages.addMessage(
           path,
           'Parameters MUST have an `in` property.',
-          config.no_in_property
+          config.no_in_property,
+          'no_in_property'
         );
       } else if (!allowedInValues.includes(obj.in)) {
         // bad because `in` must be one of a few values
@@ -43,7 +44,8 @@ module.exports.validate = function({ jsSpec }, config) {
           `Unsupported value for \`in\`: '${
             obj.in
           }'. Allowed values are ${allowedInValues.join(', ')}`,
-          config.invalid_in_property
+          config.invalid_in_property,
+          'invalid_in_property'
         );
       }
 
@@ -52,14 +54,16 @@ module.exports.validate = function({ jsSpec }, config) {
         messages.addMessage(
           path,
           'Parameters MUST have their data described by either `schema` or `content`.',
-          config.missing_schema_or_content
+          config.missing_schema_or_content,
+          'missing_schema_or_content'
         );
       } else if (obj.schema && obj.content) {
         // bad because only one is allowed to be used at a time
         messages.addMessage(
           path,
           'Parameters MUST NOT have both a `schema` and `content` property.',
-          config.has_schema_and_content
+          config.has_schema_and_content,
+          'has_schema_and_content'
         );
       }
 
@@ -91,7 +95,8 @@ module.exports.validate = function({ jsSpec }, config) {
           messages.addMessage(
             p,
             'Parameters should not contain binary (type: string, format: binary) values.',
-            binaryStringStatus
+            binaryStringStatus,
+            'json_or_param_binary_string'
           );
         }
       }

--- a/src/plugins/validation/oas3/semantic-validators/responses.js
+++ b/src/plugins/validation/oas3/semantic-validators/responses.js
@@ -47,7 +47,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
         messages.addMessage(
           path,
           'Each `responses` object MUST have at least one response code.',
-          config.no_response_codes
+          config.no_response_codes,
+          'no_response_codes'
         );
       } else {
         for (const statusCode of statusCodes) {
@@ -63,7 +64,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
             messages.addMessage(
               path.concat(['422']),
               'Should use status code 400 instead of 422 for invalid request payloads.',
-              config.ibm_status_code_guidelines
+              config.ibm_status_code_guidelines,
+              'ibm_status_code_guidelines'
             );
           } else if (statusCode === '302') {
             messages.addMessage(
@@ -142,7 +144,8 @@ function validateNoBinaryStringsInResponse(
             messages.addMessage(
               p,
               'JSON request/response bodies should not contain binary (type: string, format: binary) values.',
-              binaryStringStatus
+              binaryStringStatus,
+              'json_or_param_binary_string'
             );
           }
         }

--- a/src/plugins/validation/swagger2/semantic-validators/dummy-ibm.js
+++ b/src/plugins/validation/swagger2/semantic-validators/dummy-ibm.js
@@ -4,7 +4,7 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 
 module.exports.validate = function({ jsSpec }, config) {
 
-  const messages = new MessageCarrier();
+  const messages = new MessageCarrier(config);
 
   // use the appropriate validation category object
   // ex) `config = config.operations` for the operations validator
@@ -22,13 +22,12 @@ module.exports.validate = function({ jsSpec }, config) {
   // error pushing format:
 
 /*
-  let checkStatus = config.custom_rule_name
-  if (checkStatus !== "off") {
-    result[checkStatus].push({
-      path: "path to error, either as an array or a string",
-      message: "message about the error/warning"
-    })
-  }
+  messages.addMessage(
+    path,
+    message,
+    config.custom_rule_name,
+    'custom_rule_name'
+  )
 */
 
   return messages;

--- a/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
+++ b/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
@@ -73,7 +73,8 @@ module.exports.validate = function({ jsSpec }, config) {
           messages.addMessage(
             `paths.${pathKey}.${opKey}.consumes`,
             'PUT and POST operations with a body parameter must have a non-empty `consumes` field.',
-            config.no_consumes_for_put_or_post
+            config.no_consumes_for_put_or_post,
+            'no_consumes_for_put_or_post'
           );
         }
       }
@@ -99,7 +100,8 @@ module.exports.validate = function({ jsSpec }, config) {
           messages.addMessage(
             `paths.${pathKey}.${opKey}.produces`,
             'Operations must have a non-empty `produces` field.',
-            config.no_produces
+            config.no_produces,
+            'no_produces'
           );
         }
       }
@@ -111,7 +113,8 @@ module.exports.validate = function({ jsSpec }, config) {
           messages.addMessage(
             `paths.${pathKey}.${opKey}.consumes`,
             'GET operations should not specify a consumes field.',
-            config.get_op_has_consumes
+            config.get_op_has_consumes,
+            'get_op_has_consumes'
           );
         }
       }

--- a/src/spectral/utils/spectral-validator.js
+++ b/src/spectral/utils/spectral-validator.js
@@ -28,16 +28,16 @@ const parseResults = function(results, debug) {
         if (typeof severity === 'number' && code && message && path) {
           if (severity === 0) {
             // error
-            messages.addMessage(path, message, 'error');
+            messages.addMessage(path, message, 'error', code);
           } else if (severity === 1) {
             // warning
-            messages.addMessage(path, message, 'warning');
+            messages.addMessage(path, message, 'warning', code);
           } else if (severity === 2) {
             // info
-            messages.addMessage(path, message, 'info');
+            messages.addMessage(path, message, 'info', code);
           } else if (severity === 3) {
             // hint
-            messages.addMessage(path, message, 'hint');
+            messages.addMessage(path, message, 'hint', code);
           }
         } else {
           if (debug) {

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -2,6 +2,8 @@ const commandLineValidator = require('../../../src/cli-validator/runValidator');
 const inCodeValidator = require('../../../src/lib');
 const swaggerInMemory = require('../mockFiles/err-warn-in-memory');
 const { getCapturedText } = require('../../test-utils');
+const yaml = require('js-yaml');
+const fs = require('fs');
 
 describe('cli tool - test expected output - Swagger 2', function() {
   let consoleSpy;
@@ -54,6 +56,45 @@ describe('cli tool - test expected output - Swagger 2', function() {
 
     expect(whichProblems[0]).toEqual('errors');
     expect(whichProblems[1]).toEqual('warnings');
+  });
+
+  it('should print the associated rule with each error and warning', async function() {
+    const capturedText = [];
+
+    const unhookIntercept = intercept(function(txt) {
+      capturedText.push(txt);
+      return '';
+    });
+
+    const program = {};
+    program.args = ['./test/cli-validator/mockFiles/errAndWarn.yaml'];
+    program.default_mode = true;
+    program.print_rule_names = true;
+
+    const exitCode = await commandLineValidator(program);
+    unhookIntercept();
+
+    expect(exitCode).toEqual(1);
+
+    let ruleCount = 0;
+    capturedText.forEach(function(line) {
+      if (line.includes('Rule    :')) {
+        ruleCount++;
+      }
+    });
+
+    const defaultProgram = {};
+    defaultProgram.args = ['./test/cli-validator/mockFiles/errAndWarn.yaml'];
+    defaultProgram.default_mode = true;
+
+    const errAndWarnInMemory = yaml.safeLoad(
+      fs.readFileSync('./test/cli-validator/mockFiles/errAndWarn.yaml')
+    );
+    const validationResults = await inCodeValidator(errAndWarnInMemory, true);
+
+    expect(ruleCount).toEqual(
+      validationResults.errors.length + validationResults.warnings.length
+    );
   });
 
   it('should print the correct line numbers for each error/warning', async function() {

--- a/test/plugins/utils/message-carrier.test.js
+++ b/test/plugins/utils/message-carrier.test.js
@@ -11,11 +11,13 @@ describe('MessageCarrier tests', function() {
     expect(messages.errors.length).toEqual(2);
     expect(messages.errors[0]).toEqual({
       path: ['paths', '/example', 'get'],
-      message: 'message1'
+      message: 'message1',
+      rule: 'builtin'
     });
     expect(messages.errors[1]).toEqual({
       path: ['paths', '/example', 'post'],
-      message: 'message2'
+      message: 'message2',
+      rule: 'builtin'
     });
   });
 
@@ -28,11 +30,13 @@ describe('MessageCarrier tests', function() {
     expect(messages.warnings.length).toEqual(2);
     expect(messages.warnings[0]).toEqual({
       path: 'paths./example.get',
-      message: 'message1'
+      message: 'message1',
+      rule: 'builtin'
     });
     expect(messages.warnings[1]).toEqual({
       path: 'paths./example.post',
-      message: 'message2'
+      message: 'message2',
+      rule: 'builtin'
     });
   });
 
@@ -51,12 +55,14 @@ describe('MessageCarrier tests', function() {
     expect(messageDict.error.length).toEqual(2);
     expect(messageDict.error[0]).toEqual({
       path: ['paths', '/example', 'get'],
-      message: 'message1'
+      message: 'message1',
+      rule: 'builtin'
     });
     expect(messageDict.warning.length).toEqual(1);
     expect(messageDict.warning[0]).toEqual({
       path: 'paths./example.get.requestBody',
-      message: 'message3'
+      message: 'message3',
+      rule: 'builtin'
     });
   });
 
@@ -111,16 +117,15 @@ describe('MessageCarrier tests', function() {
     );
 
     expect(messages.errors.length).toEqual(2);
-    expect(messages.errors[0]).toEqual({
-      path: ['paths', '/example', 'get'],
-      message: 'message1',
-      authId: 'authId1'
-    });
-    expect(messages.errors[1]).toEqual({
-      path: ['paths', '/example', 'post'],
-      message: 'message2',
-      authId: 'authId2'
-    });
+    expect(messages.errors[0].path).toEqual(['paths', '/example', 'get']);
+    expect(messages.errors[0].message).toEqual('message1');
+    expect(messages.errors[0].authId).toEqual('authId1');
+    expect(messages.errors[0].rule).toEqual('builtin');
+
+    expect(messages.errors[1].path).toEqual(['paths', '/example', 'post']);
+    expect(messages.errors[1].message).toEqual('message2');
+    expect(messages.errors[1].authId).toEqual('authId2');
+    expect(messages.errors[1].rule).toEqual('builtin');
   });
 
   it('addMessageWithAuthId adds warnings and includes the authId in the warning', function() {
@@ -140,15 +145,62 @@ describe('MessageCarrier tests', function() {
     );
 
     expect(messages.warnings.length).toEqual(2);
+
+    expect(messages.warnings.length).toEqual(2);
+    expect(messages.warnings[0].path).toEqual(['paths', '/example', 'get']);
+    expect(messages.warnings[0].message).toEqual('message1');
+    expect(messages.warnings[0].authId).toEqual('authId1');
+    expect(messages.warnings[0].rule).toEqual('builtin');
+
+    expect(messages.warnings[1].path).toEqual(['paths', '/example', 'post']);
+    expect(messages.warnings[1].message).toEqual('message2');
+    expect(messages.warnings[1].authId).toEqual('authId2');
+    expect(messages.warnings[1].rule).toEqual('builtin');
+  });
+
+  it('providing addMessageWithAuthId a valid key in config should set rule to that key', function() {
+    const config = {
+      valid_rule: 'warning'
+    };
+
+    const messages = new MessageCarrier();
+
+    messages.addMessageWithAuthId(
+      ['paths', '/example', 'get'],
+      'message1',
+      'authId1',
+      config.valid_rule,
+      'valid_rule'
+    );
+    messages.addMessageWithAuthId(
+      ['paths', '/example', 'post'],
+      'message2',
+      'authId2',
+      config.valid_rule,
+      'valid_rule'
+    );
+
+    expect(messages.warnings.length).toEqual(2);
+    expect(messages.warnings[0].path).toEqual(['paths', '/example', 'get']);
+    expect(messages.warnings[0].message).toEqual('message1');
+    expect(messages.warnings[0].authId).toEqual('authId1');
+    expect(messages.warnings[0].rule).toEqual('valid_rule');
+
+    expect(messages.warnings[1].path).toEqual(['paths', '/example', 'post']);
+    expect(messages.warnings[1].message).toEqual('message2');
+    expect(messages.warnings[1].authId).toEqual('authId2');
+    expect(messages.warnings[1].rule).toEqual('valid_rule');
     expect(messages.warnings[0]).toEqual({
       path: ['paths', '/example', 'get'],
       message: 'message1',
-      authId: 'authId1'
+      authId: 'authId1',
+      rule: 'valid_rule'
     });
     expect(messages.warnings[1]).toEqual({
       path: ['paths', '/example', 'post'],
       message: 'message2',
-      authId: 'authId2'
+      authId: 'authId2',
+      rule: 'valid_rule'
     });
   });
 });

--- a/test/plugins/validation/2and3/paths-ibm.test.js
+++ b/test/plugins/validation/2and3/paths-ibm.test.js
@@ -273,9 +273,10 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.errors[0].message).toEqual(
       'Path parameter must be defined at the path or the operation level: id.'
     );
-    expect(res.errors[0].path).toEqual(
-      ['paths', '/cool_path/{id}/more_path/{other_param}']
-    );
+    expect(res.errors[0].path).toEqual([
+      'paths',
+      '/cool_path/{id}/more_path/{other_param}'
+    ]);
   });
 
   it('should flag a path segment that is not snake_case but should ignore path parameter', function() {

--- a/test/plugins/validation/2and3/paths-ibm.test.js
+++ b/test/plugins/validation/2and3/paths-ibm.test.js
@@ -239,14 +239,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
     };
 
     const res = validate({ resolvedSpec: spec }, config);
-    expect(res.errors).toEqual([
-      {
-        message:
-          'Path parameter must be defined at the path or the operation level: id.',
-        path: ['paths', '/cool_path/{id}']
-      }
-    ]);
-    expect(res.warnings).toEqual([]);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].message).toEqual(
+      'Path parameter must be defined at the path or the operation level: id.'
+    );
+    expect(res.errors[0].path).toEqual(['paths', '/cool_path/{id}']);
   });
 
   it('should return one problem for an undefined declared path parameter', function() {
@@ -272,14 +269,13 @@ describe('validation plugin - semantic - paths-ibm', function() {
     };
 
     const res = validate({ resolvedSpec: spec }, config);
-    expect(res.errors).toEqual([
-      {
-        message:
-          'Path parameter must be defined at the path or the operation level: id.',
-        path: ['paths', '/cool_path/{id}/more_path/{other_param}']
-      }
-    ]);
-    expect(res.warnings).toEqual([]);
+    expect(res.errors.length).toEqual(1);
+    expect(res.errors[0].message).toEqual(
+      'Path parameter must be defined at the path or the operation level: id.'
+    );
+    expect(res.errors[0].path).toEqual(
+      ['paths', '/cool_path/{id}/more_path/{other_param}']
+    );
   });
 
   it('should flag a path segment that is not snake_case but should ignore path parameter', function() {

--- a/test/plugins/validation/2and3/paths.test.js
+++ b/test/plugins/validation/2and3/paths.test.js
@@ -35,357 +35,345 @@ describe('validation plugin - semantic - paths', function() {
       };
 
       const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Empty path parameter declarations are not valid',
-          path: 'paths./CoolPath/{}'
-        }
-      ]);
-      expect(res.warnings).toEqual([]);
-    });
-  });
-
-  describe('Path strings must be equivalently different', () => {
-    it('should return one problem for an equivalent templated path strings', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              }
-            ]
-          },
-          '/CoolPath/{count}': {
-            parameters: [
-              {
-                name: 'count',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Equivalent paths are not allowed.',
-          path: 'paths./CoolPath/{count}'
-        }
-      ]);
-      expect(res.warnings).toEqual([]);
+      expect(res.errors.length).toEqual(1);
+      expect(res.errors[0].message).toEqual(
+        'Empty path parameter declarations are not valid'
+      );
+      expect(res.errors[0].path).toEqual('paths./CoolPath/{}');
     });
 
-    it('should return no problems for a templated and untemplated pair of path strings', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/': {},
-          '/CoolPath/{count}': {
-            parameters: [
-              {
-                name: 'count',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([]);
-      expect(res.warnings).toEqual([]);
-    });
-
-    it('should return no problems for a templated and double-templated set of path strings', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{group_id}/all': {
-            parameters: [
-              {
-                name: 'group_id',
-                in: 'path'
-              }
-            ]
-          },
-          '/CoolPath/{group_id}/{user_id}': {
-            parameters: [
-              {
-                name: 'group_id',
-                in: 'path'
-              },
-              {
-                name: 'user_id',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([]);
-      expect(res.warnings).toEqual([]);
-    });
-  });
-
-  describe('Paths must have unique name + in parameters', () => {
-    it('should return one problem for an name + in collision', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              }
-            ]
-          },
-          '/CoolPath/{count}': {
-            parameters: [
-              {
-                name: 'count',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Equivalent paths are not allowed.',
-          path: 'paths./CoolPath/{count}'
-        }
-      ]);
-      expect(res.warnings).toEqual([]);
-    });
-
-    it('should return no problems for an name collision only', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              },
-              {
-                name: 'id',
-                in: 'query'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([]);
-      expect(res.warnings).toEqual([]);
-    });
-
-    it("should return no problems when 'in' is not defined", function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              },
-              {
-                name: 'id'
-                // in: "path"
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([]);
-      expect(res.warnings).toEqual([]);
-    });
-  });
-
-  describe('Paths cannot have partial templates', () => {
-    it('should return one problem for an illegal partial path template', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/user{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Partial path templating is not allowed.',
-          path: 'paths./CoolPath/user{id}'
-        }
-      ]);
-      expect(res.warnings).toEqual([]);
-    });
-
-    it('should return no problems for a correct path template', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([]);
-      expect(res.warnings).toEqual([]);
-    });
-  });
-
-  describe('Paths cannot have query strings in them', () => {
-    it("should return one problem for an stray '?' in a path string", function() {
-      const spec = {
-        paths: {
-          '/report?': {}
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Query strings in paths are not allowed.',
-          path: 'paths./report?'
-        }
-      ]);
-      expect(res.warnings).toEqual([]);
-    });
-
-    it('should return no problems for a correct path template', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([]);
-      expect(res.warnings).toEqual([]);
-    });
-  });
-
-  describe('Integrations', () => {
-    it('should return two problems for an illegal query string in a path string', function() {
-      const spec = {
-        paths: {
-          '/report?rdate={relative_date}': {
-            parameters: [
-              {
-                name: 'relative_date',
-                in: 'path'
-              }
-            ]
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Partial path templating is not allowed.',
-          path: 'paths./report?rdate={relative_date}'
-        },
-        {
-          message: 'Query strings in paths are not allowed.',
-          path: 'paths./report?rdate={relative_date}'
-        }
-      ]);
-      expect(res.warnings).toEqual([]);
-    });
-
-    it.skip('should return two problems for an equivalent path string missing a parameter definition', function() {
-      const spec = {
-        paths: {
-          '/CoolPath/{id}': {
-            parameters: [
-              {
-                name: 'id',
-                in: 'path'
-              }
-            ]
-          },
-          '/CoolPath/{count}': {}
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Equivalent paths are not allowed.',
-          path: 'paths./CoolPath/{count}'
-        },
-        {
-          message:
-            'Declared path parameter "count" needs to be defined as a path parameter at either the path or operation level',
-          path: 'paths./CoolPath/{count}'
-        }
-      ]);
-      expect(res.warnings).toEqual([]);
-    });
-  });
-
-  it('should not crash when `parameters` is not an array', function() {
-    const spec = {
-      paths: {
-        '/resource': {
-          get: {
-            operationId: 'listResources',
-            description: 'operation with bad parameters...',
-            summary: '...but it should not crash the code',
-            parameters: {
-              allOf: [
+    describe('Path strings must be equivalently different', () => {
+      it('should return one problem for an equivalent templated path strings', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              parameters: [
                 {
-                  name: 'one',
-                  type: 'string'
-                },
-                {
-                  name: 'two',
-                  type: 'string'
+                  name: 'id',
+                  in: 'path'
                 }
               ]
             },
-            responses: {
-              '200': {
-                description: 'response'
+            '/CoolPath/{count}': {
+              parameters: [
+                {
+                  name: 'count',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors[0].message).toEqual(
+          'Equivalent paths are not allowed.'
+        );
+        expect(res.errors[0].path).toEqual('paths./CoolPath/{count}');
+      });
+
+      it('should return no problems for a templated and untemplated pair of path strings', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/': {},
+            '/CoolPath/{count}': {
+              parameters: [
+                {
+                  name: 'count',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(0);
+      });
+
+      it('should return no problems for a templated and double-templated set of path strings', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{group_id}/all': {
+              parameters: [
+                {
+                  name: 'group_id',
+                  in: 'path'
+                }
+              ]
+            },
+            '/CoolPath/{group_id}/{user_id}': {
+              parameters: [
+                {
+                  name: 'group_id',
+                  in: 'path'
+                },
+                {
+                  name: 'user_id',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(0);
+      });
+    });
+
+    describe('Paths must have unique name + in parameters', () => {
+      it('should return one problem for an name + in collision', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path'
+                }
+              ]
+            },
+            '/CoolPath/{count}': {
+              parameters: [
+                {
+                  name: 'count',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'Equivalent paths are not allowed.'
+        );
+        expect(res.errors[0].path).toEqual('paths./CoolPath/{count}');
+      });
+
+      it('should return no problems for an name collision only', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path'
+                },
+                {
+                  name: 'id',
+                  in: 'query'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(0);
+      });
+
+      it("should return no problems when 'in' is not defined", function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path'
+                },
+                {
+                  name: 'id'
+                  // in: "path"
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(0);
+      });
+    });
+
+    describe('Paths cannot have partial templates', () => {
+      it('should return one problem for an illegal partial path template', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/user{id}': {
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'Partial path templating is not allowed.'
+        );
+        expect(res.errors[0].path).toEqual('paths./CoolPath/user{id}');
+      });
+
+      it('should return no problems for a correct path template', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(0);
+      });
+    });
+
+    describe('Paths cannot have query strings in them', () => {
+      it("should return one problem for an stray '?' in a path string", function() {
+        const spec = {
+          paths: {
+            '/report?': {}
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'Query strings in paths are not allowed.'
+        );
+        expect(res.errors[0].path).toEqual('paths./report?');
+      });
+
+      it('should return no problems for a correct path template', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(0);
+      });
+    });
+
+    describe('Integrations', () => {
+      it('should return two problems for an illegal query string in a path string', function() {
+        const spec = {
+          paths: {
+            '/report?rdate={relative_date}': {
+              parameters: [
+                {
+                  name: 'relative_date',
+                  in: 'path'
+                }
+              ]
+            }
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(2);
+        expect(res.errors[0].message).toEqual(
+          'Partial path templating is not allowed.'
+        );
+        expect(res.errors[0].path).toEqual(
+          'paths./report?rdate={relative_date}'
+        );
+        expect(res.errors[1].message).toEqual(
+          'Query strings in paths are not allowed.'
+        );
+        expect(res.errors[1].path).toEqual(
+          'paths./report?rdate={relative_date}'
+        );
+      });
+
+      it.skip('should return two problems for an equivalent path string missing a parameter definition', function() {
+        const spec = {
+          paths: {
+            '/CoolPath/{id}': {
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path'
+                }
+              ]
+            },
+            '/CoolPath/{count}': {}
+          }
+        };
+
+        const res = validate({ resolvedSpec: spec });
+        expect(res.errors.length).toEqual(2);
+        expect(res.errors[0].message).toEqual(
+          'Equivalent paths are not allowed.'
+        );
+        expect(res.errors[0].path).toEqual('paths./CoolPath/{count}');
+        expect(res.errors[1].message).toEqual(
+          'Declared path parameter "count" needs to be defined as a path parameter at either the path or operation level'
+        );
+        expect(res.errors[1].path).toEqual('paths./CoolPath/{count}');
+      });
+    });
+
+    it('should not crash when `parameters` is not an array', function() {
+      const spec = {
+        paths: {
+          '/resource': {
+            get: {
+              operationId: 'listResources',
+              description: 'operation with bad parameters...',
+              summary: '...but it should not crash the code',
+              parameters: {
+                allOf: [
+                  {
+                    name: 'one',
+                    type: 'string'
+                  },
+                  {
+                    name: 'two',
+                    type: 'string'
+                  }
+                ]
+              },
+              responses: {
+                '200': {
+                  description: 'response'
+                }
               }
             }
           }
         }
-      }
-    };
+      };
 
-    const res = validate({ resolvedSpec: spec });
-    // errors/warnings would be caught it parameters-ibm.js
-    expect(res.errors.length).toBe(0);
-    expect(res.warnings.length).toBe(0);
+      const res = validate({ resolvedSpec: spec });
+      // errors/warnings would be caught it parameters-ibm.js
+      expect(res.errors.length).toBe(0);
+      expect(res.warnings.length).toBe(0);
+    });
   });
 });

--- a/test/plugins/validation/swagger2/form-data.test.js
+++ b/test/plugins/validation/swagger2/form-data.test.js
@@ -34,13 +34,11 @@ describe('validation plugin - semantic - form data', function() {
         };
 
         const res = validate({ resolvedSpec: spec });
-        expect(res.errors).toEqual([
-          {
-            message:
-              'The form data value for `in` must be camelCase (formData)',
-            path: 'parameters.CoolParam.0'
-          }
-        ]);
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'The form data value for `in` must be camelCase (formData)'
+        );
+        expect(res.errors[0].path).toEqual('parameters.CoolParam.0');
       });
     });
   });
@@ -59,13 +57,11 @@ describe('validation plugin - semantic - form data', function() {
         };
 
         const res = validate({ resolvedSpec: spec });
-        expect(res.errors).toEqual([
-          {
-            message:
-              'The form data value for `in` must be camelCase (formData)',
-            path: 'paths./some.post.parameters.0'
-          }
-        ]);
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'The form data value for `in` must be camelCase (formData)'
+        );
+        expect(res.errors[0].path).toEqual('paths./some.post.parameters.0');
       });
     });
     // Already covered in validators/operations.js
@@ -86,13 +82,11 @@ describe('validation plugin - semantic - form data', function() {
         };
 
         const res = validate({ resolvedSpec: spec });
-        expect(res.errors).toEqual([
-          {
-            message:
-              'Parameters cannot have `in` values of both "body" and "formData", as "formData" _will_ be the body',
-            path: 'paths./some.post.parameters.1'
-          }
-        ]);
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'Parameters cannot have `in` values of both "body" and "formData", as "formData" _will_ be the body'
+        );
+        expect(res.errors[0].path).toEqual('paths./some.post.parameters.1');
       });
     });
 
@@ -114,13 +108,11 @@ describe('validation plugin - semantic - form data', function() {
         };
 
         const res = validate({ resolvedSpec: spec });
-        expect(res.errors).toEqual([
-          {
-            message:
-              'Parameters with `type` "file" must have `in` be "formData"',
-            path: 'paths./some.post.parameters.0'
-          }
-        ]);
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'Parameters with `type` "file" must have `in` be "formData"'
+        );
+        expect(res.errors[0].path).toEqual('paths./some.post.parameters.0');
       });
 
       it("should complain if 'type:file` and no consumes - 'multipart/form-data'", function() {
@@ -140,13 +132,11 @@ describe('validation plugin - semantic - form data', function() {
         };
 
         const res = validate({ resolvedSpec: spec });
-        expect(res.errors).toEqual([
-          {
-            message:
-              'Operations with Parameters of `type` "file" must include "multipart/form-data" in their "consumes" property',
-            path: 'paths./some.post.parameters.0'
-          }
-        ]);
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'Operations with Parameters of `type` "file" must include "multipart/form-data" in their "consumes" property'
+        );
+        expect(res.errors[0].path).toEqual('paths./some.post.parameters.0');
       });
 
       it("should complain if 'in:formData` and no consumes - 'multipart/form-data' or 'application/x-www-form-urlencoded'", function() {
@@ -165,13 +155,11 @@ describe('validation plugin - semantic - form data', function() {
         };
 
         const res = validate({ resolvedSpec: spec });
-        expect(res.errors).toEqual([
-          {
-            message:
-              'Operations with Parameters of `in` "formData" must include "application/x-www-form-urlencoded" or "multipart/form-data" in their "consumes" property',
-            path: 'paths./some.post'
-          }
-        ]);
+        expect(res.errors.length).toEqual(1);
+        expect(res.errors[0].message).toEqual(
+          'Operations with Parameters of `in` "formData" must include "application/x-www-form-urlencoded" or "multipart/form-data" in their "consumes" property'
+        );
+        expect(res.errors[0].path).toEqual('paths./some.post');
       });
     });
   });
@@ -188,14 +176,13 @@ describe('validation plugin - semantic - form data', function() {
       };
 
       const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message:
-            'Parameters cannot have `in` values of both "body" and "formData", as "formData" _will_ be the body',
-          path: 'pathitems.CoolPathItem.parameters.1'
-        }
-      ]);
+      expect(res.errors.length).toEqual(1);
+      expect(res.errors[0].message).toEqual(
+        'Parameters cannot have `in` values of both "body" and "formData", as "formData" _will_ be the body'
+      );
+      expect(res.errors[0].path).toEqual('pathitems.CoolPathItem.parameters.1');
     });
+
     it("should complain if 'type:file` and no 'in: formData", function() {
       const spec = {
         pathitems: {
@@ -211,12 +198,11 @@ describe('validation plugin - semantic - form data', function() {
       };
 
       const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message: 'Parameters with `type` "file" must have `in` be "formData"',
-          path: 'pathitems.SomePathItem.parameters.0'
-        }
-      ]);
+      expect(res.errors.length).toEqual(1);
+      expect(res.errors[0].message).toEqual(
+        'Parameters with `type` "file" must have `in` be "formData"'
+      );
+      expect(res.errors[0].path).toEqual('pathitems.SomePathItem.parameters.0');
     });
 
     it("should complain if 'type:file` and no consumes - 'multipart/form-data'", function() {
@@ -234,13 +220,11 @@ describe('validation plugin - semantic - form data', function() {
       };
 
       const res = validate({ resolvedSpec: spec });
-      expect(res.errors).toEqual([
-        {
-          message:
-            'Operations with Parameters of `type` "file" must include "multipart/form-data" in their "consumes" property',
-          path: 'pathitems.SomePathItem.parameters.0'
-        }
-      ]);
+      expect(res.errors.length).toEqual(1);
+      expect(res.errors[0].message).toEqual(
+        'Operations with Parameters of `type` "file" must include "multipart/form-data" in their "consumes" property'
+      );
+      expect(res.errors[0].path).toEqual('pathitems.SomePathItem.parameters.0');
     });
   });
 });


### PR DESCRIPTION
This PR adds the ability to display the associated rule name for each issue reported by the validator.  Since this makes the already lengthy output longer, this feature must be enabled with a command line option.  I chose to use the `verbose` option, but this does come at some cost -- namely that the `-v` that previously was an alias of `--version` is now aliased to `--verbose`.  Note that `--version` is still supported and works as previously.

The bulk of the content in this PR was originally developed by @barrett-schonefeld and submitted in PR #147 way back in February.  I just had to make a few changes, add some tests, and update the README.