### PR TITLE
fix: update releaserc to use main branch

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branch": "main",
+  "branches": "main",
   "verifyConditions": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
   "prepare": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
   "publish": ["@semantic-release/npm", { "path": "@semantic-release/github" }]


### PR DESCRIPTION
The `semantic-release` API changed with its latest major release and now uses
"branches" instead of "branch" to specify which branch to release on.