### PR TITLE
Add validation for use of 101 status code

### DIFF
--- a/src/.defaultsForValidator.js
+++ b/src/.defaultsForValidator.js
@@ -100,6 +100,7 @@ const defaults = {
     'responses': {
       'no_response_codes': 'error',
       'no_success_response_codes': 'warning',
+      'protocol_switching_and_success_code': 'error',
       'no_response_body': 'warning',
       'ibm_status_code_guidelines': 'warning'
     },

--- a/src/plugins/validation/oas3/semantic-validators/responses.js
+++ b/src/plugins/validation/oas3/semantic-validators/responses.js
@@ -77,12 +77,19 @@ module.exports.validate = function({ resolvedSpec }, config) {
           }
         }
         // validate all success codes
-        if (!successCodes.length) {
+        if (!successCodes.length && !("101" in obj)) {
           messages.addMessage(
             path,
             'Each `responses` object SHOULD have at least one code for a successful response.',
             config.no_success_response_codes,
             'no_success_response_codes'
+          );
+        } else if (successCodes.length && ("101" in obj)) {
+          messages.addMessage(
+            path,
+            'A `responses` object MUST NOT support 101 and any success (2xx) code.',
+            config.protocol_switching_and_success_code,
+            'protocol_switching_and_success_code'
           );
         } else {
           for (const statusCode of successCodes) {

--- a/src/plugins/validation/oas3/semantic-validators/responses.js
+++ b/src/plugins/validation/oas3/semantic-validators/responses.js
@@ -77,14 +77,14 @@ module.exports.validate = function({ resolvedSpec }, config) {
           }
         }
         // validate all success codes
-        if (!successCodes.length && !("101" in obj)) {
+        if (!successCodes.length && !('101' in obj)) {
           messages.addMessage(
             path,
             'Each `responses` object SHOULD have at least one code for a successful response.',
             config.no_success_response_codes,
             'no_success_response_codes'
           );
-        } else if (successCodes.length && ("101" in obj)) {
+        } else if (successCodes.length && '101' in obj) {
           messages.addMessage(
             path,
             'A `responses` object MUST NOT support 101 and any success (2xx) code.',

--- a/src/plugins/validation/oas3/semantic-validators/responses.js
+++ b/src/plugins/validation/oas3/semantic-validators/responses.js
@@ -84,14 +84,15 @@ module.exports.validate = function({ resolvedSpec }, config) {
             config.no_success_response_codes,
             'no_success_response_codes'
           );
-        } else if (successCodes.length && '101' in obj) {
-          messages.addMessage(
-            path,
-            'A `responses` object MUST NOT support 101 and any success (2xx) code.',
-            config.protocol_switching_and_success_code,
-            'protocol_switching_and_success_code'
-          );
         } else {
+          if (successCodes.length && '101' in obj) {
+            messages.addMessage(
+              path,
+              'A `responses` object MUST NOT support 101 and any success (2xx) code.',
+              config.protocol_switching_and_success_code,
+              'protocol_switching_and_success_code'
+            );
+          }
           for (const statusCode of successCodes) {
             if (statusCode !== '204' && !obj[statusCode].content) {
               messages.addMessage(

--- a/test/plugins/validation/oas3/responses.test.js
+++ b/test/plugins/validation/oas3/responses.test.js
@@ -626,7 +626,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     );
     expect(res.errors.length).toEqual(0);
   });
-  
+
   it('should not complain about having only a 101 response', function() {
     const spec = {
       paths: {
@@ -673,17 +673,12 @@ describe('validation plugin - semantic - responses - oas3', function() {
     const res = validate({ resolvedSpec: spec }, config);
     expect(res.warnings.length).toEqual(0);
     expect(res.errors.length).toEqual(1);
-    expect(res.errors[0].path).toEqual([
-      'paths',
-      '/pets',
-      'get',
-      'responses'
-    ]);
+    expect(res.errors[0].path).toEqual(['paths', '/pets', 'get', 'responses']);
     expect(res.errors[0].message).toEqual(
       'A `responses` object MUST NOT support 101 and any success (2xx) code.'
     );
   });
-  
+
   it('should complain about 204 response that defines a response body', function() {
     const spec = {
       paths: {


### PR DESCRIPTION
Currently `101` is not considered a success and therefore it's not valid for an operation to support `101` without also supporting a `2xx` code. In fact, we'd prefer to validate that `101` *MUST NOT* be used along with a `2xx` response code.