### PR TITLE
feat: remove error for partial path templating

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/paths.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths.js
@@ -11,9 +11,6 @@
 // Paths must have unique (name + in combination) parameters
 
 // Assertation 5:
-// Paths cannot have partial templates. (/path/abc{123} is illegal)
-
-// Assertation 6:
 // Paths cannot have literal query strings in them.
 // Handled by the Spectral rule, path-not-include-query
 
@@ -42,20 +39,6 @@ module.exports.validate = function({ resolvedSpec }) {
     if (!path || !pathName) {
       return;
     }
-
-    pathName.split('/').map(substr => {
-      // Assertation 5
-      if (
-        templateRegex.test(substr) &&
-        substr.replace(templateRegex, '').length > 0
-      ) {
-        messages.addMessage(
-          `paths.${pathName}`,
-          'Partial path templating is not allowed.',
-          'error'
-        );
-      }
-    });
 
     const parametersFromPath = path.parameters ? path.parameters.slice() : [];
 

--- a/test/plugins/validation/2and3/paths.test.js
+++ b/test/plugins/validation/2and3/paths.test.js
@@ -203,28 +203,6 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Paths cannot have partial templates', () => {
-      it('should return one problem for an illegal partial path template', function() {
-        const spec = {
-          paths: {
-            '/CoolPath/user{id}': {
-              parameters: [
-                {
-                  name: 'id',
-                  in: 'path'
-                }
-              ]
-            }
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec });
-        expect(res.errors.length).toEqual(1);
-        expect(res.errors[0].message).toEqual(
-          'Partial path templating is not allowed.'
-        );
-        expect(res.errors[0].path).toEqual('paths./CoolPath/user{id}');
-      });
-
       it('should return no problems for a correct path template', function() {
         const spec = {
           paths: {
@@ -267,30 +245,6 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Integrations', () => {
-      it('should return one problem for an illegal query string in a path string', function() {
-        const spec = {
-          paths: {
-            '/report?rdate={relative_date}': {
-              parameters: [
-                {
-                  name: 'relative_date',
-                  in: 'path'
-                }
-              ]
-            }
-          }
-        };
-
-        const res = validate({ resolvedSpec: spec });
-        expect(res.errors.length).toEqual(1);
-        expect(res.errors[0].message).toEqual(
-          'Partial path templating is not allowed.'
-        );
-        expect(res.errors[0].path).toEqual(
-          'paths./report?rdate={relative_date}'
-        );
-      });
-
       it.skip('should return two problems for an equivalent path string missing a parameter definition', function() {
         const spec = {
           paths: {


### PR DESCRIPTION
We could implement the check for partial path templating as a configurable Spectral rule. This rule, however, will need a custom Spectral function. The initial work for adding a custom Spectral function is on hold until we determine how to ensure that users can extend our ruleset without having problems locating our custom functions. Should we resolve the custom functions problem and implement this check as a Spectral rule, or should we move this work through and remove the check?

Purpose:
- Partial path templating is not disallowed in OAS3, so although partial path templating may not be ideal style, do not want it to be an error.

Changes:
- Remove code that checks for partial path templating.

Tests:
- Remove tests that test partial path template validation code.