### PR TITLE
refactor: replace info object check with a custom Spectral rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2164,18 +2164,18 @@
       }
     },
     "@stoplight/better-ajv-errors": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.0.tgz",
-      "integrity": "sha512-jA1i4J5HmCXMmZdZigdeEHpisFCGVg5QfK++ouxP58pxshATJ5G40U9uGec2vYnuR2MQnzWHAXYf0f8jvJhBwg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.3.tgz",
+      "integrity": "sha512-q3PoPiYZdzfJjQ+q6ifuLVFx3dBKRxW1OBGxnLAoDlamYb+GJUNiaSLB32L6OB4fi6h/TsY21lZB7y7aYFM7tQ==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "leven": "^3.1.0"
       }
     },
     "@stoplight/json": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.9.0.tgz",
-      "integrity": "sha512-jgEKIPMLbhaU5Nw9yw+VBw2OSfDxm8VQ/k5JNezAuDMjcmqCPz3rOQTVNOROStzi70l4DRxF7eBN9liYJq5Ojw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.10.2.tgz",
+      "integrity": "sha512-mUf4t2bOBZjVa8KdEI4+EqX/8zXJLfGKv/cj++giLbCkYNGjBgJnmPSDNOOBgJHpocdVml0hK8ZuLADqWVVB2Q==",
       "requires": {
         "@stoplight/ordered-object-literal": "^1.0.1",
         "@stoplight/types": "^11.9.0",
@@ -2193,35 +2193,35 @@
       }
     },
     "@stoplight/json-ref-resolver": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.0.tgz",
-      "integrity": "sha512-tEVlRi9sMVektCiPsnint0OD/2zzQOPb7GoWboBznDc3f/99SAjgL6TBWvuFCJXWLwhZP4GA55FggmtsF5OvQg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.1.tgz",
+      "integrity": "sha512-FUOu3nPwbX2COczcCwvUz1EpqRNYlw7Ng8keOWGiwKmlXVz4OKdRw4hi2HUg9QNSX1CyFVJ3A3pPtpkizfKqlg==",
       "requires": {
-        "@stoplight/json": "^3.4.0",
-        "@stoplight/path": "^1.3.1",
-        "@stoplight/types": "^11.6.0",
-        "@types/urijs": "^1.19.9",
-        "dependency-graph": "~0.8.0",
-        "fast-memoize": "^2.5.1",
-        "immer": "^5.3.2",
-        "lodash": "^4.17.15",
-        "tslib": "^1.13.0",
-        "urijs": "^1.19.2"
+        "@stoplight/json": "^3.10.2",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^11.9.0",
+        "@types/urijs": "^1.19.14",
+        "dependency-graph": "~0.10.0",
+        "fast-memoize": "^2.5.2",
+        "immer": "^8.0.1",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "tslib": "^2.1.0",
+        "urijs": "^1.19.5"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
     "@stoplight/lifecycle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.3.0.tgz",
-      "integrity": "sha512-nVeciLEYlj97W4OEwGp7UVGzdTkux8mSacbAARPJboEvVrqW/QHfAc830rcZ/UBvpWuni5WbMAPFpQ9t9Jb/AA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.3.2.tgz",
+      "integrity": "sha512-v0u8p27FA/eg04b4z6QXw4s0NeeFcRzyvseBW0+k/q4jtpg7EhVCqy42EbbbU43NTNDpIeQ81OcvkFz+6CYshw==",
       "requires": {
-        "strict-event-emitter-types": "^2.0.0",
         "wolfy87-eventemitter": "~5.2.8"
       }
     },
@@ -2236,46 +2236,47 @@
       "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
     },
     "@stoplight/spectral": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.5.0.tgz",
-      "integrity": "sha512-2TtADRz9yNhBs4m7p9Y25VX/5aoZPNETWRFo14A/a9Tu4oPFmJojJO1FFhk8Hu2kjKHtZeB4zXVuvtmbq/fPtQ==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.8.1.tgz",
+      "integrity": "sha512-GhdKnnJ8LAYfvoiNRWmkgQMNRGHD03T9Hmtq8K7hYi98ToL3WfqYC5oAVLsYw/y9t+FpP32gWzyrTmz8lBI/kA==",
       "requires": {
-        "@stoplight/better-ajv-errors": "0.0.0",
-        "@stoplight/json": "3.9.0",
+        "@stoplight/better-ajv-errors": "0.0.3",
+        "@stoplight/json": "3.10.2",
         "@stoplight/json-ref-readers": "1.2.1",
-        "@stoplight/json-ref-resolver": "3.1.0",
-        "@stoplight/lifecycle": "2.3.0",
+        "@stoplight/json-ref-resolver": "3.1.1",
+        "@stoplight/lifecycle": "2.3.2",
         "@stoplight/path": "1.3.2",
-        "@stoplight/types": "^11.9.0",
+        "@stoplight/types": "11.9.0",
         "@stoplight/yaml": "4.2.1",
         "abort-controller": "3.0.0",
-        "ajv": "6.12.2",
+        "ajv": "6.12.5",
         "ajv-oai": "1.2.0",
-        "blueimp-md5": "2.13.0",
-        "chalk": "4.0.0",
+        "blueimp-md5": "2.18.0",
+        "chalk": "4.1.0",
         "eol": "0.9.1",
-        "fast-glob": "3.1.0",
+        "expression-eval": "3.1.2",
+        "fast-glob": "3.2.5",
         "jsonpath-plus": "4.0.0",
-        "lodash": "4.17.19",
+        "lodash": "4.17.20",
         "nanoid": "2.1.11",
         "nimma": "0.0.0",
-        "node-fetch": "2.6",
+        "node-fetch": "2.6.1",
         "proxy-agent": "3.1.1",
         "strip-ansi": "6.0",
         "text-table": "0.2",
         "tslib": "1.13.0",
-        "yargs": "15.3.1"
+        "yargs": "15.4.1"
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -2288,101 +2289,33 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-          "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
             "glob-parent": "^5.1.0",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2"
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
           }
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "merge2": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
           "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -2392,36 +2325,10 @@
             "ansi-regex": "^5.0.0"
           }
         },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
           "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        },
-        "yargs": {
-          "version": "15.3.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.1"
-          }
         }
       }
     },
@@ -2446,9 +2353,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2569,9 +2476,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -2622,9 +2529,9 @@
       "dev": true
     },
     "@types/urijs": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.12.tgz",
-      "integrity": "sha512-+BmVXyxXCmGuS177d6yj9zt3tBugh35ZIPgYTWctDf2/LwGirIWIyaH01dmTzxjro6LNiaYIIj3jveKetMmZ1A=="
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.14.tgz",
+      "integrity": "sha512-Ds9OMd4xZqI2zZtoOicASAi0SvFPyNPgkfgPrPeUTQwcJOX1w6Mwkpq8ClI4ZP11nsEI6akvKqRDV+epA8yzRw=="
     },
     "@types/yargs": {
       "version": "15.0.4",
@@ -2927,17 +2834,17 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.1.tgz",
-      "integrity": "sha512-pfSiukbt23P1qMhNnsozLzhMLBs7EEeXqPyvPmnuZM+RMfwfqwDbSVKYflgGuVI7/VehR4oMks0igzdNAg4VeQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
       "requires": {
         "tslib": "^2.0.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -2948,9 +2855,9 @@
       "dev": true
     },
     "astring": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.4.3.tgz",
-      "integrity": "sha512-yJlJU/bmN820vL+cbWShu2YQU87dBP5V7BH2N4wODapRv27A2dZtUD0LgjP9lZENvPe9XRoSyWx+pZR6qKqNBw=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.7.0.tgz",
+      "integrity": "sha512-43bervUZNvahG1v74a+POdGlAWcOUGSvP9fJVj6sywzM/SquwDkA+CdP938e8tWHUV77fStCiqzaQHAt0u6MVA=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -3235,9 +3142,9 @@
       "dev": true
     },
     "blueimp-md5": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.13.0.tgz",
-      "integrity": "sha512-lmp0m647R5e77ORduxLW5mISIDcvgJZa52vMBv5uVI3UmSWTQjkJsZVBfaFqQPw/QFogJwvY6e3Gl9nP+Loe+Q=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
     },
     "bottleneck": {
       "version": "2.19.5",
@@ -4210,9 +4117,9 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "dependency-graph": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.8.1.tgz",
-      "integrity": "sha512-g213uqF8fyk40W8SBjm079n3CZB4qSpCrA2ye1fLGzH/4HEgB6tzuW2CbLE7leb4t45/6h44Ud59Su1/ROTfqw=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.10.0.tgz",
+      "integrity": "sha512-c9amUgpgxSi1bE5/sbLwcs5diLD0ygCQYmhfM5H1s5VH1mCsYkcmAL3CcNdv4kdSw6JuMoHeDGzLgj/gAXdWVg=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -4844,6 +4751,14 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
+      }
+    },
+    "expression-eval": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-3.1.2.tgz",
+      "integrity": "sha512-c8ZN8fuAz0TRYKoGsrIq5kLNHtm81KAqWSBORHIY0DpJmZZrwK/r2zFDOhFIAJDV47gJ6irV7dWf1TOFpKvULQ==",
+      "requires": {
+        "jsep": "^0.3.0"
       }
     },
     "extend": {
@@ -5975,9 +5890,9 @@
       }
     },
     "immer": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-5.3.6.tgz",
-      "integrity": "sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -8614,6 +8529,11 @@
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -8637,6 +8557,11 @@
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -12938,11 +12863,11 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "http-proxy-agent": {
@@ -12979,9 +12904,9 @@
           },
           "dependencies": {
             "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "version": "3.2.7",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -13853,11 +13778,11 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "http-proxy-agent": {
@@ -13894,9 +13819,9 @@
           },
           "dependencies": {
             "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "version": "3.2.7",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -15246,11 +15171,6 @@
         "readable-stream": "^2.1.4"
       }
     },
-    "strict-event-emitter-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
-    },
     "string-length": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
@@ -15968,9 +15888,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
-      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
     },
     "urix": {
       "version": "0.1.0",
@@ -16333,7 +16253,6 @@
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -16352,7 +16271,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -16362,7 +16280,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -16371,7 +16288,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -16380,7 +16296,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -16388,8 +16303,7 @@
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pkg": "./node_modules/.bin/pkg --out-path=./bin ./package.json; cd bin; rename -f 's/ibm-openapi-validator-(linux|macos|win)/lint-openapi-$1/g' ./ibm-openapi-*"
   },
   "dependencies": {
-    "@stoplight/spectral": "^5.5.0",
+    "@stoplight/spectral": "^5.8.1",
     "chalk": "^4.1.0",
     "commander": "^2.17.1",
     "deepmerge": "^2.1.1",

--- a/src/cli-validator/utils/processConfiguration.js
+++ b/src/cli-validator/utils/processConfiguration.js
@@ -377,7 +377,7 @@ const validateConfigOption = function(userOption, defaultOption) {
   return result;
 };
 
-const getSpectralRuleset = async function(rulesetFileOverride, defaultRuleset) {
+const getUserSpectralRuleset = async function(rulesetFileOverride) {
   // List of ruleset files to search for
   const ruleSetFilesToFind = [
     '.spectral.yaml',
@@ -387,7 +387,7 @@ const getSpectralRuleset = async function(rulesetFileOverride, defaultRuleset) {
   if (rulesetFileOverride) {
     ruleSetFilesToFind.splice(0, 0, rulesetFileOverride);
   }
-  let ruleSetFile;
+  let ruleSetFile = null;
 
   // search up the file system for the first ruleset file found
   try {
@@ -397,15 +397,11 @@ const getSpectralRuleset = async function(rulesetFileOverride, defaultRuleset) {
       }
     }
   } catch {
-    // if there's any issue finding a custom ruleset, then
-    // just use the default
-    ruleSetFile = defaultRuleset;
+    // do nothing, ruleSetFile stays null if not found
   }
 
-  if (!ruleSetFile) {
-    ruleSetFile = defaultRuleset;
-  }
-
+  // returns user-defined ruleset if it exists
+  // null otherwise
   return ruleSetFile;
 };
 
@@ -415,4 +411,4 @@ module.exports.ignore = getFilesToIgnore;
 module.exports.validateOption = validateConfigOption;
 module.exports.validateLimits = validateLimits;
 module.exports.limits = getLimits;
-module.exports.getSpectralRuleset = getSpectralRuleset;
+module.exports.getUserSpectralRuleset = getUserSpectralRuleset;

--- a/src/plugins/validation/2and3/semantic-validators/info.js
+++ b/src/plugins/validation/2and3/semantic-validators/info.js
@@ -12,13 +12,7 @@ module.exports.validate = function({ jsSpec }) {
 
   const info = jsSpec.info;
   const hasInfo = info && isPlainObject(info);
-  if (!hasInfo) {
-    messages.addMessage(
-      ['info'],
-      'API definition must have an `info` object',
-      'error'
-    );
-  } else {
+  if (hasInfo) {
     const title = jsSpec.info.title;
     const hasTitle =
       typeof title === 'string' && title.toString().trim().length > 0;

--- a/src/spectral/rulesets/custom-rules/functions/infoIsObject.js
+++ b/src/spectral/rulesets/custom-rules/functions/infoIsObject.js
@@ -1,0 +1,11 @@
+const isPlainObject = require('lodash/isPlainObject');
+
+module.exports = targetVal => {
+  if (!(targetVal && isPlainObject(targetVal))) {
+    return [
+      {
+        message: 'API definition must have an `info` object'
+      }
+    ];
+  }
+};

--- a/src/spectral/rulesets/custom-rules/info.yaml
+++ b/src/spectral/rulesets/custom-rules/info.yaml
@@ -1,0 +1,10 @@
+functions: [infoIsObject]
+rules:
+  info-include-info-object:
+    message: "{{error}}"
+    given: $.
+    severity: error
+    resolved: true
+    then:
+      field: info
+      function: infoIsObject

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -114,7 +114,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     const defaultMode = true;
     const validationResults = await inCodeValidator(oas2Object, defaultMode);
 
-    expect(validationResults.errors.length).toBe(6);
+    expect(validationResults.errors.length).toBe(5);
     expect(validationResults.warnings.length).toBe(9);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
@@ -139,23 +139,22 @@ describe('cli tool - test expected output - Swagger 2', function() {
     //   example output would be [ 'Line', ':', '59' ]
 
     // errors
-    expect(capturedText[4].match(/\S+/g)[2]).toEqual('36');
-    expect(capturedText[8].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[12].match(/\S+/g)[2]).toEqual('31');
-    expect(capturedText[16].match(/\S+/g)[2]).toEqual('54');
-    expect(capturedText[20].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[24].match(/\S+/g)[2]).toEqual('172');
+    expect(capturedText[4].match(/\S+/g)[2]).toEqual('59');
+    expect(capturedText[8].match(/\S+/g)[2]).toEqual('31');
+    expect(capturedText[12].match(/\S+/g)[2]).toEqual('54');
+    expect(capturedText[16].match(/\S+/g)[2]).toEqual('108');
+    expect(capturedText[20].match(/\S+/g)[2]).toEqual('172');
 
     // warnings
-    expect(capturedText[29].match(/\S+/g)[2]).toEqual('36');
-    expect(capturedText[33].match(/\S+/g)[2]).toEqual('59');
+    expect(capturedText[25].match(/\S+/g)[2]).toEqual('36');
+    expect(capturedText[29].match(/\S+/g)[2]).toEqual('59');
+    expect(capturedText[33].match(/\S+/g)[2]).toEqual('15');
     expect(capturedText[37].match(/\S+/g)[2]).toEqual('15');
-    expect(capturedText[41].match(/\S+/g)[2]).toEqual('15');
-    expect(capturedText[45].match(/\S+/g)[2]).toEqual('197');
-    expect(capturedText[49].match(/\S+/g)[2]).toEqual('108');
-    expect(capturedText[53].match(/\S+/g)[2]).toEqual('131');
-    expect(capturedText[57].match(/\S+/g)[2]).toEqual('134');
-    expect(capturedText[61].match(/\S+/g)[2]).toEqual('126');
+    expect(capturedText[41].match(/\S+/g)[2]).toEqual('197');
+    expect(capturedText[45].match(/\S+/g)[2]).toEqual('108');
+    expect(capturedText[49].match(/\S+/g)[2]).toEqual('131');
+    expect(capturedText[53].match(/\S+/g)[2]).toEqual('134');
+    expect(capturedText[57].match(/\S+/g)[2]).toEqual('126');
   });
 
   it('should return exit code of 0 if there are only warnings', async function() {
@@ -334,7 +333,7 @@ describe('test expected output - OpenAPI 3', function() {
     const defaultMode = true;
     const validationResults = await inCodeValidator(oas3Object, defaultMode);
 
-    expect(validationResults.errors.length).toBe(5);
+    expect(validationResults.errors.length).toBe(4);
     expect(validationResults.warnings.length).toBe(11);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();

--- a/test/cli-validator/tests/info-and-hint.test.js
+++ b/test/cli-validator/tests/info-and-hint.test.js
@@ -32,7 +32,7 @@ describe('test info and hint rules - OAS3', function() {
     consoleSpy.mockRestore();
 
     // errors for non-unique operation ids
-    expect(jsonOutput['errors']['spectral'].length).toBe(2);
+    expect(jsonOutput['errors']['spectral'].length).toBe(1);
 
     // Verify errors
     expect(jsonOutput['errors']['operations-shared'].length).toBe(2);

--- a/test/cli-validator/tests/option-handling.test.js
+++ b/test/cli-validator/tests/option-handling.test.js
@@ -120,21 +120,21 @@ describe('cli tool - test option handling', function() {
     const statsSection = capturedText.findIndex(x => x.includes('statistics'));
 
     // totals
-    expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('6');
+    expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('5');
     expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('9');
 
     // errors
-    expect(capturedText[statsSection + 5].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 5].match(/\S+/g)[1]).toEqual('(33%)');
+    expect(capturedText[statsSection + 5].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 5].match(/\S+/g)[1]).toEqual('(20%)');
 
     expect(capturedText[statsSection + 6].match(/\S+/g)[0]).toEqual('2');
-    expect(capturedText[statsSection + 6].match(/\S+/g)[1]).toEqual('(33%)');
+    expect(capturedText[statsSection + 6].match(/\S+/g)[1]).toEqual('(40%)');
 
     expect(capturedText[statsSection + 7].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 7].match(/\S+/g)[1]).toEqual('(17%)');
+    expect(capturedText[statsSection + 7].match(/\S+/g)[1]).toEqual('(20%)');
 
     expect(capturedText[statsSection + 8].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 8].match(/\S+/g)[1]).toEqual('(17%)');
+    expect(capturedText[statsSection + 8].match(/\S+/g)[1]).toEqual('(20%)');
 
     // warnings
     expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('2');
@@ -189,15 +189,9 @@ describe('cli tool - test option handling', function() {
     expect(outputObject.warning).toEqual(true);
     expect(outputObject.error).toEqual(true);
 
-    // {"line": 36, "message": "Every operation must have a unique `operationId`.", "path": ["paths", "/pet", "post", "operationId"], "rule": "operation-operationId-unique"}
-    expect(outputObject['errors']['spectral'][0]['line']).toEqual(36);
-    expect(outputObject['errors']['spectral'][0]['message']).toEqual(
-      'Every operation must have a unique `operationId`.'
-    );
-
     // {"line": 59, "message": "Every operation must have a unique `operationId`.", "path": ["paths", "/pet", "put", "operationId"], "rule": "operation-operationId-unique"}
-    expect(outputObject['errors']['spectral'][1]['line']).toEqual(59);
-    expect(outputObject['errors']['spectral'][1]['message']).toEqual(
+    expect(outputObject['errors']['spectral'][0]['line']).toEqual(59);
+    expect(outputObject['errors']['spectral'][0]['message']).toEqual(
       'Every operation must have a unique `operationId`.'
     );
 

--- a/test/plugins/validation/2and3/info.test.js
+++ b/test/plugins/validation/2and3/info.test.js
@@ -5,32 +5,6 @@ const {
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/info');
 
 describe('validation plugin - semantic - info', () => {
-  //this is for openapi object
-  it('should return an error when a parameter does not have info', () => {
-    const spec = {
-      Openapi: '3.0.0'
-    };
-
-    const res = validate({ jsSpec: spec }, config);
-    expect(res.errors.length).toEqual(1);
-    expect(res.errors[0].path).toEqual(['info']);
-    expect(res.errors[0].message).toEqual(
-      'API definition must have an `info` object'
-    );
-  });
-  it('should return an error when a info is not defined as a proper object', () => {
-    const spec = {
-      Openapi: '3.0.0',
-      info: 'abc'
-    };
-
-    const res = validate({ jsSpec: spec }, config);
-    expect(res.errors.length).toEqual(1);
-    expect(res.errors[0].path).toEqual(['info']);
-    expect(res.errors[0].message).toEqual(
-      'API definition must have an `info` object'
-    );
-  });
   it('should return an error when a title and version is not a string', () => {
     const spec = {
       Openapi: '3.0.0',

--- a/test/spectral/tests/custom-rules/info.test.js
+++ b/test/spectral/tests/custom-rules/info.test.js
@@ -1,0 +1,45 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test that error produced for missing info object', function() {
+  it('should return an error when the spec does not include info obect', async () => {
+    const spec = {
+      Openapi: '3.0.0',
+      paths: {}
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedError = res.errors.filter(
+      error => error.message === 'API definition must have an `info` object'
+    );
+    expect(expectedError.length).toBe(1);
+  });
+
+  it('should return an error when a info is not defined as a proper object', async () => {
+    const spec = {
+      Openapi: '3.0.0',
+      info: 'abc',
+      paths: {}
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedError = res.errors.filter(
+      error => error.message === 'API definition must have an `info` object'
+    );
+    expect(expectedError.length).toBe(1);
+  });
+
+  it('should not error when info is provided as an object', async () => {
+    const spec = {
+      Openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'Info Test'
+      },
+      paths: {}
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const errors = res.errors.map(error => error.message);
+    expect(errors).not.toContain('API definition must have an `info` object');
+  });
+});

--- a/test/spectral/tests/enabled-rules.test.js
+++ b/test/spectral/tests/enabled-rules.test.js
@@ -360,7 +360,7 @@ describe('spectral - test enabled rules - OAS3', function() {
 
   it('test oas3-valid-oas-content-example rule using mockFiles/oas3/enabled-rules.yml', function() {
     expect(allOutput).toContain(
-      '`number_of_connectors` property should be equal to one of the allowed values: 1, 2, a_string, 8'
+      '`number_of_connectors` property should be equal to one of the allowed values: 1, 2, `a_string`, 8'
     );
   });
 });

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -11,8 +11,8 @@ describe('Spectral - test custom configuration', function() {
       '../mockFiles/mockConfig/info-and-hint.yaml'
     );
     const mockConfig = jest
-      .spyOn(config, 'getSpectralRuleset')
-      .mockReturnValue(mockPath);
+      .spyOn(config, 'getUserSpectralRuleset')
+      .mockResolvedValue(mockPath);
 
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
@@ -65,8 +65,8 @@ describe('Spectral - test custom configuration', function() {
       '../mockFiles/mockConfig/extends-default.yaml'
     );
     const mockConfig = jest
-      .spyOn(config, 'getSpectralRuleset')
-      .mockReturnValue(mockPath);
+      .spyOn(config, 'getUserSpectralRuleset')
+      .mockResolvedValue(mockPath);
 
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
@@ -113,8 +113,8 @@ describe('Spectral - test custom configuration', function() {
       '../mockFiles/mockConfig/custom-rules.yaml'
     );
     const mockConfig = jest
-      .spyOn(config, 'getSpectralRuleset')
-      .mockReturnValue(mockPath);
+      .spyOn(config, 'getUserSpectralRuleset')
+      .mockResolvedValue(mockPath);
 
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -127,8 +127,8 @@ describe('spectral - test config file changes with .spectral.yml', function() {
       '../mockFiles/mockConfig/.mockSpectral.yaml'
     );
     const mockConfig = jest
-      .spyOn(config, 'getSpectralRuleset')
-      .mockReturnValue(mockPath);
+      .spyOn(config, 'getUserSpectralRuleset')
+      .mockResolvedValue(mockPath);
 
     // Below is used from enabled-rules.test.js
     // set up mock user input


### PR DESCRIPTION
Outstanding problems to be resolved:
- When a user provides a Spectral configuration file, our custom rules will not be invoked. Considerations
    - Need to ensure our custom rules are invoked when the user provides a Spectral configuration file.
    - Need to ensure the custom rules have access to their corresponding custom functions. Need to consider that user's Spectral configuration file may be in different directories and adjust the path to the custom functions directory.
    - Need to ensure users are able to adjust the severity of custom rules. Users will be able to configure previously "builtin" rules.
    - May want to adjust the way we process user's Spectral config file to, first, process our default Spectral configuration file then load the user's Spectral configuration file and overwrite the default values. Simply put, I think it'd be better to merge the user's Spectral configuration file into the default Spectral configuration file.
    - Not my idea but a good idea: Have a `Spectral config file updater` to give users a command to add new rules to their Spectral configuration file.

Purpose:
- Simplify the validator ruleset by replacing good candidates with an equivalent rule
- Establish a pattern in the validator for adding custom spectral rules and custom spectral functions

Changes:
- Add custom spectral rule to ensure that an info object is provided in the spec
- Add custom spectral function
- Remove in-code validation of info object

Tests:
- Move existing tests to ensure the equivalent spectral rule produces the same behavior