### PR TITLE
chore: decrease severity of valid schema/content example validation

### DIFF
--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -120,15 +120,14 @@ const defaults = {
       'oas2-api-host': "warning",
       'oas2-api-schemes': "warning",
       'oas2-host-trailing-slash': "warning",
-      'oas2-valid-example': "warning",
-      'oas2-valid-definition-example': "error",
+      'oas2-valid-definition-example': "warning",
       'oas2-anyOf': "warning",
       'oas2-oneOf': "warning",
       'oas3-api-servers': "warning",
       'oas3-examples-value-or-externalValue': "warning",
       'oas3-server-trailing-slash': "warning",
-      'oas3-valid-example': "error",
-      'oas3-valid-schema-example': "error"
+      'oas3-valid-oas-content-example': "warning",
+      'oas3-valid-schema-example': "warning"
     }
   }
 };

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -54,8 +54,8 @@ rules:
   oas2-operation-security-defined: off
   # Turn off
   oas2-valid-parameter-example: off
-  # Enable with same severity as Spectral
-  oas2-valid-definition-example: true
+  # Enable with warn severity
+  oas2-valid-definition-example: warn
   # Turn off
   oas2-valid-response-example: off
   # Turn off
@@ -80,14 +80,14 @@ rules:
   oas3-valid-oas-parameter-example: off
   # Turn off
   oas3-valid-oas-header-example: off
-  # Turn off
-  oas3-valid-oas-content-example: off
+  # Enable with warn severity
+  oas3-valid-oas-content-example: warn
   # Turn off
   oas3-valid-parameter-schema-example: off
   # Turn off
   oas3-valid-header-schema-example: off
-  # Enable with same severity as Spectral
-  oas3-valid-schema-example: true
+  # Enable with warn severity
+  oas3-valid-schema-example: warn
   # Turn off
   oas3-schema: off
   # Turn off - duplicates non-configurable validation in base validator

--- a/test/spectral/mockFiles/oas3/enabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/enabled-rules.yml
@@ -58,6 +58,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TheBadModel'
+            example:
+              number_of_connectors: 3
       responses:
         204:
           description: "Success"

--- a/test/spectral/tests/enabled-rules.test.js
+++ b/test/spectral/tests/enabled-rules.test.js
@@ -30,8 +30,8 @@ describe('spectral - test enabled rules - Swagger 2', function() {
         foundOtherValidator = true;
       }
     });
-    // Since some spectral validations will result in errors, the exit code should equal 1
-    expect(exitCode).toEqual(1);
+
+    expect(exitCode).toEqual(0);
     expect(foundOtherValidator).toBe(false);
 
     consoleSpy.mockRestore();
@@ -124,14 +124,12 @@ describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
       defaultMode
     );
 
-    // should produce an object with `errors` and `warnings` keys that should
-    // both be non-empty
-    expect(validationResults.errors.length).toBeGreaterThan(0);
+    expect(validationResults.errors.length).toEqual(0);
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
     errors = validationResults.errors.map(error => error.message);
     warnings = validationResults.warnings.map(warn => warn.message);
-    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.length).toEqual(0);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
@@ -219,11 +217,11 @@ describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test oas2-valid-example rule using mockFiles/swagger/enabled-rules-in-memory', function() {
-    expect(errors).toContain(
+  it('test oas2-valid-definition-example rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+    expect(errors).not.toContain(
       '`number_of_coins` property type should be integer'
     );
-    expect(warnings).not.toContain(
+    expect(warnings).toContain(
       '`number_of_coins` property type should be integer'
     );
   });
@@ -273,8 +271,8 @@ describe('spectral - test enabled rules - OAS3', function() {
         foundOtherValidator = true;
       }
     });
-    // Since some spectral validations will result in errors, the exit code should equal 1
-    expect(exitCode).toEqual(1);
+
+    expect(exitCode).toEqual(0);
     expect(foundOtherValidator).toBe(false);
 
     consoleSpy.mockRestore();
@@ -336,9 +334,15 @@ describe('spectral - test enabled rules - OAS3', function() {
     );
   });
 
-  it('test oas3-valid-example rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test oas3-valid-schema-example rule using mockFiles/oas3/enabled-rules.yml', function() {
     expect(allOutput).toContain(
       '`number_of_coins` property type should be integer'
+    );
+  });
+
+  it('test oas3-valid-oas-content-example rule using mockFiles/oas3/enabled-rules.yml', function() {
+    expect(allOutput).toContain(
+      '`number_of_connectors` property should be equal to one of the allowed values: 1, 2, a_string, 8'
     );
   });
 });
@@ -352,14 +356,13 @@ describe('spectral - test enabled rules - OAS3 In Memory', function() {
     const defaultMode = true;
     const validationResults = await inCodeValidator(oas3InMemory, defaultMode);
 
-    // should produce an object with `errors` and `warnings` keys that should
-    // both be non-empty
-    expect(validationResults.errors.length).toBeGreaterThan(0);
+    // should produce an object with an empty `errors` key and a non-empty `warnings` key
+    expect(validationResults.errors.length).toEqual(0);
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
     errors = validationResults.errors.map(error => error.message);
     warnings = validationResults.warnings.map(warn => warn.message);
-    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.length).toEqual(0);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
@@ -448,10 +451,10 @@ describe('spectral - test enabled rules - OAS3 In Memory', function() {
   });
 
   it('test oas3-valid-example rule using mockFiles/oas3/enabled-rules-in-memory', function() {
-    expect(errors).toContain(
+    expect(errors).not.toContain(
       '`number_of_coins` property type should be integer'
     );
-    expect(warnings).not.toContain(
+    expect(warnings).toContain(
       '`number_of_coins` property type should be integer'
     );
   });

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -94,7 +94,7 @@ describe('Spectral - test custom configuration', function() {
     );
 
     // Verify warnings
-    expect(jsonOutput['warnings']['spectral'].length).toBe(17);
+    expect(jsonOutput['warnings']['spectral'].length).toBe(18);
     const warnings = jsonOutput['warnings']['spectral'].map(w => w['message']);
     // This warning should be turned off
     expect(warnings).not.toContain(
@@ -135,18 +135,18 @@ describe('Spectral - test custom configuration', function() {
 
     consoleSpy.mockRestore();
 
-    // Verify errors
-    expect(jsonOutput['errors']['spectral'].length).toBe(2);
+    // Verify there are no errors
+    expect(jsonOutput['errors']['spectral']).toBeUndefined();
 
     // Verify warnings
-    expect(jsonOutput['warnings']['spectral'].length).toBe(21);
+    expect(jsonOutput['warnings']['spectral'].length).toBe(23);
     const warnings = jsonOutput['warnings']['spectral'].map(w => w['message']);
-    // This is the new warning -- there should be four occurrences
+    // This is the new warning -- there should be three occurrences
     const warning = 'All request bodies should have an example.';
     const occurrences = warnings.reduce(
       (a, v) => (v === warning ? a + 1 : a),
       0
     );
-    expect(occurrences).toBe(4);
+    expect(occurrences).toBe(3);
   });
 });


### PR DESCRIPTION
This PR changes the severity of the spectral rules ``oas2-valid-definition-example`` and ``oas3-valid-schema-example`` from ``error`` to ``warn``. The spectral rule ``oas3-valid-oas-content-example`` was also enabled with a ``warn`` severity, since the linked issue reported our validator was not reporting warnings in request or response body examples. 

The ``src/.defaultsForValidator.js`` file was also updated to match the values in our default spectral ruleset.

fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/2303