### PR TITLE
refactor: use Spectral to check for query string in path

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/paths.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths.js
@@ -15,6 +15,7 @@
 
 // Assertation 6:
 // Paths cannot have literal query strings in them.
+// Handled by the Spectral rule, path-not-include-query
 
 const each = require('lodash/each');
 const findIndex = require('lodash/findIndex');
@@ -55,15 +56,6 @@ module.exports.validate = function({ resolvedSpec }) {
         );
       }
     });
-
-    // Assertation 6
-    if (pathName.indexOf('?') > -1) {
-      messages.addMessage(
-        `paths.${pathName}`,
-        'Query strings in paths are not allowed.',
-        'error'
-      );
-    }
 
     const parametersFromPath = path.parameters ? path.parameters.slice() : [];
 

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -38,8 +38,8 @@ rules:
   path-declarations-must-exist: off
   # Enable with same severity as Spectral
   path-keys-no-trailing-slash: true
-  # Turn off - duplicates non-configurable validation - paths.js
-  path-not-include-query: off
+  # Enable with same severity as Spectral
+  path-not-include-query: true
   # Turn off - duplicates $ref_siblings (off by default)
   no-$ref-siblings: off
   # Enable with same severity as Spectral

--- a/test/plugins/validation/2and3/paths.test.js
+++ b/test/plugins/validation/2and3/paths.test.js
@@ -246,21 +246,6 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Paths cannot have query strings in them', () => {
-      it("should return one problem for an stray '?' in a path string", function() {
-        const spec = {
-          paths: {
-            '/report?': {}
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec });
-        expect(res.errors.length).toEqual(1);
-        expect(res.errors[0].message).toEqual(
-          'Query strings in paths are not allowed.'
-        );
-        expect(res.errors[0].path).toEqual('paths./report?');
-      });
-
       it('should return no problems for a correct path template', function() {
         const spec = {
           paths: {
@@ -282,7 +267,7 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Integrations', () => {
-      it('should return two problems for an illegal query string in a path string', function() {
+      it('should return one problem for an illegal query string in a path string', function() {
         const spec = {
           paths: {
             '/report?rdate={relative_date}': {
@@ -297,17 +282,11 @@ describe('validation plugin - semantic - paths', function() {
         };
 
         const res = validate({ resolvedSpec: spec });
-        expect(res.errors.length).toEqual(2);
+        expect(res.errors.length).toEqual(1);
         expect(res.errors[0].message).toEqual(
           'Partial path templating is not allowed.'
         );
         expect(res.errors[0].path).toEqual(
-          'paths./report?rdate={relative_date}'
-        );
-        expect(res.errors[1].message).toEqual(
-          'Query strings in paths are not allowed.'
-        );
-        expect(res.errors[1].path).toEqual(
           'paths./report?rdate={relative_date}'
         );
       });

--- a/test/spectral/mockFiles/oas3/disabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/disabled-rules.yml
@@ -74,7 +74,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /anotherpet/path?query=true:
+  /anotherpet/path:
     get:
       summary: List all other pets
       description: List all other pets

--- a/test/spectral/mockFiles/swagger/disabled-rules.yml
+++ b/test/spectral/mockFiles/swagger/disabled-rules.yml
@@ -134,7 +134,7 @@ paths:
       security:
       - apikey:
         - "write:pets"
-  /pet/find_by_status/path?query=true:
+  /pet/find_by_status/path:
     get:
       tags:
       - "pet"

--- a/test/spectral/tests/disabled-rules.test.js
+++ b/test/spectral/tests/disabled-rules.test.js
@@ -297,15 +297,6 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     expect(warnings).not.toContain('Operations must have a default response.');
   });
 
-  it('test path-not-include-query rule using mockFiles/swagger/disabled-rules-in-memory', function() {
-    expect(errors).not.toContain(
-      'given keys should not include a query string.'
-    );
-    expect(warnings).not.toContain(
-      'given keys should not include a query string.'
-    );
-  });
-
   it('test oas2-unused-definition validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
     expect(errors).not.toContain(
       'Potentially unused definition has been detected.'
@@ -620,15 +611,6 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
     expect(warnings).not.toContain(
       'Path parameter declarations cannot be empty, ex.`/given/{}` is invalid.'
-    );
-  });
-
-  it('test path-not-include-query rule using mockFiles/oas3/disabled-rules-in-memory', function() {
-    expect(errors).not.toContain(
-      'given keys should not include a query string.'
-    );
-    expect(warnings).not.toContain(
-      'given keys should not include a query string.'
     );
   });
 


### PR DESCRIPTION
Purpose:
- Simplify validator ruleset by using equivalent Spectral rule

Changes:
- Enable the path-not-include-query Spectral rule
- Remove the in-code validation for query string in paths

Tests:
- Remove irrelevant tests that ensure path-not-include-query Spectral rule disabled
- Remove irrelevant tests for in-code validation of in-path query strings
- Note: did not add enabled-rules test for path-not-include-query rule. Adding a query string to a path in the `enabled-rules.yml` test file also violates the validator's in-code paths_case_convention rule. This caused test failures that I thought would be ugly to fix, so thus far, we do not add a positive test for the path-not-include-query rule on our side.