### PR TITLE
chore: asoc configuration

### DIFF
--- a/appscan-config.xml
+++ b/appscan-config.xml
@@ -1,0 +1,7 @@
+<Configuration>
+  <Targets>
+    <Target path=".">
+      <Exclude>test/</Exclude>
+    </Target>
+  </Targets>
+</Configuration>


### PR DESCRIPTION
This PR excludes the `test` directory from the AppScan code scanning tool.