### PR TITLE
feat: warn for missing response examples

### DIFF
--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -28,3 +28,48 @@ responses:
 ```
 
 **Default Severity**: warn
+
+## response-example-provided
+
+Response examples are used to generate documentation. To improve the generated documentation, response examples should be provided in the schema object or "next to" the schema object.
+
+**Bad Example**
+
+```yaml
+responses:
+  200:
+    content:
+      application/json:
+        schema:
+          type: string
+```
+
+**Good Example**
+
+The example may be provided in the schema object.
+
+```yaml
+responses:
+  200:
+    content:
+      application/json:
+        schema:
+          type: string
+          example: 'example string'
+```
+
+**Good Example**
+
+The example may be provided at the response level "next to" the schema object.
+
+```yaml
+responses:
+  200:
+    content:
+      application/json:
+        schema:
+          type: string
+        example: 'example string'
+```
+
+**Default Severity**: warn

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -1,4 +1,7 @@
 extends: spectral:oas
+functionsDir: './ibm-oas'
+functions:
+  - response-example-provided
 rules:
 
   # Original list created from Spectral with:
@@ -104,3 +107,11 @@ rules:
     then:
       field: schema
       function: truthy
+  # custom Spectral rule to ensure response example provided
+  response-example-provided:
+    message: "{{error}}"
+    given: $.paths[*][*].responses[*].content.application/json
+    severity: warn
+    resolved: true
+    then:
+      function: response-example-provided

--- a/src/spectral/rulesets/ibm-oas/response-example-provided.js
+++ b/src/spectral/rulesets/ibm-oas/response-example-provided.js
@@ -1,0 +1,17 @@
+module.exports = function(response) {
+  if (!responseLevelExamples(response) && !schemaLevelExample(response)) {
+    return [
+      {
+        message: 'Response bodies should include an example response'
+      }
+    ];
+  }
+};
+
+function responseLevelExamples(response) {
+  return response.example || response.examples;
+}
+
+function schemaLevelExample(response) {
+  return response.schema && response.schema.example;
+}

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -117,6 +117,10 @@ components:
         tag:
           type: string
           description: "tag property"
+      example:
+        id: 1
+        name: doggie
+        tag: dog
     Pets:
       description:
         A list of pets
@@ -145,6 +149,15 @@ components:
         next_token:
           type: string
           description: next token
+      example:
+        pets:
+        - id: 1
+          name: doggie
+          tag: dog
+        next_url: 'https://www.nexturl.com'
+        limit: 50
+        offset: 20
+        next_token: TOKEN_STRING
 
     Error:
       description:
@@ -160,3 +173,6 @@ components:
         message:
           type: string
           description: "message property"
+      example:
+        code: 123
+        message: "error occurred"

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -363,7 +363,7 @@ describe('test expected output - OpenAPI 3', function() {
     const validationResults = await inCodeValidator(oas3Object, defaultMode);
 
     expect(validationResults.errors.length).toBe(4);
-    expect(validationResults.warnings.length).toBe(10);
+    expect(validationResults.warnings.length).toBe(11);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 

--- a/test/cli-validator/tests/info-and-hint.test.js
+++ b/test/cli-validator/tests/info-and-hint.test.js
@@ -35,7 +35,7 @@ describe('test info and hint rules - OAS3', function() {
     expect(jsonOutput['errors'].length).toBe(4);
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(7);
+    expect(jsonOutput['warnings'].length).toBe(8);
 
     // Verify infos
     expect(jsonOutput['infos'].length).toBe(1);

--- a/test/spectral/mockFiles/oas3/disabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/disabled-rules.yml
@@ -192,6 +192,10 @@ components:
         tag:
           type: string
           description: "tag property"
+      example:
+        id: 1
+        name: doggie
+        tag: dog
     Pets:
       description:
         A list of pets
@@ -220,6 +224,15 @@ components:
         next_token:
           type: string
           description: next token
+      example:
+        pets:
+        - id: 1
+          name: doggie
+          tag: dog
+        next_url: 'https://www.nexturl.com'
+        limit: 50
+        offset: 20
+        next_token: TOKEN_STRING
 
     Error:
       description:
@@ -235,3 +248,6 @@ components:
         message:
           type: string
           description: "message property"
+      example:
+        code: 123
+        message: "error occurred"

--- a/test/spectral/tests/custom-rules/json-response-example-provided.test.js
+++ b/test/spectral/tests/custom-rules/json-response-example-provided.test.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test validation that schema provided in content object', function() {
+  it('should not error when a response example provided in the schema or at the response level', async () => {
+    const spec = {
+      Openapi: '3.0.0',
+      paths: {
+        path1: {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      example: 'example string'
+                    }
+                  }
+                }
+              },
+              '400': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string'
+                    },
+                    example: 'example string'
+                  }
+                }
+              },
+              '404': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string'
+                    },
+                    examples: {
+                      example1: {
+                        value: 'example string 1'
+                      },
+                      example2: {
+                        value: 'example string 2'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message === 'Response bodies should include an example response'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should error when a response example is not provided', async () => {
+    const spec = {
+      Openapi: '3.0.0',
+      paths: {
+        path1: {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    // schema provided
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message === 'Response bodies should include an example response'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+
+  it('should not error on a clean API definition with response examples', async () => {
+    const spec = yaml.safeLoad(
+      fs.readFileSync(
+        path.join(__dirname, '../../../cli-validator/mockFiles/oas3/clean.yml')
+      )
+    );
+
+    const res = await inCodeValidator(spec, true);
+    expect(res.warnings).toBeUndefined();
+  });
+});

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -1,37 +1,23 @@
-const path = require('path');
 const commandLineValidator = require('../../../src/cli-validator/runValidator');
-const config = require('../../../src/cli-validator/utils/processConfiguration');
 const { getCapturedText } = require('../../test-utils');
 
 describe('Spectral - test custom configuration', function() {
   it('test Spectral info and hint rules', async function() {
-    // Set config to mock .spectral.yml file before running
-    const mockPath = path.join(
-      __dirname,
-      '../mockFiles/mockConfig/info-and-hint.yaml'
-    );
-    const mockConfig = jest
-      .spyOn(config, 'getSpectralRuleset')
-      .mockResolvedValue(mockPath);
-
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
     // set up mock user input
     const program = {};
     program.args = ['./test/spectral/mockFiles/oas3/enabled-rules.yml'];
     program.default_mode = true;
     program.json = true;
+    program.ruleset = 'test/spectral/mockFiles/mockConfig/info-and-hint.yaml';
 
-    // Note: validator does not set exitcode for jsonOutput
-    await commandLineValidator(program);
-
-    // Ensure mockConfig was called and revert it to its original state
-    expect(mockConfig).toHaveBeenCalled();
-    mockConfig.mockRestore();
+    const exitcode = await commandLineValidator(program);
+    expect(exitcode).toBe(0);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const jsonOutput = JSON.parse(capturedText);
-
     consoleSpy.mockRestore();
+    const jsonOutput = JSON.parse(capturedText);
 
     // Verify errors
     expect(jsonOutput['errors'].length).toBe(2);
@@ -59,33 +45,20 @@ describe('Spectral - test custom configuration', function() {
   });
 
   it('test Spectral custom config that extends ibm:oas', async function() {
-    // Set config to mock .spectral.yml file before running
-    const mockPath = path.join(
-      __dirname,
-      '../mockFiles/mockConfig/extends-default.yaml'
-    );
-    const mockConfig = jest
-      .spyOn(config, 'getSpectralRuleset')
-      .mockResolvedValue(mockPath);
-
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
     program.args = ['./test/spectral/mockFiles/oas3/enabled-rules.yml'];
     program.default_mode = true;
     program.json = true;
+    program.ruleset = 'test/spectral/mockFiles/mockConfig/extends-default.yaml';
 
-    // Note: validator does not set exitcode for jsonOutput
-    await commandLineValidator(program);
-
-    // Ensure mockConfig was called and revert it to its original state
-    expect(mockConfig).toHaveBeenCalled();
-    mockConfig.mockRestore();
+    const exitcode = await commandLineValidator(program);
+    expect(exitcode).toBe(0);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const jsonOutput = JSON.parse(capturedText);
-
     consoleSpy.mockRestore();
+    const jsonOutput = JSON.parse(capturedText);
 
     // Verify errors
     expect(jsonOutput['errors'].length).toBe(1);
@@ -94,7 +67,7 @@ describe('Spectral - test custom configuration', function() {
     );
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(20);
+    expect(jsonOutput['warnings'].length).toBe(21);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This warning should be turned off
     expect(warnings).not.toContain(
@@ -107,39 +80,26 @@ describe('Spectral - test custom configuration', function() {
   });
 
   it('test Spectral custom config that extends ibm:oas with custom rules', async function() {
-    // Set config to mock .spectral.yml file before running
-    const mockPath = path.join(
-      __dirname,
-      '../mockFiles/mockConfig/custom-rules.yaml'
-    );
-    const mockConfig = jest
-      .spyOn(config, 'getSpectralRuleset')
-      .mockResolvedValue(mockPath);
-
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
     program.args = ['./test/spectral/mockFiles/oas3/enabled-rules.yml'];
     program.default_mode = true;
     program.json = true;
+    program.ruleset = 'test/spectral/mockFiles/mockConfig/custom-rules.yaml';
 
-    // Note: validator does not set exitcode for jsonOutput
-    await commandLineValidator(program);
-
-    // Ensure mockConfig was called and revert it to its original state
-    expect(mockConfig).toHaveBeenCalled();
-    mockConfig.mockRestore();
+    const exitcode = await commandLineValidator(program);
+    expect(exitcode).toBe(0);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const jsonOutput = JSON.parse(capturedText);
-
     consoleSpy.mockRestore();
+    const jsonOutput = JSON.parse(capturedText);
 
     // Verify there are no errors
     expect(jsonOutput['errors']).toBeUndefined();
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(25);
+    expect(jsonOutput['warnings'].length).toBe(26);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This is the new warning -- there should be three occurrences
     const warning = 'All request bodies should have an example.';

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -251,7 +251,9 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
       'oas3-server-trailing-slash': 'off',
       'oas3-valid-oas-content-example': 'off',
       'oas3-valid-example': 'off',
-      'oas3-valid-schema-example': 'off'
+      'oas3-valid-schema-example': 'off',
+      'content-entry-contains-schema': 'off',
+      'response-example-provided': 'off'
     };
     const mockConfig = jest.spyOn(config, 'get').mockReturnValue(mockObject);
 


### PR DESCRIPTION
Purpose:
- Establish working pattern for writing custom functions such that, when users extend the `ibm:oas` ruleset, our custom functions are still findable by Spectral.
- Tooling to generate documentation relies on response examples provided either in the schema or "next to" the schema at response level. Warn about responses that do not provide examples in these locations.

Changes:
- Create a custom Spectral rule to warn about missing response examples
- Create a custom Spectral function to check if a response example provided in the locations supported by the code that generates documentation.

Tests:
- Add tests to ensure no warning given when a response example is provided.
- Add a test to ensure a warning is given when no response example provided.

Docs:
- Document the response-example-provided rule in `docs/spectral-rules.md`

**Possible changes:**
- Include more than `application/json` responses. To do this, we would change the `given` field of the rule from `$.paths[*][*].responses[*].content.application/json` to `$.paths[*][*].responses[*].content[*]`.
- May want to condense the error message. I had writer's block, so I went with a verbose description initially.