### PR TITLE
fix: correct the minimum required version of Node

### DIFF
--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -2,8 +2,8 @@
 
 // this module enforces that the user is running a supported version
 // of Node by exiting the process if the version is less than
-// the passed in argument (currently 8.9.x)
-require('./utils/checkVersion')('10.0');
+// the passed in argument (currently 10.0.0)
+require('./utils/checkVersion')('10.0.0');
 require('./utils/updateNotifier');
 
 const program = require('./utils/modified-commander');


### PR DESCRIPTION
Changes:
- Node version requires all three major, minor, patch fields, so update minimum version from 10.0 to 10.0.0