### PR TITLE
docs: add enabled Spectral rules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,9 +514,11 @@ no-script-tags-in-markdown: true
 openapi-tags: true
 operation-description: true
 operation-operationId-unique: true
+operation-parameters: true
 operation-tags: true
 operation-tag-defined: true
 path-keys-no-trailing-slash: true
+path-not-include-query: true
 typed-enum: true
 oas2-api-host: true
 oas2-api-schemes: true


### PR DESCRIPTION
Adds the enabled rules from recent work, #248 and #249, to the README.