### PR TITLE
Add rule to check for consistent major version in path

### DIFF
--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -56,6 +56,12 @@ responses:
 
 **Default Severity**: warn
 
+## major-version-in-path
+
+Validates that every path contains a path segment for the API major version, of the form `v<n>`, and that all paths have the same major version segment. The major version can appear in either the server URL (oas3), the basePath (oas2), or in each path entry.
+
+**Default Severity**: warn
+
 ## response-error-response-schema
 
 `4xx` and `5xx` error responses should provide good information to help the user resolve the error. The error response validations are based on the design principles outlined in the [errors section of the IBM API Handbook](https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors). The `response-error-response-schema` rule is more lenient than what is outlined in the handbook. Specifically, the `response-error-response-schema` rule does not require an Error Container Model and allows for a single Error Model to be provided at the top level of the error response schema or in an `error` field.

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -1,6 +1,7 @@
 extends: spectral:oas
 functionsDir: './ibm-oas'
 functions:
+  - check-major-version
   - error-response-schema
   - response-example-provided
 rules:
@@ -96,7 +97,7 @@ rules:
   oas3-schema: off
   # Turn off - duplicates non-configurable validation in base validator
   oas3-unused-components-schema: off
-  
+
   # custom Spectral rule to ensure request bodies and non-204 responses provide content object
   content-entry-provided:
     description: Request bodies and non-204 responses should define a content object
@@ -137,3 +138,12 @@ rules:
     resolved: true
     then:
       function: error-response-schema
+  # ensure major version is in path
+  major-version-in-path:
+    description: 'All paths must contain the API major version as a distinct path segment'
+    message: "{{error}}"
+    formats: ["oas2", "oas3"]
+    given: $
+    severity: warn
+    then:
+      function: check-major-version

--- a/src/spectral/rulesets/ibm-oas/check-major-version.js
+++ b/src/spectral/rulesets/ibm-oas/check-major-version.js
@@ -1,0 +1,96 @@
+// Check:
+// - Each url in the servers object has a path segment of the form v followed by a number,
+//   and the number is the same for all urls, or
+// - Each path has a path segment of the form v followed by a number, and the number is
+//   the same for all paths
+
+module.exports = targetVal => {
+  if (targetVal === null || typeof targetVal !== 'object') {
+    return;
+  }
+
+  const oas3 = targetVal['openapi'];
+
+  if (oas3) {
+    const servers = targetVal['servers'];
+    if (servers && Array.isArray(servers)) {
+      const urls = servers.map(o => o['url']);
+      const versions = urls.map(url => getVersion(url));
+
+      if (versions.length > 1 && !versions.every(v => v === versions[0])) {
+        const uniqueVersions = versions.filter(
+          (val, i, self) => self.indexOf(val) === i
+        );
+        return [
+          {
+            message:
+              'Major version segments of urls in servers object do not match. Found ' +
+              uniqueVersions.join(', '),
+            path: ['servers']
+          }
+        ];
+      }
+
+      if (versions.length >= 1 && versions[0]) {
+        // Major version present in server URL and all match -- all good
+        return;
+      }
+    }
+  } else {
+    // oas2
+    const basePath = targetVal['basePath'] || '';
+    const version = getVersion(basePath);
+    if (version) {
+      return;
+    }
+  }
+
+  // We did not find a major version in server URLs, so now check the paths
+
+  const paths = targetVal['paths'];
+  if (paths && typeof paths === 'object') {
+    const urls = Object.keys(paths);
+    const versions = urls.map(url => getVersion(url));
+
+    if (versions.length > 1 && !versions.every(v => v === versions[0])) {
+      const uniqueVersions = versions.filter(
+        (val, i, self) => self.indexOf(val) === i
+      );
+      return [
+        {
+          message:
+            'Major version segments of paths object do not match. Found ' +
+            uniqueVersions.join(', '),
+          path: ['paths']
+        }
+      ];
+    }
+
+    if (versions.length >= 1 && versions[0]) {
+      // Major version present in server URL and all match -- all good
+      return;
+    }
+  }
+
+  if (oas3) {
+    return [
+      {
+        message:
+          'Major version segment not present in either server URLs or paths'
+      }
+    ];
+  } else {
+    return [
+      {
+        message: 'Major version segment not present in either basePath or paths'
+      }
+    ];
+  }
+};
+
+// Return the first segment of a path that matches the pattern 'v\d+'
+function getVersion(path) {
+  const url = new URL(path, 'https://foo.bar');
+  const segments = url.pathname.split('/');
+  return segments.find(segment => segment.match(/v[0-9]+/));
+}

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -400,13 +400,13 @@ describe('test expected output - OpenAPI 3', function() {
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     const jsonOutput = JSON.parse(capturedText);
-    expect(jsonOutput.warnings[3].componentPath).toEqual([
+    expect(jsonOutput.warnings[4].componentPath).toEqual([
       'components',
       'responses',
       'Ok',
       'content',
       'application/json'
     ]);
-    expect(jsonOutput.warnings[3].componentLine).toEqual(6);
+    expect(jsonOutput.warnings[4].componentLine).toEqual(6);
   });
 });

--- a/test/spectral/mockFiles/oas3/multiple-major-versions.yml
+++ b/test/spectral/mockFiles/oas3/multiple-major-versions.yml
@@ -1,0 +1,97 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: 'Test major-version-in-path'
+servers:
+  - url: http://petstore.swagger.io
+tags:
+  - name: pets
+    description: A pet
+paths:
+  /v1/pet:
+    post:
+      summary: Add pet
+      description: "Add a new pet to the store"
+      operationId: "add_pet"
+      tags:
+        - pets
+      requestBody:
+        description: "Pet object that needs to be added to the store"
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        204:
+          description: "Success"
+        400:
+          description: "Invalid input"
+        default:
+          description: "Invalid input"
+  /v1/pet/{pet_id}:
+    get:
+      tags:
+        - pets
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: get_pet_by_id
+      parameters:
+        - name: pet_id
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: "Invalid input"
+  /v2/search:
+    get:
+      summary: search
+      description: Search for a pet
+      operationId: v2_search
+      tags:
+        - pets
+      parameters:
+        - name: pet_id
+          in: query
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: "Invalid input"
+components:
+  schemas:
+    Pet:
+      type: object
+      description: pet object
+      properties:
+        pet_id:
+          description: pet_id
+          type: integer
+          format: int64
+          example: 10
+        name:
+          description: pet name
+          type: string
+          example: doggie
+      example:
+        id: 1
+        name: doggie

--- a/test/spectral/tests/custom-rules/major-version-in-path.test.js
+++ b/test/spectral/tests/custom-rules/major-version-in-path.test.js
@@ -1,0 +1,86 @@
+const commandLineValidator = require('../../../../src/cli-validator/runValidator');
+const inCodeValidator = require('../../../../src/lib');
+const { getCapturedText } = require('../../../test-utils');
+const re = /^Validator: spectral/;
+
+describe('spectral - test major-version-in-path rule', function() {
+  it('test major-version-in-path using mockFiles/oas3/multiple-major-versions.yml', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    // set up mock user input
+    const program = {};
+    program.args = [
+      './test/spectral/mockFiles/oas3/multiple-major-versions.yml'
+    ];
+    program.default_mode = true;
+    program.print_validator_modules = true;
+
+    const exitCode = await commandLineValidator(program);
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+    const allOutput = capturedText.join('');
+    // Spectral should be the only validator module in the output, so use regex to verify that
+    const validatorsText = allOutput.match(/Validator:\s\w.+/g) || [];
+    let foundOtherValidator = false;
+
+    expect(validatorsText.length).toBeGreaterThan(0);
+
+    validatorsText.forEach(text => {
+      const match = re.test(text);
+      if (!match) {
+        foundOtherValidator = true;
+      }
+    });
+
+    expect(exitCode).toEqual(0);
+    expect(foundOtherValidator).toBe(false);
+
+    consoleSpy.mockRestore();
+
+    expect(allOutput).toContain(
+      'Major version segments of paths object do not match. Found v1, v2'
+    );
+  });
+
+  it('test major-version-in-path flags multiple versions in server URLs', async () => {
+    // set up mock user input
+    const apidef = {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'Multiple versions in server URLs'
+      },
+      servers: [
+        {
+          url: 'http://petstore.swagger.io/v1'
+        },
+        {
+          url: 'http://petstore.swagger.io/v2'
+        }
+      ],
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'Get a list of pets',
+            operationId: 'list_pets',
+            responses: {
+              '200': {
+                description: 'Success'
+              }
+            }
+          }
+        }
+      }
+    };
+    const validationResults = await inCodeValidator(apidef, true);
+
+    // should produce an object with an empty `errors` key and a non-empty `warnings` key
+    expect(validationResults.errors).toBeUndefined();
+    expect(validationResults.warnings.length).toBeGreaterThan(0);
+
+    const warnings = validationResults.warnings.map(warn => warn.message);
+    expect(warnings.length).toBeGreaterThan(0);
+
+    expect(warnings).toContain(
+      'Major version segments of urls in servers object do not match. Found v1, v2'
+    );
+  });
+});

--- a/test/spectral/tests/enabled-rules.test.js
+++ b/test/spectral/tests/enabled-rules.test.js
@@ -110,6 +110,12 @@ describe('spectral - test enabled rules - Swagger 2', function() {
       'oneOf is not available in OpenAPI v2, it was added in OpenAPI v3'
     );
   });
+
+  it('test major-version-in-path rule using mockFiles/swagger/enabled-rules.yml', function() {
+    expect(allOutput).toContain(
+      'Major version segment not present in either basePath or paths'
+    );
+  });
 });
 
 describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
@@ -315,6 +321,12 @@ describe('spectral - test enabled rules - OAS3', function() {
   it('test oas3-valid-oas-content-example rule using mockFiles/oas3/enabled-rules.yml', function() {
     expect(allOutput).toContain(
       '`number_of_connectors` property should be equal to one of the allowed values: 1, 2, `a_string`, 8'
+    );
+  });
+
+  it('test major-version-in-path rule using mockFiles/oas3/enabled-rules.yml', function() {
+    expect(allOutput).toContain(
+      'Major version segment not present in either server URLs or paths'
     );
   });
 });

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -67,7 +67,7 @@ describe('Spectral - test custom configuration', function() {
     );
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(34);
+    expect(jsonOutput['warnings'].length).toBe(35);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This warning should be turned off
     expect(warnings).not.toContain(
@@ -99,7 +99,7 @@ describe('Spectral - test custom configuration', function() {
     expect(jsonOutput['errors']).toBeUndefined();
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(39);
+    expect(jsonOutput['warnings'].length).toBe(40);
     const warnings = jsonOutput['warnings'].map(w => w['message']);
     // This is the new warning -- there should be three occurrences
     const warning = 'All request bodies should have an example.';

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -254,6 +254,7 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
       'oas3-valid-schema-example': 'off',
       'content-entry-provided': 'off',
       'content-entry-contains-schema': 'off',
+      'major-version-in-path': 'off',
       'response-example-provided': 'off',
       'response-error-response-schema': 'off'
     };


### PR DESCRIPTION
This PR adds a new rule, `major-version-in-path`, the verifies that all paths contain a path segment that represents the major version of the API, in the form `v<n>`.  This is a requirement of the [IBM API Guidelines](https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-uris#version).

Testing notes:
- Single major version specified in single server URL:
  - test/cli-validator/mockFiles/oas3/clean.yml
- Single major version specified in multiple server URLs: no test
- Multiple major versions specified in multiple server URLs: inline in enabled-rules.js
- Single major version specified in basePath:
  - test/cli-validator/mockFiles/swagger/clean.yml
- No major version in server URLs or paths
  - oas2: test/spectral/mockFiles/swagger/enabled-rules.yml
  - oas3: test/spectral/mockFiles/oas3/enabled-rules.yml
- Multiple major versions in paths
  - oas2: no test
  - oas3: test/spectral/mockFiles/oas3/multiple-major-versions.yml