### PR TITLE
refactor: use Spectral to validate `consumes` property with formData param

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ oas2-valid-example: true
 oas2-valid-definition-example: true
 oas2-anyOf: true
 oas2-oneOf: true
+oas2-operation-formData-consume-check: true
 oas3-api-servers: true
 oas3-examples-value-or-externalValue: true
 oas3-server-trailing-slash: true

--- a/src/plugins/validation/swagger2/semantic-validators/form-data.js
+++ b/src/plugins/validation/swagger2/semantic-validators/form-data.js
@@ -13,6 +13,7 @@
 
 // Assertation 3:
 // If a parameter with `in: formData` exists a consumes property ( inherited or inline ) my contain `application/x-www-form-urlencoded` or `multipart/form-data`
+// Assertation 3 checked with Spectral rule oas2-operation-formData-consume-check
 
 const isPlainObject = require('lodash/isPlainObject');
 const getIn = require('lodash/get');
@@ -50,7 +51,7 @@ module.exports.validate = function({ resolvedSpec }) {
 
       return (
         // assertationOne(obj, path)
-        assertationTwo(obj, path, opItem) || assertationThree(obj, path, opItem)
+        assertationTwo(obj, path, opItem)
       );
     }
 
@@ -160,32 +161,6 @@ module.exports.validate = function({ resolvedSpec }) {
     }
 
     return hasErrors;
-  }
-
-  // If a parameter with `in: formData` exists, a consumes property ( inherited or inline ) my contain `application/x-www-form-urlencoded` or `multipart/form-data`
-  function assertationThree(params, path, operation) {
-    const hasFormData = params.some(
-      p => isPlainObject(p) && p['in'] === 'formData'
-    );
-
-    if (!hasFormData) {
-      return;
-    }
-
-    if (
-      hasConsumes(operation, 'multipart/form-data') ||
-      hasConsumes(operation, 'application/x-www-form-urlencoded')
-    ) {
-      return;
-    }
-
-    const pathStr = path.slice(0, -1).join('.'); // Blame the operation, not the parameter0
-    messages.addMessage(
-      pathStr,
-      'Operations with Parameters of `in` "formData" must include "application/x-www-form-urlencoded" or "multipart/form-data" in their "consumes" property',
-      'error'
-    );
-    return;
   }
 
   walk(resolvedSpec, []);

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -6,8 +6,8 @@ rules:
 
   # Turn off -- duplicates no_success_response_codes
   operation-2xx-response: off
-  # Turn off - duplicates non-configurable validation - form-data.js
-  oas2-operation-formData-consume-check: off
+  # Enable with same severity as Spectral
+  oas2-operation-formData-consume-check: true
   # Enable with same severity as Spectral
   operation-operationId-unique: true
   # Turn off - duplicates non-configurable validation - operations-shared.js

--- a/test/plugins/validation/oas3/responses.test.js
+++ b/test/plugins/validation/oas3/responses.test.js
@@ -645,7 +645,6 @@ describe('validation plugin - semantic - responses - oas3', function() {
     };
 
     const res = validate({ resolvedSpec: spec }, config);
-    console.log(res.warnings);
     expect(res.warnings.length).toEqual(0);
     expect(res.errors.length).toEqual(0);
   });

--- a/test/plugins/validation/swagger2/form-data.test.js
+++ b/test/plugins/validation/swagger2/form-data.test.js
@@ -138,29 +138,6 @@ describe('validation plugin - semantic - form data', function() {
         );
         expect(res.errors[0].path).toEqual('paths./some.post.parameters.0');
       });
-
-      it("should complain if 'in:formData` and no consumes - 'multipart/form-data' or 'application/x-www-form-urlencoded'", function() {
-        const spec = {
-          paths: {
-            '/some': {
-              post: {
-                parameters: [
-                  {
-                    in: 'formData'
-                  }
-                ]
-              }
-            }
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec });
-        expect(res.errors.length).toEqual(1);
-        expect(res.errors[0].message).toEqual(
-          'Operations with Parameters of `in` "formData" must include "application/x-www-form-urlencoded" or "multipart/form-data" in their "consumes" property'
-        );
-        expect(res.errors[0].path).toEqual('paths./some.post');
-      });
     });
   });
 

--- a/test/spectral/mockFiles/swagger/disabled-rules.yml
+++ b/test/spectral/mockFiles/swagger/disabled-rules.yml
@@ -115,6 +115,7 @@ paths:
         - pet
       consumes:
       - "application/xml"
+      - "multipart/form-data"
       produces:
       - "application/xml"
       - "application/json"

--- a/test/spectral/mockFiles/swagger/enabled-rules.yml
+++ b/test/spectral/mockFiles/swagger/enabled-rules.yml
@@ -153,6 +153,33 @@ paths:
             $ref: '#/definitions/ModelWithOneOf'
         default:
           description: "Invalid input"
+  /path4:
+    post:
+      summary: "path four"
+      description: operation with form data
+      operationId: "form_data"
+      tags:
+        - pet
+      consumes:
+      # formData param, so consumes should include application/x-www-form-urlencoded or multipart/form-data
+      - "application/xml"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "formData"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          type: file
+      responses:
+        200:
+          description: "A paged array of pets"
+          schema:
+            $ref: '#/definitions/ModelWithOneOf'
+        default:
+          description: "Invalid input"
 definitions:
   TheBadModel:
     type: object

--- a/test/spectral/tests/disabled-rules.test.js
+++ b/test/spectral/tests/disabled-rules.test.js
@@ -324,15 +324,6 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test oas2-operation-formData-consume-check validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
-    expect(errors).not.toContain(
-      'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.'
-    );
-    expect(warnings).not.toContain(
-      'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.'
-    );
-  });
-
   it('test oas2-operation-security-defined validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
     expect(errors).not.toContain(
       'Operation `security` values must match a scheme defined in the `securityDefinitions` object.'

--- a/test/spectral/tests/enabled-rules.test.js
+++ b/test/spectral/tests/enabled-rules.test.js
@@ -243,6 +243,15 @@ describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
       'oneOf is not available in OpenAPI v2, it was added in OpenAPI v3'
     );
   });
+
+  it('test oas2-operation-formData-consume-check rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+    expect(errors).not.toContain(
+      'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.'
+    );
+    expect(warnings).toContain(
+      'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.'
+    );
+  });
 });
 
 describe('spectral - test enabled rules - OAS3', function() {

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -263,7 +263,7 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
     mockConfig.mockRestore();
   });
 
-  // There should be no errors and 2 warnings for a non-spectral rule
+  // There should be no errors, 2 warnings for a non-spectral rule
   it('test no spectral errors and no spectral warnings', function() {
     expect(validationResults.errors.length).toBe(0);
     expect(validationResults.warnings.length).toBe(2);


### PR DESCRIPTION
Addresses:
- Desire to simplify the validator ruleset by using an equivalent Spectral rule

Changes:
- Enable the oas2-operation-formData-consume-check Spectral rule
- Remove the in-code validation of this rule

Tests:
- Remove irrelevant disable-rules tests
- Remove irrelevant test for in-code validation of the `formData consumes` rule
- Update swagger/disable-rules.yml to remove the violation of the `formData consumes` rule
- Fix incongruities between swagger/disable-rules.yml and swagger/disable-rules-in-memory.js by loading swagger/disable-rules.yml into memory
- Add a test to enabled-rules.test to ensure the Spectral rule is enabled and produces a warning for rule violation