### PR TITLE
refactor: use Spectral to check for duplicate parameters

### DIFF
--- a/src/cli-validator/utils/buildSwaggerObject.js
+++ b/src/cli-validator/utils/buildSwaggerObject.js
@@ -37,7 +37,8 @@ module.exports = async function(input) {
   //   but without the $$ref tags (which are not used in the validations)
   const parser = new RefParser();
   parser.dereference.circular = false;
-  swagger.resolvedSpec = await parser.dereference(input);
+  // passes the parser a copy of the spec to keep the original spec intact
+  swagger.resolvedSpec = await parser.dereference(JSON.parse(swagger.specStr));
   swagger.circular = parser.$refs.circular;
 
   const version = getVersion(swagger.jsSpec);

--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -17,7 +17,6 @@
 const pick = require('lodash/pick');
 const map = require('lodash/map');
 const each = require('lodash/each');
-const findIndex = require('lodash/findIndex');
 const { checkCase, hasRefProperty } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
@@ -60,26 +59,6 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
           'error'
         );
       }
-
-      // check for unique name/in properties in params
-      each(op.parameters, (param, paramIndex) => {
-        const nameAndInComboIndex = findIndex(op.parameters, {
-          name: param.name,
-          in: param.in
-        });
-        // comparing the current index against the first found index is good, because
-        // it cuts down on error quantity when only two parameters are involved,
-        // i.e. if param1 and param2 conflict, this will only complain about param2.
-        // it also will favor complaining about parameters later in the spec, which
-        // makes more sense to the user.
-        if (paramIndex !== nameAndInComboIndex) {
-          messages.addMessage(
-            `paths.${pathKey}.${opKey}.parameters[${paramIndex}]`,
-            "Operation parameters must have unique 'name' + 'in' properties",
-            'error'
-          );
-        }
-      });
 
       // Arrays MUST NOT be returned as the top-level structure in a response body.
       const checkStatusArrRes = config.no_array_responses;

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -10,8 +10,8 @@ rules:
   oas2-operation-formData-consume-check: true
   # Enable with same severity as Spectral
   operation-operationId-unique: true
-  # Turn off - duplicates non-configurable validation - operations-shared.js
-  operation-parameters: off
+  # Enable with same severity as Spectral
+  operation-parameters: true
   # Enable with same severity as Spectral
   operation-tag-defined: true
   # Turn off - duplicates missing_path_parameter

--- a/test/plugins/validation/2and3/operations-shared.test.js
+++ b/test/plugins/validation/2and3/operations-shared.test.js
@@ -8,41 +8,6 @@ const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
 describe('validation plugin - semantic - operations-shared', function() {
   describe('Swagger 2', function() {
-    it('should complain about a non-unique (name + in combination) parameters', function() {
-      const spec = {
-        paths: {
-          '/': {
-            get: {
-              operationId: 'get_everything',
-              summary: 'this is a summary',
-              parameters: [
-                {
-                  name: 'test',
-                  in: 'query',
-                  description: 'just a test param',
-                  type: 'string'
-                },
-                {
-                  name: 'test',
-                  in: 'query',
-                  description: 'another test param',
-                  type: 'string'
-                }
-              ]
-            }
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec }, config);
-      expect(res.errors.length).toEqual(1);
-      expect(res.errors[0].path).toEqual('paths./.get.parameters[1]');
-      expect(res.errors[0].message).toEqual(
-        "Operation parameters must have unique 'name' + 'in' properties"
-      );
-      expect(res.warnings.length).toEqual(0);
-    });
-
     it('should complain about a missing operationId', function() {
       const spec = {
         paths: {
@@ -650,64 +615,6 @@ describe('validation plugin - semantic - operations-shared', function() {
   });
 
   describe('OpenAPI 3', function() {
-    it('should complain about a non-unique (name + in combination) parameters', async function() {
-      const spec = {
-        components: {
-          parameters: {
-            RefParam: {
-              name: 'test',
-              in: 'query',
-              description: 'referenced test param',
-              schema: {
-                type: 'string'
-              }
-            }
-          }
-        },
-        paths: {
-          '/': {
-            get: {
-              operationId: 'get_everything',
-              summary: 'this is a summary',
-              responses: {
-                default: {
-                  description: 'default response',
-                  'text/plain': {
-                    schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              },
-              parameters: [
-                {
-                  $ref: '#/components/parameters/RefParam'
-                },
-                {
-                  name: 'test',
-                  in: 'query',
-                  description: 'another test param',
-                  schema: {
-                    type: 'string'
-                  }
-                }
-              ]
-            }
-          }
-        }
-      };
-
-      const resolvedSpec = await resolver.dereference(spec);
-
-      const res = validate({ resolvedSpec, isOAS3: true }, config);
-      expect(res.errors.length).toEqual(1);
-      expect(res.errors[0].path).toEqual('paths./.get.parameters[1]');
-      expect(res.errors[0].message).toEqual(
-        "Operation parameters must have unique 'name' + 'in' properties"
-      );
-      expect(res.warnings.length).toEqual(0);
-    });
-
     it('should complain about a top-level array response', function() {
       const spec = {
         paths: {

--- a/test/spectral/mockFiles/oas3/disabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/disabled-rules.yml
@@ -127,11 +127,6 @@ paths:
         - name: pet_id
           in: path
           required: true
-          schema:
-            type: string
-        - name: pet_id
-          in: path
-          required: true
           description: The id of the pet to retrieve
           schema:
             type: string

--- a/test/spectral/mockFiles/oas3/enabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/enabled-rules.yml
@@ -45,6 +45,37 @@ paths:
           description: "Validation exception"
         default:
           description: "Error"
+  /pet/{pet_id}:
+    get:
+      tags:
+        - pets
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: get_pet_by_id
+      parameters:
+        - name: pet_id
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: pet_id
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: "Invalid input"
   /given/another/:
     post:
       summary: "bad path"
@@ -123,6 +154,19 @@ components:
           description: The number of extension points.
       example:
           number_of_coins: 'testString'
+    Pet:
+      type: object
+      description: pet object
+      properties:
+        pet_id:
+          description: pet_id
+          type: integer
+          format: int64
+          example: 10
+        name:
+          description: pet name
+          type: string
+          example: doggie
     TheBadModel:
       type: object
       description: The bad model

--- a/test/spectral/mockFiles/swagger/disabled-rules.yml
+++ b/test/spectral/mockFiles/swagger/disabled-rules.yml
@@ -157,19 +157,6 @@ paths:
           - "sold"
           default: "available"
         collectionFormat: "multi"
-      - name: "status"
-        in: "query"
-        description: "Status values that need to be considered for filter"
-        required: true
-        type: "array"
-        items:
-          type: "string"
-          enum:
-          - "available"
-          - "pending"
-          - "sold"
-          default: "available"
-        collectionFormat: "multi"
       responses:
         200:
           description: "successful operation"

--- a/test/spectral/mockFiles/swagger/enabled-rules.yml
+++ b/test/spectral/mockFiles/swagger/enabled-rules.yml
@@ -53,6 +53,39 @@ paths:
           description: "Validation exception"
         default:
           description: "Error"
+  /pet/{pet_id}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: get_pet_by_id
+      produces:
+      - "application/json"
+      parameters:
+      - name: pet_id
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: pet_id
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/Pet'
+        default:
+          description: "Invalid input"
   /given/another/:
     post:
       summary: "bad path"
@@ -193,6 +226,19 @@ definitions:
           - 2
           - a_string
           - 8
+  Pet:
+      type: object
+      description: pet object
+      properties:
+        pet_id:
+          description: pet_id
+          type: integer
+          format: int64
+          example: 10
+        name:
+          description: pet name
+          type: string
+          example: doggie
   ModelWithBadExample:
     type: object
     description: A bad example model

--- a/test/spectral/tests/disabled-rules.test.js
+++ b/test/spectral/tests/disabled-rules.test.js
@@ -274,15 +274,6 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test operation-parameters validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
-    expect(errors).not.toContain(
-      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
-    );
-    expect(warnings).not.toContain(
-      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
-    );
-  });
-
   it('test operation-operationId-valid-in-url validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
     expect(errors).not.toContain(
       'operationId may only use characters that are valid when used in a URL.'
@@ -611,15 +602,6 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
     expect(warnings).not.toContain(
       'Operation must have at least one `2xx` response.'
-    );
-  });
-
-  it('test operation-parameters validator rule mockFiles/oas3/disabled-rules-in-memory', function() {
-    expect(errors).not.toContain(
-      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
-    );
-    expect(warnings).not.toContain(
-      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
     );
   });
 

--- a/test/spectral/tests/enabled-rules.test.js
+++ b/test/spectral/tests/enabled-rules.test.js
@@ -169,6 +169,15 @@ describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
     );
   });
 
+  it('test operation-parameters rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+    expect(errors).not.toContain(
+      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
+    );
+    expect(warnings).toContain(
+      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
+    );
+  });
+
   it('test operation-tags rule using mockFiles/swagger/enabled-rules-in-memory', function() {
     expect(errors).not.toContain(
       'Operation should have non-empty `tags` array.'
@@ -408,6 +417,15 @@ describe('spectral - test enabled rules - OAS3 In Memory', function() {
     );
     expect(warnings).toContain(
       'Operation `description` must be present and non-empty string.'
+    );
+  });
+
+  it('test operation-parameters rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+    expect(errors).not.toContain(
+      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
+    );
+    expect(warnings).toContain(
+      'A parameter in this operation already exposes the same combination of `name` and `in` values.'
     );
   });
 

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -40,7 +40,7 @@ describe('Spectral - test custom configuration', function() {
     expect(jsonOutput['warnings']['spectral'].length).toBe(10);
 
     // Verify infos
-    expect(jsonOutput['infos']['spectral'].length).toBe(5);
+    expect(jsonOutput['infos']['spectral'].length).toBe(6);
     expect(jsonOutput['infos']['spectral'][0]['message']).toEqual(
       'Markdown descriptions should not contain `<script>` tags.'
     );
@@ -94,7 +94,7 @@ describe('Spectral - test custom configuration', function() {
     );
 
     // Verify warnings
-    expect(jsonOutput['warnings']['spectral'].length).toBe(18);
+    expect(jsonOutput['warnings']['spectral'].length).toBe(20);
     const warnings = jsonOutput['warnings']['spectral'].map(w => w['message']);
     // This warning should be turned off
     expect(warnings).not.toContain(
@@ -139,7 +139,7 @@ describe('Spectral - test custom configuration', function() {
     expect(jsonOutput['errors']['spectral']).toBeUndefined();
 
     // Verify warnings
-    expect(jsonOutput['warnings']['spectral'].length).toBe(23);
+    expect(jsonOutput['warnings']['spectral'].length).toBe(25);
     const warnings = jsonOutput['warnings']['spectral'].map(w => w['message']);
     // This is the new warning -- there should be three occurrences
     const warning = 'All request bodies should have an example.';

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -234,6 +234,7 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
       'no-script-tags-in-markdown': 'off',
       'openapi-tags': 'off',
       'operation-description': 'off',
+      'operation-parameters': 'off',
       'operation-tags': 'off',
       'operation-tag-defined': 'off',
       'path-keys-no-trailing-slash': 'off',
@@ -263,9 +264,9 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
     mockConfig.mockRestore();
   });
 
-  // There should be no errors, 2 warnings for a non-spectral rule
+  // There should be no errors and no warnings
   it('test no spectral errors and no spectral warnings', function() {
     expect(validationResults.errors.length).toBe(0);
-    expect(validationResults.warnings.length).toBe(2);
+    expect(validationResults.warnings.length).toBe(0);
   });
 });


### PR DESCRIPTION
Purpose:
- Simplify the validator ruleset by using an equivalent Spectral rule
- Avoid resolving spec in-place to ensure inCodeValidator does not modify user's original spec object

Changes:
- Enable the operation-parameters Spectral rule
- Remove the in-code validation for parameters with duplicate `in:` and `name:` properties
- Pass a copy of the original spec to the reference resolver to prevent modification of the original spec

Tests:
- Remove tests meant to ensure the operation-parameters test is disabled
- Remove invalid oas3 from `disable-rules.yml` meant to invoke operation-parameters errors
- Remove irrelevant tests for in-code validation
- Add test to ensure operation-parameters check catches duplicate parameters for oas3 document