### PR TITLE
fix: soften the response-example rule to look only at success responses

### DIFF
--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -123,7 +123,7 @@ rules:
   # custom Spectral rule to ensure response example provided
   response-example-provided:
     message: "{{error}}"
-    given: $.paths[*][*].responses[*].content.application/json
+    given: $.paths[*][*].responses[?(@property >= 200 && @property < 300)].content.application/json
     severity: warn
     resolved: true
     then:

--- a/test/spectral/tests/custom-rules/response-example-provided.test.js
+++ b/test/spectral/tests/custom-rules/response-example-provided.test.js
@@ -62,7 +62,7 @@ describe('spectral - test validation that schema provided in content object', fu
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should error when a response example is not provided', async () => {
+  it('should only error when a response example is not provided in a success response', async () => {
     const spec = {
       openapi: '3.0.0',
       paths: {
@@ -70,6 +70,26 @@ describe('spectral - test validation that schema provided in content object', fu
           get: {
             responses: {
               '200': {
+                content: {
+                  'application/json': {
+                    // schema provided
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                }
+              },
+              '300': {
+                content: {
+                  'application/json': {
+                    // schema provided
+                    schema: {
+                      type: 'string'
+                    }
+                  }
+                }
+              },
+              default: {
                 content: {
                   'application/json': {
                     // schema provided


### PR DESCRIPTION
Purpose:
- Do not necessarily expect response examples for non-2xx and default responses. Expected for 2xx responses.

Changes:
- Soften the check to look only at success responses.

Tests:
- Update tests to ensure errors only issued for success responses without examples.