### PR TITLE
chore: update appscan config

### DIFF
--- a/appscan-config.xml
+++ b/appscan-config.xml
@@ -2,6 +2,7 @@
   <Targets>
     <Target path=".">
       <Exclude>test/</Exclude>
+      <Exclude>README.md</Exclude>
     </Target>
   </Targets>
 </Configuration>


### PR DESCRIPTION
This issue excludes the README file from the ASOC codescanning system, which is flagging the Docker command instructions as security vulnerabilities.