### PR TITLE
fix: fix imports in json-schema-validation function

### DIFF
--- a/src/spectral/rulesets/ibm-oas/json-schema-validation.js
+++ b/src/spectral/rulesets/ibm-oas/json-schema-validation.js
@@ -1,6 +1,15 @@
-const AJV = require('ajv');
-const ajv = new AJV({ allErrors: true, jsonPointers: true });
-const { STATIC_ASSETS } = require('@stoplight/spectral/dist/assets');
+let ajv;
+let STATIC_ASSETS;
+
+try {
+  const AJV = require('ajv');
+  ajv = new AJV({ allErrors: true, jsonPointers: true });
+  STATIC_ASSETS = require('@stoplight/spectral/dist/assets').STATIC_ASSETS;
+} catch (err) {
+  const AJV = require('../../../node_modules/ajv');
+  ajv = new AJV({ allErrors: true, jsonPointers: true });
+  STATIC_ASSETS = require('../../assets').STATIC_ASSETS;
+}
 
 // performs JSON Schema validation on the given object
 // expects `schemaKey` options with the key to retrieve the schema


### PR DESCRIPTION
Purpose:
- When users extend the `ibm:oas` ruleset with their own Spectral config file, the original `ajv` and `STATIC_ASSETS` imports break.

Changes:
- If the standard attempt to import is broken, use relative import based on the structure of the Spectral package.

Needs:
- Maybe a better approach. This may be volatile to changes in the way Spectral organizes its distributions.
- If the approach is acceptable, need a test that tracks the case when the user extends the `ibm:oas` ruleset where the current working directory is outside the scope of our project.

Alternative approaches:
- Remove the `ibm-sdk-operations` rule for now and reintroduce it later. [Branch that implements this approach](https://github.com/IBM/openapi-validator/tree/fix-extends-problem).

Related Issue: #275 