### PR TITLE
fix: set the exit code for json output

### DIFF
--- a/src/cli-validator/utils/printResults.js
+++ b/src/cli-validator/utils/printResults.js
@@ -88,7 +88,7 @@ module.exports = function print(
         // print the path array as a dot-separated string
 
         console.log(chalk[color](`  Message :   ${problem.message}`));
-        if (printRuleNames) {
+        if (printRuleNames && problem.rule) {
           console.log(chalk[color](`  Rule    :   ${problem.rule}`));
         }
         console.log(chalk[color](`  Path    :   ${path.join('.')}`));

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -115,7 +115,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     program.json = true;
 
     const exitcode = await commandLineValidator(program);
-    expect(exitcode).toBe(0);
+    expect(exitcode).toBe(1);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     const jsonOutput = JSON.parse(capturedText);

--- a/test/cli-validator/tests/threshold-validator.test.js
+++ b/test/cli-validator/tests/threshold-validator.test.js
@@ -27,9 +27,7 @@ describe('test the .thresholdrc limits', function() {
 
     expect(exitCode).toEqual(1);
 
-    expect(capturedText[capturedText.length - 1].slice(0, 18)).toEqual(
-      `Number of warnings`
-    );
+    expect(capturedText[2].slice(14, 32)).toEqual(`Number of warnings`);
   });
 
   it('should print errors for unsupported limit options and invalid limit values', async function() {

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -13,7 +13,7 @@ describe('Spectral - test custom configuration', function() {
     program.ruleset = 'test/spectral/mockFiles/mockConfig/info-and-hint.yaml';
 
     const exitcode = await commandLineValidator(program);
-    expect(exitcode).toBe(0);
+    expect(exitcode).toBe(1);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     consoleSpy.mockRestore();
@@ -54,7 +54,7 @@ describe('Spectral - test custom configuration', function() {
     program.ruleset = 'test/spectral/mockFiles/mockConfig/extends-default.yaml';
 
     const exitcode = await commandLineValidator(program);
-    expect(exitcode).toBe(0);
+    expect(exitcode).toBe(1);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     consoleSpy.mockRestore();


### PR DESCRIPTION
Purpose:
- Want the exit code set properly for json output.

Changes:
- Move the logic to set the exit code so that it applies to json output as well.
- If the warnings limit exceeded, add this as an error to the results so that it may be naturally included in the json output.

Tests:
- repair warnings limit tests and exit code tests