### PR TITLE
build: drop support for Node 8.x and deprecate Node 10.x

### DIFF
--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -3,7 +3,7 @@
 // this module enforces that the user is running a supported version
 // of Node by exiting the process if the version is less than
 // the passed in argument (currently 8.9.x)
-require('./utils/checkVersion')('8.9.0');
+require('./utils/checkVersion')('10.0');
 require('./utils/updateNotifier');
 
 const program = require('./utils/modified-commander');

--- a/src/cli-validator/utils/checkVersion.js
+++ b/src/cli-validator/utils/checkVersion.js
@@ -18,13 +18,13 @@ module.exports = function(requiredVersion) {
   }
 
   // print deprecation warnings for specific node versions that will no longer be supported
-  const isNodeEight = semver.satisfies(process.version, '8.x');
-  if (isNodeEight) {
+  const isNodeTen = semver.satisfies(process.version, '10.x');
+  if (isNodeTen) {
     console.log(
       '\n' +
         chalk.yellow('[Warning]') +
-        ` Support for Node v8 is deprecated. Support will be officially dropped when it reaches end of life` +
-        ` (31 December 2019) or when v1.0 of this package is released, whichever happens first.\n`
+        ` Support for Node 10.x is deprecated. Support will be officially dropped when it reaches end of life` +
+        ` (30 April 2021).\n`
     );
   }
 };


### PR DESCRIPTION
Purpose:
- Node 8 reach its end-of-life, and Node 10 is scheduled to reach end of life at the end of April 2021.

Changes:
- Increase the required version.
- Change the check and deprecation message to warn for Node 10.x.