### PR TITLE
fix(function): Fix error when adding custom ignore names for inconsistent_property

### DIFF
--- a/src/cli-validator/utils/processConfiguration.js
+++ b/src/cli-validator/utils/processConfiguration.js
@@ -363,7 +363,7 @@ const validateConfigOption = function(userOption, defaultOption) {
       optionType = option;
     }
   });
-  // return directly if there is no matched optionType
+  // if optionType doesn't match, there are no predefined options for this rule
   if (!optionType) {
     return result;
   }

--- a/src/cli-validator/utils/processConfiguration.js
+++ b/src/cli-validator/utils/processConfiguration.js
@@ -363,6 +363,10 @@ const validateConfigOption = function(userOption, defaultOption) {
       optionType = option;
     }
   });
+  // return directly if there is no matched optionType
+  if (!optionType) {
+    return result;
+  }
   // verify the given option is valid
   const validOptions = configOptions[optionType];
   if (!validOptions.includes(userOption)) {

--- a/test/plugins/validation/2and3/schema-ibm.test.js
+++ b/test/plugins/validation/2and3/schema-ibm.test.js
@@ -1800,4 +1800,51 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
     expect(res.warnings.length).toEqual(0);
     expect(res.errors.length).toEqual(0);
   });
+
+  it('should not produce a warning for properties with duplicate custom names', () => {
+    const customConfig = {
+      schemas: {
+        inconsistent_property_type: ['warning', ['year']]
+      }
+    };
+
+    const spec = {
+      components: {
+        schemas: {
+          person: {
+            description: 'Produce warnings',
+            properties: {
+              year: {
+                description: 'type integer',
+                type: 'integer'
+              }
+            }
+          },
+          adult: {
+            description: 'Causes first warnings',
+            properties: {
+              year: {
+                description: 'different type',
+                type: 'number'
+              }
+            }
+          },
+          kid: {
+            description: 'Causes second warning',
+            properties: {
+              year: {
+                type: 'string',
+                description: 'differnt type'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, customConfig);
+
+    expect(res.warnings.length).toEqual(0);
+    expect(res.errors.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
After upgrading to 0.34.0, I want to use some custom ignore names for `inconsistent_property_type` such as:
```json
"schemas": {
  ...
  "inconsistent_property_type": ["warning", ["year"]],
  ...
}
```

But got an error:
```
TypeError: Cannot read property 'includes' of undefined
    at validateConfigOption (/usr/local/lib/node_modules/ibm-openapi-validator/src/cli-validator/utils/processConfiguration.js:369:21)
    at /usr/local/lib/node_modules/ibm-openapi-validator/src/cli-validator/utils/processConfiguration.js:118:28
    at Array.forEach (<anonymous>)
    at /usr/local/lib/node_modules/ibm-openapi-validator/src/cli-validator/utils/processConfiguration.js:76:17
    at Array.forEach (<anonymous>)
    at /usr/local/lib/node_modules/ibm-openapi-validator/src/cli-validator/utils/processConfiguration.js:63:20
    at Array.forEach (<anonymous>)
    at validateConfigObject (/usr/local/lib/node_modules/ibm-openapi-validator/src/cli-validator/utils/processConfiguration.js:46:13)
    at Object.getConfigObject [as get] (/usr/local/lib/node_modules/ibm-openapi-validator/src/cli-validator/utils/processConfiguration.js:235:20)
    at async processInput (/usr/local/lib/node_modules/ibm-openapi-validator/src/cli-validator/runValidator.js:145:20)
```

This sample change is to try to solve this problem, but I don't know if it's a good solution since I'm not very familiar with the whole project.