### PR TITLE
fix: error parsing JSONSchema in json-schema-validation function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
+os:
+- windows
+- linux
 node_js:
-- 10
 - 12
+- 14
 cache:
   npm: false
 script:


### PR DESCRIPTION
Some users, as outlined in #270, are getting an error parsing the `x-sdk-operations` JSON Schema in the `json-schema-validation` function.

Instead of parsing the JSON in the `json-schema-validation`, it may resolve the problem to parse the JSON file up front, and load it into `STATIC_ASSETS` as an object, which in hindsight is the more sensible approach.

This simple change passes in our testing environment. However, the original implementation also works in our testing environment. Without replicating the users' environments who are experiencing this issue, I'm not sure this resolves the problem. I am, however, certain that parsing the JSON Schema is the root of the problem.