### PR TITLE
Error responses

### DIFF
--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -29,6 +29,33 @@ responses:
 
 **Default Severity**: warn
 
+## response-error-response-has-content
+
+`4xx` and `5xx` series responses should provide a useful error response object. This rule ensures that error responses provide a content object.
+
+**Bad Example**
+
+```yaml
+responses:
+  400:
+    description: 'example error description`
+```
+
+**Good Example**
+
+```yaml
+responses:
+  400:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            $ref: '#/components/responses/ErrorResponse'
+```
+
+**Default Severity**: warn
+
 ## response-example-provided
 
 Response examples are used to generate documentation. To improve the generated documentation, response examples should be provided in the schema object or "next to" the schema object.

--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -2,6 +2,33 @@
 
 This document outlines the custom Spectral rules implemented in `ibm:oas` ruleset.
 
+## content-entry-provided
+
+Checks for `content` entry for all request bodies and non-204 responses.
+
+**Bad Example**
+
+```yaml
+responses:
+  200:
+    description: 'example error description`
+```
+
+**Good Example**
+
+```yaml
+responses:
+  200:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            $ref: '#/components/responses/SuccessSchema'
+```
+
+**Default Severity**: warn
+
 ## content-entry-contains-schema
 
 Any request or response body that has `content` should contain a schema.
@@ -25,33 +52,6 @@ responses:
       application/json:
         schema:
           type: string
-```
-
-**Default Severity**: warn
-
-## response-error-response-has-content
-
-`4xx` and `5xx` series responses should provide a useful error response object. This rule ensures that error responses provide a content object.
-
-**Bad Example**
-
-```yaml
-responses:
-  400:
-    description: 'example error description`
-```
-
-**Good Example**
-
-```yaml
-responses:
-  400:
-    content:
-      application/json:
-        schema:
-          type: object
-          properties:
-            $ref: '#/components/responses/ErrorResponse'
 ```
 
 **Default Severity**: warn

--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -56,6 +56,12 @@ responses:
 
 **Default Severity**: warn
 
+## response-error-response-schema
+
+`4xx` and `5xx` error responses should provide good information to help the user resolve the error. The error response validations are based on the design principles outlined in the [errors section of the IBM API Handbook](https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors). The `response-error-response-schema` rule is more lenient than what is outlined in the handbook. Specifically, the `response-error-response-schema` rule does not require an Error Container Model and allows for a single Error Model to be provided at the top level of the error response schema or in an `error` field.
+
+**Default Severity**: warn
+
 ## response-example-provided
 
 Response examples are used to generate documentation. To improve the generated documentation, response examples should be provided in the schema object or "next to" the schema object.

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -17,7 +17,6 @@ const { printJson } = require('./utils/jsonResults');
 const printError = require('./utils/printError');
 const preprocessFile = require('./utils/preprocessFile');
 const spectralValidator = require('../spectral/utils/spectral-validator');
-const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 // import the init module for creating a .validaterc file
 const init = require('./utils/init.js');
@@ -169,9 +168,7 @@ const processInput = async function(program) {
 
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset
-  const spectral = new Spectral({
-    computeFingerprint: dedupFunction
-  });
+  const spectral = new Spectral();
   try {
     await spectralValidator.setup(spectral, rulesetFileOverride, configObject);
   } catch (err) {

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -17,6 +17,7 @@ const { printJson } = require('./utils/jsonResults');
 const printError = require('./utils/printError');
 const preprocessFile = require('./utils/preprocessFile');
 const spectralValidator = require('../spectral/utils/spectral-validator');
+const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 // import the init module for creating a .validaterc file
 const init = require('./utils/init.js');
@@ -168,7 +169,9 @@ const processInput = async function(program) {
 
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset
-  const spectral = new Spectral();
+  const spectral = new Spectral({
+    computeFingerprint: dedupFunction
+  });
   try {
     await spectralValidator.setup(spectral, rulesetFileOverride, configObject);
   } catch (err) {

--- a/src/cli-validator/utils/noDeduplication.js
+++ b/src/cli-validator/utils/noDeduplication.js
@@ -1,0 +1,7 @@
+let globalId = 0;
+
+// assigns a unique id to each error
+module.exports = function() {
+  globalId += 1;
+  return globalId;
+};

--- a/src/cli-validator/utils/noDeduplication.js
+++ b/src/cli-validator/utils/noDeduplication.js
@@ -1,7 +1,0 @@
-let globalId = 0;
-
-// assigns a unique id to each error
-module.exports = function() {
-  globalId += 1;
-  return globalId;
-}

--- a/src/cli-validator/utils/noDeduplication.js
+++ b/src/cli-validator/utils/noDeduplication.js
@@ -1,0 +1,7 @@
+let globalId = 0;
+
+// assigns a unique id to each error
+module.exports = function() {
+  globalId += 1;
+  return globalId;
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -13,7 +13,6 @@ module.exports = async function(input, defaultMode = false) {
   // or the default ruleset
   let configObject;
   let spectralResults;
-  const globalId = 0;
   const spectral = new Spectral({
     computeFingerprint: dedupFunction
   });

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,7 +4,6 @@ const buildSwaggerObject = require('../cli-validator/utils/buildSwaggerObject');
 const validator = require('../cli-validator/utils/validator');
 const { formatResultsAsObject } = require('../cli-validator/utils/jsonResults');
 const spectralValidator = require('../spectral/utils/spectral-validator');
-const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 
 module.exports = async function(input, defaultMode = false) {
@@ -13,10 +12,7 @@ module.exports = async function(input, defaultMode = false) {
   // or the default ruleset
   let configObject;
   let spectralResults;
-  let globalId = 0;
-  const spectral = new Spectral({
-    computeFingerprint: dedupFunction
-  });
+  const spectral = new Spectral();
 
   try {
     configObject = await config.get(defaultMode, chalk);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,6 +4,7 @@ const buildSwaggerObject = require('../cli-validator/utils/buildSwaggerObject');
 const validator = require('../cli-validator/utils/validator');
 const { formatResultsAsObject } = require('../cli-validator/utils/jsonResults');
 const spectralValidator = require('../spectral/utils/spectral-validator');
+const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 
 module.exports = async function(input, defaultMode = false) {
@@ -12,7 +13,10 @@ module.exports = async function(input, defaultMode = false) {
   // or the default ruleset
   let configObject;
   let spectralResults;
-  const spectral = new Spectral();
+  let globalId = 0;
+  const spectral = new Spectral({
+    computeFingerprint: dedupFunction
+  });
 
   try {
     configObject = await config.get(defaultMode, chalk);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,6 +4,7 @@ const buildSwaggerObject = require('../cli-validator/utils/buildSwaggerObject');
 const validator = require('../cli-validator/utils/validator');
 const { formatResultsAsObject } = require('../cli-validator/utils/jsonResults');
 const spectralValidator = require('../spectral/utils/spectral-validator');
+const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 
 module.exports = async function(input, defaultMode = false) {
@@ -12,7 +13,10 @@ module.exports = async function(input, defaultMode = false) {
   // or the default ruleset
   let configObject;
   let spectralResults;
-  const spectral = new Spectral();
+  const globalId = 0;
+  const spectral = new Spectral({
+    computeFingerprint: dedupFunction
+  });
 
   try {
     configObject = await config.get(defaultMode, chalk);

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -115,3 +115,13 @@ rules:
     resolved: true
     then:
       function: response-example-provided
+  # ensure error response has content
+  response-error-response-has-content:
+    description: Error response should have a content field
+    given: $.paths[*][*].responses[?(@property >= 400 && @property < 600)]
+    severity: warn
+    formats: ["oas3"]
+    resolved: true
+    then:
+      field: content
+      function: truthy

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -1,6 +1,7 @@
 extends: spectral:oas
 functionsDir: './ibm-oas'
 functions:
+  - error-response-schema
   - response-example-provided
 rules:
 
@@ -125,3 +126,12 @@ rules:
     then:
       field: content
       function: truthy
+  # ensure error response has content
+  response-error-response-schema:
+    message: "{{error}}"
+    given: $.paths[*][*].responses[?(@property >= 400 && @property < 600)].content[*].schema
+    severity: warn
+    formats: ["oas3"]
+    resolved: true
+    then:
+      function: error-response-schema

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -96,7 +96,19 @@ rules:
   oas3-schema: off
   # Turn off - duplicates non-configurable validation in base validator
   oas3-unused-components-schema: off
-
+  
+  # custom Spectral rule to ensure request bodies and non-204 responses provide content object
+  content-entry-provided:
+    description: Request bodies and non-204 responses should define a content object
+    given:
+      - $.paths[*][*].responses[?(@property != '204')]
+      - $.paths[*][*].requestBody
+    severity: warn
+    formats: ["oas3"]
+    resolved: true
+    then:
+      field: content
+      function: truthy
   # custom Spectral rule to ensure content object contains schema
   content-entry-contains-schema:
     description: Content entries in request and response bodies must specify a schema
@@ -116,16 +128,6 @@ rules:
     resolved: true
     then:
       function: response-example-provided
-  # ensure error response has content
-  response-error-response-has-content:
-    description: Error response should have a content field
-    given: $.paths[*][*].responses[?(@property >= 400 && @property < 600)]
-    severity: warn
-    formats: ["oas3"]
-    resolved: true
-    then:
-      field: content
-      function: truthy
   # ensure error response has content
   response-error-response-schema:
     message: "{{error}}"

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -66,7 +66,13 @@ function validateErrorModelSchema(errorModelSchema, pathToSchema) {
       errors.push({
         message:
           'Error Model should contain `code` field, a snake-case, string, enum error code',
-        path: [...pathToSchema, 'properties']
+        path: [...pathToSchema, 'properties', 'code']
+      });
+    }
+    if (!hasMessageField(errorModelSchema.properties)) {
+      errors.push({
+        message: 'Error Model should contain a string, `message`, field',
+        path: [...pathToSchema, 'properties', 'message']
       });
     }
   }
@@ -84,10 +90,15 @@ function validStatusCodeField(errorResponseProperties) {
 function hasCodeField(errorModelSchemaProperties) {
   return (
     errorModelSchemaProperties.code &&
-    // type either not defined or type defined as a string
-    (!errorModelSchemaProperties.code.type ||
-      errorModelSchemaProperties.code.type === 'string') &&
+    errorModelSchemaProperties.code.type === 'string' &&
     errorModelSchemaProperties.code.enum
+  );
+}
+
+function hasMessageField(errorModelSchemaProperties) {
+  return (
+    errorModelSchemaProperties.message &&
+    errorModelSchemaProperties.message.type === 'string'
   );
 }
 

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -1,9 +1,14 @@
 module.exports = function(errorResponseSchema, _opts, paths) {
   const errors = [];
+  const rootPath = paths.target !== void 0 ? paths.target : paths.given;
   if (!schemaIsObjectWithProperties(errorResponseSchema)) {
-    return [{ message: 'Error response should be an object with properties' }];
+    return [
+      {
+        message: 'Error response should be an object with properties',
+        path: rootPath
+      }
+    ];
   } else {
-    const rootPath = paths.target !== void 0 ? paths.target : paths.given;
     errors.push(
       ...validateErrorResponseProperties(errorResponseSchema.properties, [
         ...rootPath,
@@ -22,7 +27,7 @@ function validateErrorResponseProperties(
   if (!hasTraceField(errorResponseProperties)) {
     errors.push({
       message: 'Error response should have a uuid `trace` field',
-      path: pathToProperties
+      path: [...pathToProperties, 'trace']
     });
   }
   if (!validStatusCodeField(errorResponseProperties)) {
@@ -57,6 +62,13 @@ function validateErrorResponseProperties(
         'error'
       ])
     );
+  } else {
+    // no `errors` or `error` field, so recommend that one be added
+    errors.push({
+      message:
+        'Error response should contain an error model container called `errors`',
+      path: pathToProperties
+    });
   }
   return errors;
 }

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -10,20 +10,16 @@ module.exports = function(errorResponseSchema, _opts, paths) {
     ];
   } else {
     errors.push(
-      ...validateErrorResponseProperties(errorResponseSchema.properties, [
-        ...rootPath,
-        'properties'
-      ])
+      ...validateErrorResponseProperties(errorResponseSchema, rootPath)
     );
   }
   return errors;
 };
 
-function validateErrorResponseProperties(
-  errorResponseProperties,
-  pathToProperties
-) {
+function validateErrorResponseProperties(errorResponseSchema, pathToSchema) {
   const errors = [];
+  const errorResponseProperties = errorResponseSchema.properties;
+  const pathToProperties = [...pathToSchema, 'properties'];
   if (!hasTraceField(errorResponseProperties)) {
     errors.push({
       message: 'Error response should have a uuid `trace` field',
@@ -63,12 +59,8 @@ function validateErrorResponseProperties(
       ])
     );
   } else {
-    // no `errors` or `error` field, so recommend that one be added
-    errors.push({
-      message:
-        'Error response should contain an error model container called `errors`',
-      path: pathToProperties
-    });
+    // no `errors` or `error` field, so expect error model at top level of schema
+    errors.push(...validateErrorModelSchema(errorResponseSchema, pathToSchema));
   }
   return errors;
 }

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -129,7 +129,6 @@ function hasMoreInfoField(errorModelSchemaProperties) {
 
 function hasTraceField(errorResponseProperties) {
   return (
-    errorResponseProperties &&
     errorResponseProperties.trace &&
     errorResponseProperties.trace.type === 'string'
   );

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -28,6 +28,15 @@ function validateErrorResponseProperties(errorResponseProperties, rootPath) {
       path: [...rootPath, 'properties', 'status_code']
     });
   }
+  if (errorResponseProperties.errors) {
+    // validate `errors` is error model container
+    if (errorResponseProperties.errors.type !== 'array') {
+      errors.push({
+        message: '`errors` field should be an array of error models',
+        path: [...rootPath, 'properties', 'errors']
+      });
+    }
+  }
   return errors;
 }
 

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -49,6 +49,14 @@ function validateErrorResponseProperties(
         ])
       );
     }
+  } else if (errorResponseProperties.error) {
+    // expect a single error model, validate error model schema
+    errors.push(
+      ...validateErrorModelSchema(errorResponseProperties.error, [
+        ...pathToProperties,
+        'error'
+      ])
+    );
   }
   return errors;
 }

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -1,13 +1,29 @@
 module.exports = function(errorResponseSchema) {
+  let errors = [];
   if (!schemaIsObject(errorResponseSchema)) {
-    return [
-      {
-        message: 'Error response should be an object'
-      }
-    ];
+    return [{ message: 'Error response should be an object' }];
+  } else {
+    errors.push(
+      ...validateErrorResponseProperties(errorResponseSchema.properties)
+    );
   }
+  return errors;
 };
 
+function validateErrorResponseProperties(errorResponseProperties) {
+  let errors = [];
+  if (!hasTraceField(errorResponseProperties)) {
+    errors.push({ message: 'Error response should have a uuid `trace` field' });
+  }
+  return errors;
+}
+
+function hasTraceField(errorResponseProperties) {
+  return errorResponseProperties && errorResponseProperties.trace && errorResponseProperties.trace.type === 'string' && errorResponseProperties.trace.format === 'uuid';
+}
+
 function schemaIsObject(errorResponseSchema) {
-  return errorResponseSchema.properties || errorResponseSchema.type === 'object';
+  return (
+    errorResponseSchema.properties || errorResponseSchema.type === 'object'
+  );
 }

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -1,0 +1,13 @@
+module.exports = function(errorResponseSchema) {
+  if (!schemaIsObject(errorResponseSchema)) {
+    return [
+      {
+        message: 'Error response should be an object'
+      }
+    ];
+  }
+};
+
+function schemaIsObject(errorResponseSchema) {
+  return errorResponseSchema.properties || errorResponseSchema.type === 'object';
+}

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -75,6 +75,13 @@ function validateErrorModelSchema(errorModelSchema, pathToSchema) {
         path: [...pathToSchema, 'properties', 'message']
       });
     }
+    if (!hasMoreInfoField(errorModelSchema.properties)) {
+      errors.push({
+        message:
+          'Error Model should contain `more_info` field that contains a URL with more info about the error',
+        path: [...pathToSchema, 'properties', 'more_info']
+      });
+    }
   }
   return errors;
 }
@@ -99,6 +106,13 @@ function hasMessageField(errorModelSchemaProperties) {
   return (
     errorModelSchemaProperties.message &&
     errorModelSchemaProperties.message.type === 'string'
+  );
+}
+
+function hasMoreInfoField(errorModelSchemaProperties) {
+  return (
+    errorModelSchemaProperties.more_info &&
+    errorModelSchemaProperties.more_info.type === 'string'
   );
 }
 

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -77,7 +77,7 @@ function validateErrorModelSchema(errorModelSchema, pathToSchema) {
     if (!hasCodeField(errorModelSchema.properties)) {
       errors.push({
         message:
-          'Error Model should contain `code` field, a snake-case, string, enum error code',
+          'Error Model should contain `code` field, a snake-case, string error code',
         path: [...pathToSchema, 'properties', 'code']
       });
     }
@@ -109,8 +109,7 @@ function validStatusCodeField(errorResponseProperties) {
 function hasCodeField(errorModelSchemaProperties) {
   return (
     errorModelSchemaProperties.code &&
-    errorModelSchemaProperties.code.type === 'string' &&
-    errorModelSchemaProperties.code.enum
+    errorModelSchemaProperties.code.type === 'string'
   );
 }
 
@@ -132,8 +131,7 @@ function hasTraceField(errorResponseProperties) {
   return (
     errorResponseProperties &&
     errorResponseProperties.trace &&
-    errorResponseProperties.trace.type === 'string' &&
-    errorResponseProperties.trace.format === 'uuid'
+    errorResponseProperties.trace.type === 'string'
   );
 }
 

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -1,25 +1,51 @@
-module.exports = function(errorResponseSchema) {
-  let errors = [];
+module.exports = function(errorResponseSchema, _opts, paths) {
+  const errors = [];
   if (!schemaIsObject(errorResponseSchema)) {
     return [{ message: 'Error response should be an object' }];
   } else {
+    const rootPath = paths.target !== void 0 ? paths.target : paths.given;
     errors.push(
-      ...validateErrorResponseProperties(errorResponseSchema.properties)
+      ...validateErrorResponseProperties(
+        errorResponseSchema.properties,
+        rootPath
+      )
     );
   }
   return errors;
 };
 
-function validateErrorResponseProperties(errorResponseProperties) {
-  let errors = [];
+function validateErrorResponseProperties(errorResponseProperties, rootPath) {
+  const errors = [];
   if (!hasTraceField(errorResponseProperties)) {
-    errors.push({ message: 'Error response should have a uuid `trace` field' });
+    errors.push({
+      message: 'Error response should have a uuid `trace` field',
+      path: [...rootPath, 'properties']
+    });
+  }
+  if (!validStatusCodeField(errorResponseProperties)) {
+    errors.push({
+      message: '`status_code` field must be an integer',
+      path: [...rootPath, 'properties', 'status_code']
+    });
   }
   return errors;
 }
 
+function validStatusCodeField(errorResponseProperties) {
+  // valid if no status_code provided or if the provided status_code is an integer
+  return (
+    !errorResponseProperties.status_code ||
+    errorResponseProperties.status_code.type === 'integer'
+  );
+}
+
 function hasTraceField(errorResponseProperties) {
-  return errorResponseProperties && errorResponseProperties.trace && errorResponseProperties.trace.type === 'string' && errorResponseProperties.trace.format === 'uuid';
+  return (
+    errorResponseProperties &&
+    errorResponseProperties.trace &&
+    errorResponseProperties.trace.type === 'string' &&
+    errorResponseProperties.trace.format === 'uuid'
+  );
 }
 
 function schemaIsObject(errorResponseSchema) {

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -60,6 +60,15 @@ function validateErrorModelSchema(errorModelSchema, pathToSchema) {
       message: 'Error Model should be an object with properties',
       path: pathToSchema
     });
+  } else {
+    // error model has properties, validate the properties
+    if (!hasCodeField(errorModelSchema.properties)) {
+      errors.push({
+        message:
+          'Error Model should contain `code` field, a snake-case, string, enum error code',
+        path: [...pathToSchema, 'properties']
+      });
+    }
   }
   return errors;
 }
@@ -69,6 +78,16 @@ function validStatusCodeField(errorResponseProperties) {
   return (
     !errorResponseProperties.status_code ||
     errorResponseProperties.status_code.type === 'integer'
+  );
+}
+
+function hasCodeField(errorModelSchemaProperties) {
+  return (
+    errorModelSchemaProperties.code &&
+    // type either not defined or type defined as a string
+    (!errorModelSchemaProperties.code.type ||
+      errorModelSchemaProperties.code.type === 'string') &&
+    errorModelSchemaProperties.code.enum
   );
 }
 

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -363,7 +363,7 @@ describe('test expected output - OpenAPI 3', function() {
     const validationResults = await inCodeValidator(oas3Object, defaultMode);
 
     expect(validationResults.errors.length).toBe(4);
-    expect(validationResults.warnings.length).toBe(11);
+    expect(validationResults.warnings.length).toBe(16);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 

--- a/test/cli-validator/tests/info-and-hint.test.js
+++ b/test/cli-validator/tests/info-and-hint.test.js
@@ -35,7 +35,7 @@ describe('test info and hint rules - OAS3', function() {
     expect(jsonOutput['errors'].length).toBe(4);
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(8);
+    expect(jsonOutput['warnings'].length).toBe(13);
 
     // Verify infos
     expect(jsonOutput['infos'].length).toBe(1);

--- a/test/spectral/mockFiles/oas3/disabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/disabled-rules.yml
@@ -68,6 +68,10 @@ paths:
       responses:
         '405':
           description: "Invalid input"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: unexpected error
           content:
@@ -166,8 +170,16 @@ paths:
       responses:
         405:
           description: "Invalid input"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: "Invalid input"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     Sibling:

--- a/test/spectral/mockFiles/oas3/disabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/disabled-rules.yml
@@ -260,6 +260,9 @@ components:
         message:
           type: string
           description: "message property"
+        trace:
+          type: string
+          format: uuid
       example:
         code: 123
         message: "error occurred"

--- a/test/spectral/mockFiles/oas3/disabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/disabled-rules.yml
@@ -250,19 +250,28 @@ components:
       description:
         An error in processing a service request
       required:
-        - code
-        - message
+        - error
+        - trace
       properties:
-        code:
-          type: integer
-          format: int32
-          description: "code property"
-        message:
-          type: string
-          description: "message property"
+        error:
+          type: 'object'
+          properties:
+            code:
+              type: string
+              enum:
+              - 'error1'
+              - 'error2'
+              description: "code property"
+            message:
+              type: string
+              description: "message property"
+            more_info:
+              type: string
         trace:
           type: string
           format: uuid
       example:
-        code: 123
-        message: "error occurred"
+        error:
+          code: 'error1'
+          message: "error occurred"
+        trace: "00112233-4455-6677-8899-aabbccddeeff"

--- a/test/spectral/tests/custom-rules/content-entry-contains-schema.test.js
+++ b/test/spectral/tests/custom-rules/content-entry-contains-schema.test.js
@@ -3,7 +3,7 @@ const inCodeValidator = require('../../../../src/lib');
 describe('spectral - test validation that schema provided in content object', function() {
   it('should not error when the content object contains a schema', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
       paths: {
         path1: {
           get: {
@@ -42,7 +42,7 @@ describe('spectral - test validation that schema provided in content object', fu
 
   it('should error when a content object in a requestBody reference does not contain a schema', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
       paths: {
         path1: {
           post: {
@@ -76,7 +76,7 @@ describe('spectral - test validation that schema provided in content object', fu
 
   it('should error when a content object in a response reference does not contain a schema', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
       paths: {
         path1: {
           post: {
@@ -112,7 +112,7 @@ describe('spectral - test validation that schema provided in content object', fu
 
   it('should error when the content object does not contain a schema in a response', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
       paths: {
         'pets/{petId}': {
           get: {
@@ -149,7 +149,7 @@ describe('spectral - test validation that schema provided in content object', fu
 
   it('should error when the content object does not contain a schema in a request body', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
       paths: {
         createPet: {
           post: {

--- a/test/spectral/tests/custom-rules/content-entry-provided.test.js
+++ b/test/spectral/tests/custom-rules/content-entry-provided.test.js
@@ -1,0 +1,93 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test content entry validation does not produce false positives', function() {
+  it('should not error when content object provided or for 204 response without content', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'ErrorAPI'
+      },
+      servers: [{ url: 'http://api.errorapi.com/v1' }],
+      paths: {
+        path1: {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  $ref: '#/components/schemas/GenericSchema'
+                }
+              }
+            },
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              },
+              '204': {
+                description: 'Success response with no response body'
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          GenericSchema: {
+            type: 'object',
+            properties: {
+              prop: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Request bodies and non-204 responses should define a content object'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+});
+
+describe('spectral - test content entry validation does not produce false positives', function() {
+  it('should error when content object not provided', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'ErrorAPI'
+      },
+      servers: [{ url: 'http://api.errorapi.com/v1' }],
+      paths: {
+        path1: {
+          post: {
+            requestBody: {},
+            responses: {
+              '200': {},
+              '300': {},
+              '400': {},
+              '500': {}
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Request bodies and non-204 responses should define a content object'
+    );
+    expect(expectedWarnings.length).toBe(5);
+  });
+});

--- a/test/spectral/tests/custom-rules/error-response-schema.test.js
+++ b/test/spectral/tests/custom-rules/error-response-schema.test.js
@@ -121,7 +121,9 @@ describe('spectral - test error-response validation does not produce false posit
 
   it('should not error when content object provided', function() {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error response should have a content field'
+      warn =>
+        warn.message ===
+        'Request bodies and non-204 responses should define a content object'
     );
     expect(expectedWarnings.length).toBe(0);
   });
@@ -422,7 +424,9 @@ describe('spectral - test error-response validation catches invalid error respon
 
   it('should error for missing content for failure response with no content', function() {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error response should have a content field'
+      warn =>
+        warn.message ===
+        'Request bodies and non-204 responses should define a content object'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -258,7 +258,8 @@ describe('spectral - test error-response validation catches invalid error respon
 
   it('should error for error-response that is not an object', function() {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error response should be an object'
+      warn =>
+        warn.message === 'Error response should be an object with properties'
     );
     expect(expectedWarnings.length).toBe(1);
   });
@@ -287,7 +288,7 @@ describe('spectral - test error-response validation catches invalid error respon
 
   it('should error for error-response that with an invalid status_code field', function() {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error Model should be an object'
+      warn => warn.message === 'Error Model should be an object with properties'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -1,7 +1,9 @@
 const inCodeValidator = require('../../../../src/lib');
 
 describe('spectral - test error-response validation does not produce false positives', function() {
-  it('should not error for missing content for success response with no content or failure response with content', async () => {
+  let res;
+
+  beforeAll(async () => {
     const spec = {
       openapi: '3.0.0',
       info: {
@@ -114,9 +116,84 @@ describe('spectral - test error-response validation does not produce false posit
       }
     };
 
-    const res = await inCodeValidator(spec, true);
+    res = await inCodeValidator(spec, true);
+  });
+
+  it('should not error when content object provided', function() {
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === 'Error response should have a content field'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error-response that is an object', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message === 'Error response should be an object with properties'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error-response that includes trace field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === 'Error response should have a uuid `trace` field'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error-response with a valid status_code field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === '`status_code` field must be an integer'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error-response `errors` field that is an array', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message === '`errors` field should be an array of error models'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error-response that with `errors` field that has object items', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === 'Error Model should be an object with properties'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error model with valid code field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Error Model should contain `code` field, a snake-case, string, enum error code'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error model with valid message field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message === 'Error Model should contain a string, `message`, field'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error model with valid `more_info` field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Error Model should contain `more_info` field that contains a URL with more info about the error'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+
+  it('should not error for error model with `errors` or `error` field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Error response should contain an error model container called `errors`'
     );
     expect(expectedWarnings.length).toBe(0);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -141,10 +141,13 @@ describe('spectral - test error-response validation catches invalid error respon
                 description: 'Success response with no response body'
               },
               '400': {
-                $ref: '#/components/responses/BadErrorModelResponse'
+                $ref: '#/components/responses/NoObjectErrorModelResponse'
               },
               '404': {
                 $ref: '#/components/responses/NoContentErrorResponse'
+              },
+              '500': {
+                $ref: '#/components/responses/MissingPropertiesErrorResponse'
               }
             }
           }
@@ -152,7 +155,7 @@ describe('spectral - test error-response validation catches invalid error respon
       },
       components: {
         responses: {
-          BadErrorModelResponse: {
+          NoObjectErrorModelResponse: {
             content: {
               'application/json': {
                 schema: {
@@ -165,16 +168,29 @@ describe('spectral - test error-response validation catches invalid error respon
             schema: {
               $ref: '#/components/schemas/BadErrorModel'
             }
+          },
+          MissingPropertiesErrorResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/MissingPropertiesErrorModel'
+                }
+              }
+            }
           }
         },
         schemas: {
           BadErrorModel: {
             type: 'string'
+          },
+          MissingPropertiesErrorModel: {
+            type: 'object',
+            properties: {}
           }
         }
       }
     };
-    
+
     res = await inCodeValidator(spec, true);
   });
 
@@ -188,6 +204,13 @@ describe('spectral - test error-response validation catches invalid error respon
   it('should error for error-response that is not an object', function() {
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === 'Error response should be an object'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+
+  it('should error for error-response that does not include error field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === 'Error response should have a uuid `trace` field'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -421,4 +421,13 @@ describe('spectral - test error-response validation catches invalid error respon
     );
     expect(expectedWarnings.length).toBe(2);
   });
+
+  it('should error for error model without `errors` or `error` field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Error response should contain an error model container called `errors`'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
 });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -270,6 +270,9 @@ describe('spectral - test error-response validation catches invalid error respon
                     },
                     message: {
                       type: 'integer'
+                    },
+                    more_info: {
+                      type: 'integer'
                     }
                   }
                 }
@@ -347,6 +350,14 @@ describe('spectral - test error-response validation catches invalid error respon
     const expectedWarnings = res.warnings.filter(
       warn =>
         warn.message === 'Error Model should contain a string, `message`, field'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+
+  it('should error for error model with missing or invalid `more_info` field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message === 'Error Model should contain `more_info` field that contains a URL with more info about the error'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -188,15 +188,6 @@ describe('spectral - test error-response validation does not produce false posit
     );
     expect(expectedWarnings.length).toBe(0);
   });
-
-  it('should not error for error model with `errors` or `error` field', function() {
-    const expectedWarnings = res.warnings.filter(
-      warn =>
-        warn.message ===
-        'Error response should contain an error model container called `errors`'
-    );
-    expect(expectedWarnings.length).toBe(0);
-  });
 });
 
 describe('spectral - test error-response validation catches invalid error responses', function() {
@@ -479,7 +470,7 @@ describe('spectral - test error-response validation catches invalid error respon
         warn.message ===
         'Error Model should contain `code` field, a snake-case, string, enum error code'
     );
-    expect(expectedWarnings.length).toBe(2);
+    expect(expectedWarnings.length).toBe(3);
   });
 
   it('should error for error model with missing or invalid message field', function() {
@@ -487,7 +478,7 @@ describe('spectral - test error-response validation catches invalid error respon
       warn =>
         warn.message === 'Error Model should contain a string, `message`, field'
     );
-    expect(expectedWarnings.length).toBe(2);
+    expect(expectedWarnings.length).toBe(3);
   });
 
   it('should error for error model with missing or invalid `more_info` field', function() {
@@ -496,15 +487,6 @@ describe('spectral - test error-response validation catches invalid error respon
         warn.message ===
         'Error Model should contain `more_info` field that contains a URL with more info about the error'
     );
-    expect(expectedWarnings.length).toBe(2);
-  });
-
-  it('should error for error model without `errors` or `error` field', function() {
-    const expectedWarnings = res.warnings.filter(
-      warn =>
-        warn.message ===
-        'Error response should contain an error model container called `errors`'
-    );
-    expect(expectedWarnings.length).toBe(1);
+    expect(expectedWarnings.length).toBe(3);
   });
 });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -146,6 +146,10 @@ describe('spectral - test error-response validation catches invalid error respon
               '404': {
                 $ref: '#/components/responses/NoContentErrorResponse'
               },
+              '412': {
+                $ref:
+                  '#/components/responses/ErrorContainerModelItemsNotObjectsResponse'
+              },
               '500': {
                 $ref: '#/components/responses/MissingPropertiesErrorResponse'
               },
@@ -189,6 +193,16 @@ describe('spectral - test error-response validation catches invalid error respon
                 }
               }
             }
+          },
+          ErrorContainerModelItemsNotObjectsResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref:
+                    '#/components/schemas/ErrorContainerModelItemsNotObjects'
+                }
+              }
+            }
           }
         },
         schemas: {
@@ -209,6 +223,22 @@ describe('spectral - test error-response validation catches invalid error respon
               },
               status_code: {
                 type: 'string'
+              }
+            }
+          },
+          ErrorContainerModelItemsNotObjects: {
+            type: 'object',
+            properties: {
+              errors: {
+                type: 'array',
+                items: {}
+              },
+              trace: {
+                type: 'string',
+                format: 'uuid'
+              },
+              status_code: {
+                type: 'integer'
               }
             }
           }
@@ -251,6 +281,13 @@ describe('spectral - test error-response validation catches invalid error respon
     const expectedWarnings = res.warnings.filter(
       warn =>
         warn.message === '`errors` field should be an array of error models'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+
+  it('should error for error-response that with an invalid status_code field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === 'Error Model should be an object'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -155,6 +155,10 @@ describe('spectral - test error-response validation catches invalid error respon
               },
               '501': {
                 $ref: '#/components/responses/IncorrectPropertiesErrorResponse'
+              },
+              '502': {
+                $ref:
+                  '#/components/responses/ErrorContainerModelIncorrectItemsPropertiesResponse'
               }
             }
           }
@@ -203,6 +207,16 @@ describe('spectral - test error-response validation catches invalid error respon
                 }
               }
             }
+          },
+          ErrorContainerModelIncorrectItemsPropertiesResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref:
+                    '#/components/schemas/ErrorContainerModelIncorrectItemsProperties'
+                }
+              }
+            }
           }
         },
         schemas: {
@@ -232,6 +246,30 @@ describe('spectral - test error-response validation catches invalid error respon
               errors: {
                 type: 'array',
                 items: {}
+              },
+              trace: {
+                type: 'string',
+                format: 'uuid'
+              },
+              status_code: {
+                type: 'integer'
+              }
+            }
+          },
+          ErrorContainerModelIncorrectItemsProperties: {
+            type: 'object',
+            properties: {
+              errors: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      type: 'string'
+                      // should be an enum
+                    }
+                  }
+                }
               },
               trace: {
                 type: 'string',
@@ -289,6 +327,15 @@ describe('spectral - test error-response validation catches invalid error respon
   it('should error for error-response that with an invalid status_code field', function() {
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === 'Error Model should be an object with properties'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+
+  it('should error for error-response that with an invalid status_code field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Error Model should contain `code` field, a snake-case, string, enum error code'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -326,8 +326,8 @@ describe('spectral - test error-response validation catches invalid error respon
             properties: {
               errors: {},
               trace: {
-                type: 'string'
-                // missing format, uuid
+                // should be string, uuid
+                type: 'integer'
               },
               status_code: {
                 type: 'string'
@@ -402,8 +402,8 @@ describe('spectral - test error-response validation catches invalid error respon
             type: 'object',
             properties: {
               code: {
-                type: 'string'
-                // should be an enum
+                // should be string
+                type: 'integer'
               },
               message: {
                 type: 'integer'
@@ -468,7 +468,7 @@ describe('spectral - test error-response validation catches invalid error respon
     const expectedWarnings = res.warnings.filter(
       warn =>
         warn.message ===
-        'Error Model should contain `code` field, a snake-case, string, enum error code'
+        'Error Model should contain `code` field, a snake-case, string error code'
     );
     expect(expectedWarnings.length).toBe(3);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -205,6 +205,9 @@ describe('spectral - test error-response validation catches invalid error respon
               trace: {
                 type: 'string'
                 // missing format, uuid
+              },
+              status_code: {
+                type: 'string'
               }
             }
           }
@@ -234,5 +237,12 @@ describe('spectral - test error-response validation catches invalid error respon
       warn => warn.message === 'Error response should have a uuid `trace` field'
     );
     expect(expectedWarnings.length).toBe(2);
+  });
+
+  it('should error for error-response that does not include error field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === '`status_code` field must be an integer'
+    );
+    expect(expectedWarnings.length).toBe(1);
   });
 });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -159,6 +159,13 @@ describe('spectral - test error-response validation catches invalid error respon
               '502': {
                 $ref:
                   '#/components/responses/ErrorContainerModelIncorrectItemsPropertiesResponse'
+              },
+              '503': {
+                $ref:
+                  '#/components/responses/SingleErrorModelIncorrectPropertiesResponse'
+              },
+              '504': {
+                $ref: '#/components/responses/SingleErrorModelNotObjectResponse'
               }
             }
           }
@@ -217,6 +224,25 @@ describe('spectral - test error-response validation catches invalid error respon
                 }
               }
             }
+          },
+          SingleErrorModelIncorrectPropertiesResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref:
+                    '#/components/schemas/SingleErrorModelIncorrectProperties'
+                }
+              }
+            }
+          },
+          SingleErrorModelNotObjectResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/SingleErrorModelNotObject'
+                }
+              }
+            }
           }
         },
         schemas: {
@@ -262,19 +288,7 @@ describe('spectral - test error-response validation catches invalid error respon
               errors: {
                 type: 'array',
                 items: {
-                  type: 'object',
-                  properties: {
-                    code: {
-                      type: 'string'
-                      // should be an enum
-                    },
-                    message: {
-                      type: 'integer'
-                    },
-                    more_info: {
-                      type: 'integer'
-                    }
-                  }
+                  $ref: '#/components/schemas/IncorrectPropertiesSchema'
                 }
               },
               trace: {
@@ -282,6 +296,51 @@ describe('spectral - test error-response validation catches invalid error respon
                 format: 'uuid'
               },
               status_code: {
+                type: 'integer'
+              }
+            }
+          },
+          SingleErrorModelNotObject: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string'
+              },
+              trace: {
+                type: 'string',
+                format: 'uuid'
+              },
+              status_code: {
+                type: 'integer'
+              }
+            }
+          },
+          SingleErrorModelIncorrectProperties: {
+            type: 'object',
+            properties: {
+              error: {
+                $ref: '#/components/schemas/IncorrectPropertiesSchema'
+              },
+              trace: {
+                type: 'string',
+                format: 'uuid'
+              },
+              status_code: {
+                type: 'integer'
+              }
+            }
+          },
+          IncorrectPropertiesSchema: {
+            type: 'object',
+            properties: {
+              code: {
+                type: 'string'
+                // should be an enum
+              },
+              message: {
+                type: 'integer'
+              },
+              more_info: {
                 type: 'integer'
               }
             }
@@ -334,7 +393,7 @@ describe('spectral - test error-response validation catches invalid error respon
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === 'Error Model should be an object with properties'
     );
-    expect(expectedWarnings.length).toBe(1);
+    expect(expectedWarnings.length).toBe(2);
   });
 
   it('should error for error model with missing or invalid code field', function() {
@@ -343,7 +402,7 @@ describe('spectral - test error-response validation catches invalid error respon
         warn.message ===
         'Error Model should contain `code` field, a snake-case, string, enum error code'
     );
-    expect(expectedWarnings.length).toBe(1);
+    expect(expectedWarnings.length).toBe(2);
   });
 
   it('should error for error model with missing or invalid message field', function() {
@@ -351,7 +410,7 @@ describe('spectral - test error-response validation catches invalid error respon
       warn =>
         warn.message === 'Error Model should contain a string, `message`, field'
     );
-    expect(expectedWarnings.length).toBe(1);
+    expect(expectedWarnings.length).toBe(2);
   });
 
   it('should error for error model with missing or invalid `more_info` field', function() {
@@ -360,6 +419,6 @@ describe('spectral - test error-response validation catches invalid error respon
         warn.message ===
         'Error Model should contain `more_info` field that contains a URL with more info about the error'
     );
-    expect(expectedWarnings.length).toBe(1);
+    expect(expectedWarnings.length).toBe(2);
   });
 });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -1,0 +1,173 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test error-response validation does not produce false positives', function() {
+  it('should not error for missing content for success response with no content or failure response with content', async () => {
+    const spec = {
+      Openapi: '3.0.0',
+      paths: {
+        path1: {
+          get: {
+            responses: {
+              '204': {
+                description: 'Success response with no response body'
+              },
+              '400': {
+                $ref: '#/components/responses/ErrorResponse'
+              },
+              '404': {
+                $ref: '#/components/responses/AcceptableErrorResponse'
+              },
+              '500': {
+                $ref: '#/components/responses/ErrorResponse'
+              }
+            }
+          }
+        }
+      },
+      components: {
+        responses: {
+          AcceptableErrorResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/AcceptableErrorModel'
+                },
+              }
+            }
+          },
+          ErrorResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ErrorContainerModel'
+                },
+              }
+            }
+          }
+        },
+        schemas: {
+          AcceptableErrorModel: {
+            type: 'object',
+            properties: {
+              error: {
+                $ref: '#/components/schemas/ErrorModel'
+              },
+              trace: {
+                type: 'string',
+                format: 'uuid'
+              }
+            }
+          },
+          ErrorContainerModel: {
+            type: 'object',
+            properties: {
+              errors: {
+                type: 'array',
+                items: {
+                  $ref: '#/components/schemas/ErrorModel'
+                }
+              },
+              trace: {
+                type: 'string',
+                format: 'uuid'
+              },
+              status_code: {
+                type: 'integer'
+              }
+            }
+          },
+          ErrorModel: {
+            type: 'object',
+            properties: {
+              code: {
+                type: 'string',
+                enum: [
+                  'error_1',
+                  'error_2'
+                ]
+              },
+              message: {
+                type: 'string'
+              },
+              more_info: {
+                type: 'string',
+                description: 'url with link to more information about the error'
+              },
+              target: {
+                $ref: '#/components/schemas/ErrorTargetModel'
+              }
+            }
+          },
+          ErrorTargetModel: {
+            type: {
+              type: 'string',
+              enum: [
+                'field',
+                'parameter',
+                'header'
+              ]
+            },
+            name: {
+              type: 'string',
+              description: 'name of the problematic field that caused the error'
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Error response should have a content field'
+    );
+    expect(expectedWarnings.length).toBe(0);
+  });
+});
+
+describe('spectral - test error-response validation catches invalid error responses', function() {
+  it('should error for missing content for failure response with no content', async () => {
+    const spec = {
+      Openapi: '3.0.0',
+      paths: {
+        path1: {
+          get: {
+            responses: {
+              '204': {
+                description: 'Success response with no response body'
+              },
+              '400': {
+                $ref: '#/components/responses/BadErrorResponse'
+              }
+            }
+          }
+        }
+      },
+      components: {
+        responses: {
+          BadErrorResponse: {
+            schema: {
+              $ref: '#/components/schemas/BadErrorModel'
+            }
+          }
+        },
+        schemas: {
+          BadErrorModel: {
+            type: 'string',
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    expect(res.warnings).toBe('');
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        'Error response should have a content field'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+});
+

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -249,7 +249,8 @@ describe('spectral - test error-response validation catches invalid error respon
 
   it('should error for error-response that with an invalid status_code field', function() {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === '`errors` field should be an array of error models'
+      warn =>
+        warn.message === '`errors` field should be an array of error models'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -232,14 +232,14 @@ describe('spectral - test error-response validation catches invalid error respon
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response that does not include error field', function() {
+  it('should error for error-response that does not include trace field', function() {
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === 'Error response should have a uuid `trace` field'
     );
     expect(expectedWarnings.length).toBe(2);
   });
 
-  it('should error for error-response that does not include error field', function() {
+  it('should error for error-response that with an invalid status_code field', function() {
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === '`status_code` field must be an integer'
     );

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -267,6 +267,9 @@ describe('spectral - test error-response validation catches invalid error respon
                     code: {
                       type: 'string'
                       // should be an enum
+                    },
+                    message: {
+                      type: 'integer'
                     }
                   }
                 }
@@ -316,7 +319,7 @@ describe('spectral - test error-response validation catches invalid error respon
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response that with an invalid status_code field', function() {
+  it('should error for error-response `errors` field that is not an array', function() {
     const expectedWarnings = res.warnings.filter(
       warn =>
         warn.message === '`errors` field should be an array of error models'
@@ -324,18 +327,26 @@ describe('spectral - test error-response validation catches invalid error respon
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response that with an invalid status_code field', function() {
+  it('should error for error-response that with `errors` field that does not have object items', function() {
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === 'Error Model should be an object with properties'
     );
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response that with an invalid status_code field', function() {
+  it('should error for error model with missing or invalid code field', function() {
     const expectedWarnings = res.warnings.filter(
       warn =>
         warn.message ===
         'Error Model should contain `code` field, a snake-case, string, enum error code'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+
+  it('should error for error model with missing or invalid message field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message === 'Error Model should contain a string, `message`, field'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -357,7 +357,8 @@ describe('spectral - test error-response validation catches invalid error respon
   it('should error for error model with missing or invalid `more_info` field', function() {
     const expectedWarnings = res.warnings.filter(
       warn =>
-        warn.message === 'Error Model should contain `more_info` field that contains a URL with more info about the error'
+        warn.message ===
+        'Error Model should contain `more_info` field that contains a URL with more info about the error'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -148,6 +148,9 @@ describe('spectral - test error-response validation catches invalid error respon
               },
               '500': {
                 $ref: '#/components/responses/MissingPropertiesErrorResponse'
+              },
+              '501': {
+                $ref: '#/components/responses/IncorrectPropertiesErrorResponse'
               }
             }
           }
@@ -177,6 +180,15 @@ describe('spectral - test error-response validation catches invalid error respon
                 }
               }
             }
+          },
+          IncorrectPropertiesErrorResponse: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/IncorrectPropertiesModel'
+                }
+              }
+            }
           }
         },
         schemas: {
@@ -186,6 +198,15 @@ describe('spectral - test error-response validation catches invalid error respon
           MissingPropertiesErrorModel: {
             type: 'object',
             properties: {}
+          },
+          IncorrectPropertiesModel: {
+            type: 'object',
+            properties: {
+              trace: {
+                type: 'string'
+                // missing format, uuid
+              }
+            }
           }
         }
       }
@@ -212,6 +233,6 @@ describe('spectral - test error-response validation catches invalid error respon
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === 'Error response should have a uuid `trace` field'
     );
-    expect(expectedWarnings.length).toBe(1);
+    expect(expectedWarnings.length).toBe(2);
   });
 });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -202,6 +202,7 @@ describe('spectral - test error-response validation catches invalid error respon
           IncorrectPropertiesModel: {
             type: 'object',
             properties: {
+              errors: {},
               trace: {
                 type: 'string'
                 // missing format, uuid
@@ -242,6 +243,13 @@ describe('spectral - test error-response validation catches invalid error respon
   it('should error for error-response that with an invalid status_code field', function() {
     const expectedWarnings = res.warnings.filter(
       warn => warn.message === '`status_code` field must be an integer'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+
+  it('should error for error-response that with an invalid status_code field', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === '`errors` field should be an array of error models'
     );
     expect(expectedWarnings.length).toBe(1);
   });

--- a/test/spectral/tests/custom-rules/error-response.test.js
+++ b/test/spectral/tests/custom-rules/error-response.test.js
@@ -3,7 +3,12 @@ const inCodeValidator = require('../../../../src/lib');
 describe('spectral - test error-response validation does not produce false positives', function() {
   it('should not error for missing content for success response with no content or failure response with content', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'ErrorAPI'
+      },
+      servers: [{ url: 'http://api.errorapi.com/v1' }],
       paths: {
         path1: {
           get: {
@@ -31,7 +36,7 @@ describe('spectral - test error-response validation does not produce false posit
               'application/json': {
                 schema: {
                   $ref: '#/components/schemas/AcceptableErrorModel'
-                },
+                }
               }
             }
           },
@@ -40,7 +45,7 @@ describe('spectral - test error-response validation does not produce false posit
               'application/json': {
                 schema: {
                   $ref: '#/components/schemas/ErrorContainerModel'
-                },
+                }
               }
             }
           }
@@ -81,10 +86,7 @@ describe('spectral - test error-response validation does not produce false posit
             properties: {
               code: {
                 type: 'string',
-                enum: [
-                  'error_1',
-                  'error_2'
-                ]
+                enum: ['error_1', 'error_2']
               },
               message: {
                 type: 'string'
@@ -101,11 +103,7 @@ describe('spectral - test error-response validation does not produce false posit
           ErrorTargetModel: {
             type: {
               type: 'string',
-              enum: [
-                'field',
-                'parameter',
-                'header'
-              ]
+              enum: ['field', 'parameter', 'header']
             },
             name: {
               type: 'string',
@@ -118,9 +116,7 @@ describe('spectral - test error-response validation does not produce false posit
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
-        warn.message ===
-        'Error response should have a content field'
+      warn => warn.message === 'Error response should have a content field'
     );
     expect(expectedWarnings.length).toBe(0);
   });
@@ -129,7 +125,12 @@ describe('spectral - test error-response validation does not produce false posit
 describe('spectral - test error-response validation catches invalid error responses', function() {
   it('should error for missing content for failure response with no content', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'ErrorAPI'
+      },
+      servers: [{ url: 'http://api.errorapi.com/v1' }],
       paths: {
         path1: {
           get: {
@@ -154,20 +155,16 @@ describe('spectral - test error-response validation catches invalid error respon
         },
         schemas: {
           BadErrorModel: {
-            type: 'string',
+            type: 'string'
           }
         }
       }
     };
 
     const res = await inCodeValidator(spec, true);
-    expect(res.warnings).toBe('');
     const expectedWarnings = res.warnings.filter(
-      warn =>
-        warn.message ===
-        'Error response should have a content field'
+      warn => warn.message === 'Error response should have a content field'
     );
     expect(expectedWarnings.length).toBe(1);
   });
 });
-

--- a/test/spectral/tests/custom-rules/json-response-example-provided.test.js
+++ b/test/spectral/tests/custom-rules/json-response-example-provided.test.js
@@ -6,7 +6,7 @@ const inCodeValidator = require('../../../../src/lib');
 describe('spectral - test validation that schema provided in content object', function() {
   it('should not error when a response example provided in the schema or at the response level', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
       paths: {
         path1: {
           get: {
@@ -64,7 +64,7 @@ describe('spectral - test validation that schema provided in content object', fu
 
   it('should error when a response example is not provided', async () => {
     const spec = {
-      Openapi: '3.0.0',
+      openapi: '3.0.0',
       paths: {
         path1: {
           get: {

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -67,7 +67,7 @@ describe('Spectral - test custom configuration', function() {
     );
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(28);
+    expect(jsonOutput['warnings'].length).toBe(34);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This warning should be turned off
     expect(warnings).not.toContain(
@@ -99,7 +99,7 @@ describe('Spectral - test custom configuration', function() {
     expect(jsonOutput['errors']).toBeUndefined();
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(33);
+    expect(jsonOutput['warnings'].length).toBe(39);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This is the new warning -- there should be three occurrences
     const warning = 'All request bodies should have an example.';

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -67,7 +67,7 @@ describe('Spectral - test custom configuration', function() {
     );
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(21);
+    expect(jsonOutput['warnings'].length).toBe(28);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This warning should be turned off
     expect(warnings).not.toContain(
@@ -99,7 +99,7 @@ describe('Spectral - test custom configuration', function() {
     expect(jsonOutput['errors']).toBeUndefined();
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(26);
+    expect(jsonOutput['warnings'].length).toBe(33);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This is the new warning -- there should be three occurrences
     const warning = 'All request bodies should have an example.';

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -252,9 +252,10 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
       'oas3-valid-oas-content-example': 'off',
       'oas3-valid-example': 'off',
       'oas3-valid-schema-example': 'off',
+      'content-entry-provided': 'off',
       'content-entry-contains-schema': 'off',
       'response-example-provided': 'off',
-      'response-error-response-has-content': 'off'
+      'response-error-response-schema': 'off'
     };
     const mockConfig = jest.spyOn(config, 'get').mockReturnValue(mockObject);
 

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -253,7 +253,8 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
       'oas3-valid-example': 'off',
       'oas3-valid-schema-example': 'off',
       'content-entry-contains-schema': 'off',
-      'response-example-provided': 'off'
+      'response-example-provided': 'off',
+      'response-error-response-has-content': 'off'
     };
     const mockConfig = jest.spyOn(config, 'get').mockReturnValue(mockObject);
 


### PR DESCRIPTION
Purpose:
- Error responses should be robust and give the user enough information to resolve their problems. The added validation recommends certain fields be included and recommends a schema for those fields.

Changes:
- Add a custom Spectral rule that applies a custom Spectral function to validate 4xx and 5xx responses.
- Add a custom Spectral rule that validates the error response schema is an object, has fields, such as `trace`, `code`, `errors` or `error`, etc. and validates the schema of those fields to ensure the error response follows good practices.
- Defines a deduplication function and passes it to spectral to avoid deduplicating `response-error-response-schema` errors with the same path.
- Add a custom Spectral rule to check for `content` object in request bodies and non-204 responses.

Tests:
- Add tests to ensure warnings are issued for missing fields or invalid/incomplete schemas for each field.
- Add negative tests to ensure no warnings for valid error response.
- Add tests to ensure warning when content object not provided

Docs:
- document `reponse-error-response-schema` rule
- document `content-entry-provided` rule