### PR TITLE
build: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -812,6 +812,67 @@
         }
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -1447,18 +1508,18 @@
       }
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
+        "@nodelib/fs.stat": "2.0.4",
         "run-parallel": "^1.1.9"
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
         }
       }
     },
@@ -1468,44 +1529,45 @@
       "integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
+        "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
-      "integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.0.0"
+        "@octokit/types": "^6.0.3"
       }
     },
     "@octokit/core": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.4.tgz",
-      "integrity": "sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
       "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
         "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
         "@octokit/types": "^6.0.3",
-        "before-after-hook": "^2.1.0",
+        "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
-      "integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.0.0",
+        "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -1519,60 +1581,58 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
-      "integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^6.0.0",
+        "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/openapi-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.0.tgz",
-      "integrity": "sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
+      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.2.tgz",
-      "integrity": "sha512-3Dy7/YZAwdOaRpGQoNHPeT0VU1fYLpIUdPyvR37IyFLgd6XSij4j9V/xN/+eSjF2KKvmfIulEh9LF1tRPjIiDA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.0.1"
+        "@octokit/types": "^6.11.0"
       }
     },
     "@octokit/plugin-request-log": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
-      "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
-      "integrity": "sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
+      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.1.0",
+        "@octokit/types": "^6.13.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz",
-      "integrity": "sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^6.0.3",
-        "deprecation": "^2.0.0",
+        "@octokit/types": "^6.7.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.1",
-        "once": "^1.4.0",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -1585,36 +1645,35 @@
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
-      "integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.0.0",
+        "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.12.tgz",
-      "integrity": "sha512-hNRCZfKPpeaIjOVuNJzkEL6zacfZlBPV8vw8ReNeyUkVvbuCvvrrx8K8Gw2eyHHsmd4dPlAxIXIZ9oHhJfkJpw==",
+      "version": "18.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
+      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
       "dev": true,
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "4.4.1"
+        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
       }
     },
     "@octokit/types": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.1.1.tgz",
-      "integrity": "sha512-btm3D6S7VkRrgyYF31etUtVY/eQ1KzrNRqhFt25KSe2mKlXuLXJilglRC6eDA2P6ou94BUnk/Kz5MPEolXgoiw==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^2.0.0",
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^6.0.0"
       }
     },
     "@semantic-release/changelog": {
@@ -1752,9 +1811,9 @@
       }
     },
     "@semantic-release/github": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.2.0.tgz",
-      "integrity": "sha512-tMRnWiiWb43whRHvbDGXq4DGEbKRi56glDpXDJZit4PIiwDPX7Kx3QzmwRtDOcG+8lcpGjpdPabYZ9NBxoI2mw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.2.1.tgz",
+      "integrity": "sha512-+gOhbaG4T3xJb6aTZu1/7KvCmYKRChkasdIyFWdaGaTWVeGpdl4o0zMviV1z3kRcgPOSXeqjHSQ6SOQAfHQiDw==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.0.0",
@@ -1776,9 +1835,9 @@
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
           "dev": true
         },
         "array-union": {
@@ -1806,9 +1865,9 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -1820,21 +1879,21 @@
           }
         },
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "globby": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -1846,9 +1905,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
           "dev": true
         },
         "ignore": {
@@ -1865,14 +1924,6 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
           }
         },
         "merge2": {
@@ -1900,17 +1951,17 @@
           "dev": true
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }
     },
     "@semantic-release/npm": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.9.tgz",
-      "integrity": "sha512-VsmmQF3/n7mDbm6AGL0yPD3QNTGsHdinBtkyyerN1eLgvhdGJ/vEeAvmDMARiuf5Ev9cFeCheF0wLyUZNlAkeA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.1.1.tgz",
+      "integrity": "sha512-zTYAno1j49XiH+uAVCY47dKOJAagA/MaJb26FFIfNujNHw3GYXk3ygsFa5CSa55xsO0qEMLcsDX3f3ByCg6nZw==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
@@ -1919,8 +1970,8 @@
         "fs-extra": "^9.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^5.0.0",
-        "npm": "^6.14.8",
+        "normalize-url": "^6.0.0",
+        "npm": "^7.0.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -1957,27 +2008,27 @@
           }
         },
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "get-stream": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-          "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
           "dev": true
         },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
           "dev": true
         },
         "human-signals": {
@@ -2000,14 +2051,6 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
           }
         },
         "lru-cache": {
@@ -2044,9 +2087,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -2074,9 +2117,9 @@
           "dev": true
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         },
         "which": {
@@ -2097,9 +2140,9 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.1.tgz",
-      "integrity": "sha512-bOoTiH6SiiR0x2uywSNR7uZcRDl22IpZhj+Q5Bn0v+98MFtOMhCxFhbrKQjhbYoZw7vps1mvMRmFkp/g6R9cvQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.2.tgz",
+      "integrity": "sha512-xGFSidhGqB27uwgWCU6y0gbf4r/no5flOAkJyFFc4+bPf8S+LfAVm7xhhlK5VPXLt2Iu1RBH8F+IgMK2ah5YpA==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
@@ -2109,7 +2152,7 @@
         "debug": "^4.0.0",
         "get-stream": "^5.0.0",
         "import-from": "^3.0.0",
-        "into-stream": "^5.0.0",
+        "into-stream": "^6.0.0",
         "lodash": "^4.17.4",
         "read-pkg-up": "^7.0.0"
       },
@@ -2164,18 +2207,18 @@
       }
     },
     "@stoplight/better-ajv-errors": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.3.tgz",
-      "integrity": "sha512-q3PoPiYZdzfJjQ+q6ifuLVFx3dBKRxW1OBGxnLAoDlamYb+GJUNiaSLB32L6OB4fi6h/TsY21lZB7y7aYFM7tQ==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.4.tgz",
+      "integrity": "sha512-HFXOerq/6/6YisiTJwCOScwfNaXyGmX7ROAEUoKOrckK9+hJ/QLFm5EofQYEgX4aXkvHokLEbWBs4NMwZ6hQUw==",
       "requires": {
         "jsonpointer": "^4.0.1",
         "leven": "^3.1.0"
       }
     },
     "@stoplight/json": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.10.2.tgz",
-      "integrity": "sha512-mUf4t2bOBZjVa8KdEI4+EqX/8zXJLfGKv/cj++giLbCkYNGjBgJnmPSDNOOBgJHpocdVml0hK8ZuLADqWVVB2Q==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.11.2.tgz",
+      "integrity": "sha512-6ePZkRBrcy/SVvnXH+Yi+sIBkKH4Nu4acG8dgaAi/pV8322lvnylyfZ21KLWEKYKON+Ll+NOZeIcaZNj5M0O9g==",
       "requires": {
         "@stoplight/ordered-object-literal": "^1.0.1",
         "@stoplight/types": "^11.9.0",
@@ -2185,11 +2228,19 @@
       }
     },
     "@stoplight/json-ref-readers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.1.tgz",
-      "integrity": "sha512-fbh8sXRrwfOCx4EA2e6FGUwvu5zxCQ9xHZg3vYDFSb1HLTlrCeRTdx3VCmYjCSGAhpcwgpB4zMc8kiudujo8Yg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+      "integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
       "requires": {
-        "node-fetch": "^2.6.0"
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@stoplight/json-ref-resolver": {
@@ -2211,9 +2262,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
@@ -2236,17 +2287,17 @@
       "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
     },
     "@stoplight/spectral": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.8.1.tgz",
-      "integrity": "sha512-GhdKnnJ8LAYfvoiNRWmkgQMNRGHD03T9Hmtq8K7hYi98ToL3WfqYC5oAVLsYw/y9t+FpP32gWzyrTmz8lBI/kA==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.9.1.tgz",
+      "integrity": "sha512-YgTtieZpYOva6vAwHRBQWom2muwtB6mzpbBG896C1vOiNq+ebAYA1PP9gzHyf+Uagt674CWTOfvsMrzVPosBqQ==",
       "requires": {
-        "@stoplight/better-ajv-errors": "0.0.3",
-        "@stoplight/json": "3.10.2",
-        "@stoplight/json-ref-readers": "1.2.1",
+        "@stoplight/better-ajv-errors": "0.0.4",
+        "@stoplight/json": "3.11.2",
+        "@stoplight/json-ref-readers": "1.2.2",
         "@stoplight/json-ref-resolver": "3.1.1",
         "@stoplight/lifecycle": "2.3.2",
         "@stoplight/path": "1.3.2",
-        "@stoplight/types": "11.9.0",
+        "@stoplight/types": "11.10.0",
         "@stoplight/yaml": "4.2.1",
         "abort-controller": "3.0.0",
         "ajv": "6.12.5",
@@ -2261,7 +2312,7 @@
         "nanoid": "2.1.11",
         "nimma": "0.0.0",
         "node-fetch": "2.6.1",
-        "proxy-agent": "3.1.1",
+        "proxy-agent": "4.0.1",
         "strip-ansi": "6.0",
         "text-table": "0.2",
         "tslib": "1.13.0",
@@ -2333,9 +2384,9 @@
       }
     },
     "@stoplight/types": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.9.0.tgz",
-      "integrity": "sha512-4bzPpWZobt0e+d0OtALCJyl1HGzKo6ur21qxnId9dTl8v3yeD+5HJKZ2h1mv7e94debH5QDtimMU80V6jbXM8Q==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.10.0.tgz",
+      "integrity": "sha512-ffHD9i4UHS8Gsg7Ar8pKjI9B4kq7MRekE7tCROFGcFDzQhfRx9T92AduoLAtP/010XNYq23yDKpLBRPIEk8+xg==",
       "requires": {
         "@types/json-schema": "^7.0.4",
         "utility-types": "^3.10.0"
@@ -2375,8 +2426,7 @@
     "@tootallnate/once": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
-      "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
-      "dev": true
+      "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA=="
     },
     "@types/babel__core": {
       "version": "7.1.7",
@@ -2529,9 +2579,9 @@
       "dev": true
     },
     "@types/urijs": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.14.tgz",
-      "integrity": "sha512-Ds9OMd4xZqI2zZtoOicASAi0SvFPyNPgkfgPrPeUTQwcJOX1w6Mwkpq8ClI4ZP11nsEI6akvKqRDV+epA8yzRw=="
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.15.tgz",
+      "integrity": "sha512-pEDVREIvkyRtzpWlO5nqsUgR/JpLv9+lAzvkERCwoH2jXxl+TmaTNshhL7gjQLhfqgFUzCM6ovmoB1JssTop1A=="
     },
     "@types/yargs": {
       "version": "15.0.4",
@@ -2589,9 +2639,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "acorn-walk": {
@@ -2604,7 +2654,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
       "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
-      "dev": true,
       "requires": {
         "debug": "4"
       },
@@ -2613,7 +2662,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2621,8 +2669,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2645,9 +2692,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -2657,9 +2704,9 @@
       },
       "dependencies": {
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         }
       }
@@ -2699,6 +2746,12 @@
           }
         }
       }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -2834,30 +2887,30 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "requires": {
         "tslib": "^2.0.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
     "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "astring": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.7.0.tgz",
-      "integrity": "sha512-43bervUZNvahG1v74a+POdGlAWcOUGSvP9fJVj6sywzM/SquwDkA+CdP938e8tWHUV77fStCiqzaQHAt0u6MVA=="
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.7.4.tgz",
+      "integrity": "sha512-WiVqDJV0AayUUH65FfUrbnBO4KD10854cyU49lK30+2n/lEkJDRqBKj/2fYGhZSD3uIt1H1VfW/pQtO07kR2Xg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -3136,9 +3189,9 @@
       }
     },
     "before-after-hook": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==",
       "dev": true
     },
     "blueimp-md5": {
@@ -3324,6 +3377,16 @@
         }
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -3427,12 +3490,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -3475,43 +3532,14 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
       "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
     },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
     "cli-table": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.4.tgz",
-      "integrity": "sha512-1vinpnX/ZERcmE443i3SZTmU5DF0rPO9DrL4I2iVAllhxzCM9SzPlHnz19fsZB78htkKZvYBvj6SZ6vXnaxmTA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
+      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "string-width": "^4.2.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
+        "colors": "1.0.3"
       }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
     },
     "cliui": {
       "version": "6.0.0",
@@ -3574,7 +3602,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "codecov": {
       "version": "3.7.1",
@@ -3617,6 +3646,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
     "combined-stream": {
@@ -3677,9 +3712,9 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz",
-      "integrity": "sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -3719,16 +3754,16 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz",
-      "integrity": "sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
+      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.1",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
-        "split2": "^2.0.0",
+        "split2": "^3.0.0",
         "through2": "^4.0.0",
         "trim-off-newlines": "^1.0.0"
       }
@@ -3753,16 +3788,16 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       },
       "dependencies": {
         "path-type": {
@@ -3837,9 +3872,9 @@
       }
     },
     "data-uri-to-buffer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -3983,20 +4018,13 @@
       }
     },
     "degenerator": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
-      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
+      "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
       "requires": {
-        "ast-types": "0.x.x",
-        "escodegen": "1.x.x",
-        "esprima": "3.x.x"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        }
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0"
       }
     },
     "del": {
@@ -4016,9 +4044,9 @@
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
           "dev": true
         },
         "array-union": {
@@ -4037,9 +4065,9 @@
           }
         },
         "fast-glob": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -4051,9 +4079,9 @@
           }
         },
         "globby": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -4065,9 +4093,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
           "dev": true
         },
         "ignore": {
@@ -4226,6 +4254,15 @@
         "once": "^1.4.0"
       }
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "env-ci": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
@@ -4250,18 +4287,11 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -4299,102 +4329,128 @@
       }
     },
     "eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
+      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
-        "table": "^5.2.3",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
+            "ms": "2.1.2"
           }
         },
         "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
           "dev": true
         },
-        "glob-parent": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "globals": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+          "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
         "ignore": {
@@ -4403,19 +4459,29 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
           }
         },
         "ms": {
@@ -4425,82 +4491,134 @@
           "dev": true
         },
         "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
           "dev": true,
           "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
           }
         },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         },
         "strip-json-comments": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.0.1.tgz",
-      "integrity": "sha512-vA0TB8HCx/idHXfKHYcg9J98p0Q8nkfNwNAoP7e+ywUidn6ScaFS5iqncZAHPz+/a0A/tp657ulFHFx/2JDP4Q==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.2.0.tgz",
+      "integrity": "sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==",
+      "dev": true
     },
     "eslint-plugin-prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
-      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
+      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
       "dev": true,
       "requires": {
-        "fast-diff": "^1.1.1",
-        "jest-docblock": "^21.0.0"
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-          "dev": true
-        }
       }
     },
     "eslint-visitor-keys": {
@@ -4510,20 +4628,26 @@
       "dev": true
     },
     "espree": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-      "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
         "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
       }
@@ -4534,21 +4658,37 @@
       "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
     },
     "esquery": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -4764,7 +4904,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4783,17 +4924,6 @@
             "is-plain-object": "^2.0.4"
           }
         }
-      }
-    },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -4880,9 +5010,9 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -5204,9 +5334,9 @@
       "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "fastq": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.1.tgz",
-      "integrity": "sha512-mpIH5sKYueh3YyeJwqtVo8sORi0CgtmkVbK6kZStpQlZBYQuTzG2CZ7idSiJuA7bY0SFCWUc5WIs+oYumGCQNw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -5230,18 +5360,18 @@
       }
     },
     "file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       }
     },
     "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+      "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -5270,54 +5400,28 @@
       }
     },
     "find-versions": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
-      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
       "dev": true,
       "requires": {
-        "semver-regex": "^2.0.0"
+        "semver-regex": "^3.1.2"
       }
     },
     "flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
     "for-in": {
@@ -5428,7 +5532,7 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
@@ -5443,11 +5547,16 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-stream": {
       "version": "4.1.0",
@@ -5458,25 +5567,45 @@
       }
     },
     "get-uri": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
-      "integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
+      "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
       "requires": {
-        "data-uri-to-buffer": "1",
-        "debug": "2",
-        "extend": "~3.0.2",
-        "file-uri-to-path": "1",
-        "ftp": "~0.3.10",
-        "readable-stream": "2"
+        "@tootallnate/once": "1",
+        "data-uri-to-buffer": "3",
+        "debug": "4",
+        "file-uri-to-path": "2",
+        "fs-extra": "^8.1.0",
+        "ftp": "^0.3.10"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -5543,9 +5672,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -5614,9 +5743,9 @@
       "optional": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -5683,6 +5812,12 @@
       "version": "3.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "has-value": {
@@ -5799,7 +5934,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
       "requires": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -5810,7 +5944,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -5818,8 +5951,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -5838,7 +5970,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -5848,7 +5979,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -5856,8 +5986,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -5890,9 +6019,9 @@
       }
     },
     "immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
+      "integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -5941,6 +6070,12 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5960,145 +6095,10 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "inquirer": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-      "integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.11.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "figures": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
-        }
-      }
-    },
     "into-stream": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
-      "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
       "dev": true,
       "requires": {
         "from2": "^2.3.0",
@@ -6137,6 +6137,15 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -6240,6 +6249,12 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true
+    },
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -6278,16 +6293,16 @@
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-text-path": {
@@ -6951,12 +6966,6 @@
           }
         }
       }
-    },
-    "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
     },
     "jest-each": {
       "version": "26.0.0",
@@ -8355,7 +8364,7 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
@@ -8391,7 +8400,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -8523,10 +8531,22 @@
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.get": {
@@ -8573,6 +8593,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "lodash.uniqby": {
@@ -8630,9 +8656,9 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
       "dev": true
     },
     "map-visit": {
@@ -8644,74 +8670,23 @@
       }
     },
     "marked": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
-      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.0.tgz",
-      "integrity": "sha512-5KllfAOW02WS6hLRQ7cNvGOxvKW1BKuXELH4EtbWfyWgxQhROoMxEvuQ/3fTgkNjledR0J48F4HbapvYp1zWkQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
+      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.3.1",
         "cardinal": "^2.1.1",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.0",
         "cli-table": "^0.3.1",
         "node-emoji": "^1.10.0",
         "supports-hyperlinks": "^2.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "matcher": {
@@ -8723,9 +8698,9 @@
       }
     },
     "meow": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
-      "integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
@@ -8742,9 +8717,9 @@
       },
       "dependencies": {
         "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
           "dev": true
         }
       }
@@ -8770,9 +8745,9 @@
       }
     },
     "mime": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
-      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
       "dev": true
     },
     "mime-db": {
@@ -8897,12 +8872,6 @@
         "readable-stream": "^2.0.5"
       }
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
     "nanoid": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
@@ -8962,9 +8931,9 @@
       "dev": true
     },
     "netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -9049,21 +9018,21 @@
       }
     },
     "normalize-package-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-      "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^3.0.6",
-        "resolve": "^1.17.0",
-        "semver": "^7.3.2",
+        "hosted-git-info": "^4.0.1",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -9079,19 +9048,19 @@
           }
         },
         "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
           "dev": true,
           "requires": {
-            "is-core-module": "^2.1.0",
+            "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -9112,150 +9081,232 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.0.tgz",
-      "integrity": "sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.0.tgz",
+      "integrity": "sha512-3nv3dKMucKPEXhx/FEtJQR26ksYdyVlLEP9/dYvYwCbLbP6H8ya94IRf+mB93ec+fndv/Ye8SylWfD7jmN6kSA==",
       "dev": true
     },
     "npm": {
-      "version": "6.14.10",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.10.tgz",
-      "integrity": "sha512-FT23Qy/JMA+qxEYReMOr1MY7642fKn8Onn+72LASPi872Owvmw0svm+/DXTHOC3yO9CheEO+EslyXEpdBdRtIA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.10.0.tgz",
+      "integrity": "sha512-DD4eEB71HGVt6pS6n4LmFD4eHsrglJ+QtLhv/kP2UWNKkJalL8TPfsiw9p8LmWKa6ed61LHPw5FE6krS3aGv0A==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.3.5",
+        "@npmcli/arborist": "^2.3.0",
+        "@npmcli/ci-detect": "^1.2.0",
+        "@npmcli/config": "^2.1.0",
+        "@npmcli/run-script": "^1.8.4",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
-        "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.8",
-        "bluebird": "^3.5.5",
-        "byte-size": "^5.0.1",
-        "cacache": "^12.0.3",
-        "call-limit": "^1.1.1",
-        "chownr": "^1.1.4",
-        "ci-info": "^2.0.0",
+        "byte-size": "^7.0.1",
+        "cacache": "^15.0.6",
+        "chalk": "^4.1.0",
+        "chownr": "^2.0.0",
         "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.1",
-        "cmd-shim": "^3.0.3",
+        "cli-table3": "^0.6.0",
         "columnify": "~1.5.4",
-        "config-chain": "^1.1.12",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.5.1",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.3.1",
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.4",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.8.8",
-        "iferr": "^1.0.2",
-        "imurmurhash": "*",
-        "infer-owner": "^1.0.4",
-        "inflight": "~1.0.6",
-        "inherits": "^2.0.4",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^3.0.0",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.8",
-        "libnpm": "^3.0.1",
-        "libnpmaccess": "^3.0.2",
-        "libnpmhook": "^5.0.3",
-        "libnpmorg": "^1.0.1",
-        "libnpmsearch": "^2.0.2",
-        "libnpmteam": "^1.0.2",
-        "libnpx": "^10.2.4",
-        "lock-verify": "^2.1.0",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^5.1.1",
-        "meant": "^1.0.2",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.5",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.1.0",
-        "nopt": "^4.0.3",
-        "normalize-package-data": "^2.5.0",
-        "npm-audit-report": "^1.3.3",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "^3.0.2",
-        "npm-lifecycle": "^3.1.5",
-        "npm-package-arg": "^6.1.1",
-        "npm-packlist": "^1.4.8",
-        "npm-pick-manifest": "^3.0.2",
-        "npm-profile": "^4.0.4",
-        "npm-registry-fetch": "^4.0.7",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "hosted-git-info": "^4.0.2",
+        "ini": "^2.0.0",
+        "init-package-json": "^2.0.2",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "leven": "^3.1.0",
+        "libnpmaccess": "^4.0.1",
+        "libnpmdiff": "^2.0.4",
+        "libnpmfund": "^1.0.2",
+        "libnpmhook": "^6.0.1",
+        "libnpmorg": "^2.0.1",
+        "libnpmpack": "^2.0.1",
+        "libnpmpublish": "^4.0.0",
+        "libnpmsearch": "^3.1.0",
+        "libnpmteam": "^2.0.2",
+        "libnpmversion": "^1.2.0",
+        "make-fetch-happen": "^8.0.14",
+        "minipass": "^3.1.3",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^7.1.2",
+        "nopt": "^5.0.0",
+        "npm-audit-report": "^2.1.4",
+        "npm-package-arg": "^8.1.2",
+        "npm-pick-manifest": "^6.1.1",
+        "npm-profile": "^5.0.2",
+        "npm-registry-fetch": "^9.0.0",
         "npm-user-validate": "^1.0.1",
         "npmlog": "~4.1.2",
-        "once": "~1.4.0",
         "opener": "^1.5.2",
-        "osenv": "^0.1.5",
-        "pacote": "^9.5.12",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
+        "pacote": "^11.3.1",
+        "parse-conflict-json": "^1.1.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.2",
-        "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "^1.0.5",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.1.1",
-        "read-package-tree": "^5.3.1",
-        "readable-stream": "^3.6.0",
+        "read-package-json": "^3.0.1",
+        "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
-        "request": "^2.88.0",
-        "retry": "^0.12.0",
-        "rimraf": "^2.7.1",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.7.1",
-        "sha": "^3.0.0",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.1",
-        "stringify-package": "^1.0.1",
-        "tar": "^4.4.13",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "ssri": "^8.0.1",
+        "tar": "^6.1.0",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "^1.1.1",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.3.3",
-        "validate-npm-package-license": "^3.0.4",
+        "treeverse": "^1.0.4",
         "validate-npm-package-name": "~3.0.0",
-        "which": "^1.3.1",
-        "worker-farm": "^1.7.0",
-        "write-file-atomic": "^2.4.3"
+        "which": "^2.0.2",
+        "write-file-atomic": "^3.0.3"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.5",
+        "@npmcli/arborist": {
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/map-workspaces": "^1.0.2",
+            "@npmcli/metavuln-calculator": "^1.1.0",
+            "@npmcli/move-file": "^1.1.0",
+            "@npmcli/name-from-folder": "^1.0.1",
+            "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/run-script": "^1.8.2",
+            "bin-links": "^2.2.1",
+            "cacache": "^15.0.3",
+            "common-ancestor-path": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.1",
+            "json-stringify-nice": "^1.1.2",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-install-checks": "^4.0.0",
+            "npm-package-arg": "^8.1.0",
+            "npm-pick-manifest": "^6.1.0",
+            "npm-registry-fetch": "^9.0.0",
+            "pacote": "^11.2.6",
+            "parse-conflict-json": "^1.1.1",
+            "promise-all-reject-late": "^1.0.0",
+            "promise-call-limit": "^1.0.1",
+            "read-package-json-fast": "^2.0.2",
+            "readdir-scoped-modules": "^1.1.0",
+            "semver": "^7.3.5",
+            "tar": "^6.1.0",
+            "treeverse": "^1.0.4",
+            "walk-up-path": "^1.0.0"
           }
+        },
+        "@npmcli/ci-detect": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/config": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ini": "^2.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^5.0.0",
+            "semver": "^7.3.4",
+            "walk-up-path": "^1.0.0"
+          }
+        },
+        "@npmcli/disparity-colors": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.3.0"
+          }
+        },
+        "@npmcli/git": {
+          "version": "2.0.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^1.3.2",
+            "lru-cache": "^6.0.0",
+            "mkdirp": "^1.0.4",
+            "npm-pick-manifest": "^6.1.1",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^2.0.1",
+            "semver": "^7.3.5",
+            "which": "^2.0.2"
+          }
+        },
+        "@npmcli/installed-package-contents": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-bundled": "^1.1.1",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "@npmcli/map-workspaces": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/name-from-folder": "^1.0.1",
+            "glob": "^7.1.6",
+            "minimatch": "^3.0.4",
+            "read-package-json-fast": "^2.0.1"
+          }
+        },
+        "@npmcli/metavuln-calculator": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cacache": "^15.0.5",
+            "pacote": "^11.1.11",
+            "semver": "^7.3.2"
+          }
+        },
+        "@npmcli/move-file": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mkdirp": "^1.0.4",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "@npmcli/name-from-folder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/node-gyp": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@npmcli/promise-spawn": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "infer-owner": "^1.0.4"
+          }
+        },
+        "@npmcli/run-script": {
+          "version": "1.8.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/node-gyp": "^1.0.2",
+            "@npmcli/promise-spawn": "^1.3.2",
+            "infer-owner": "^1.0.4",
+            "node-gyp": "^7.1.0",
+            "read-package-json-fast": "^2.0.1"
+          }
+        },
+        "@tootallnate/once": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
         },
         "abbrev": {
           "version": "1.1.1",
@@ -9263,27 +9314,41 @@
           "dev": true
         },
         "agent-base": {
-          "version": "4.3.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "debug": "4"
           }
         },
         "agentkeepalive": {
-          "version": "3.5.2",
+          "version": "4.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
+            "debug": "^4.1.0",
+            "depd": "^1.1.2",
             "humanize-ms": "^1.2.1"
           }
         },
-        "ansi-align": {
-          "version": "2.0.0",
+        "aggregate-error": {
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ansi-regex": {
@@ -9292,11 +9357,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.1",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "^2.0.1"
           }
         },
         "ansicolors": {
@@ -9320,36 +9385,12 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
           }
         },
         "asap": {
@@ -9381,12 +9422,12 @@
           "dev": true
         },
         "aws4": {
-          "version": "1.8.0",
+          "version": "1.11.0",
           "bundled": true,
           "dev": true
         },
         "balanced-match": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
@@ -9394,42 +9435,27 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
           }
         },
         "bin-links": {
-          "version": "1.1.8",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.3",
-            "cmd-shim": "^3.0.0",
-            "gentle-fs": "^2.3.0",
-            "graceful-fs": "^4.1.15",
+            "cmd-shim": "^4.0.1",
+            "mkdirp": "^1.0.3",
             "npm-normalize-package-bin": "^1.0.0",
-            "write-file-atomic": "^2.3.0"
+            "read-cmd-shim": "^2.0.0",
+            "rimraf": "^3.0.0",
+            "write-file-atomic": "^3.0.3"
           }
         },
-        "bluebird": {
-          "version": "3.5.5",
+        "binary-extensions": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -9440,62 +9466,39 @@
             "concat-map": "0.0.1"
           }
         },
-        "buffer-from": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "builtins": {
           "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
-        "byline": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "byte-size": {
-          "version": "5.0.1",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true
         },
         "cacache": {
-          "version": "12.0.3",
+          "version": "15.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.1",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
           }
-        },
-        "call-limit": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -9503,35 +9506,29 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.4.1",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "chownr": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "ci-info": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "cidr-regex": {
-          "version": "2.0.10",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-regex": "^2.1.0"
+            "ip-regex": "^4.1.0"
           }
         },
-        "cli-boxes": {
-          "version": "1.0.0",
+        "clean-stack": {
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
         },
@@ -9545,51 +9542,41 @@
           }
         },
         "cli-table3": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
-            "string-width": "^2.1.1"
-          }
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
+            "string-width": "^4.2.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
+              "version": "5.0.0",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
-              "version": "2.0.0",
+              "version": "3.0.0",
               "bundled": true,
               "dev": true
             },
             "string-width": {
-              "version": "3.1.0",
+              "version": "4.2.2",
               "bundled": true,
               "dev": true,
               "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
               }
             },
             "strip-ansi": {
-              "version": "5.2.0",
+              "version": "6.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^4.1.0"
+                "ansi-regex": "^5.0.0"
               }
             }
           }
@@ -9600,12 +9587,11 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "3.0.3",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "mkdirp-infer-owner": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -9614,20 +9600,20 @@
           "dev": true
         },
         "color-convert": {
-          "version": "1.9.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-name": "^1.1.1"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true
         },
         "colors": {
-          "version": "1.3.3",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -9642,151 +9628,30 @@
           }
         },
         "combined-stream": {
-          "version": "1.0.6",
+          "version": "1.0.8",
           "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
+        "common-ancestor-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
           "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "config-chain": {
-          "version": "1.1.12",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
-          }
-        },
-        "configstore": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.2.1",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
-        "copy-concurrently": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.1",
-            "fs-write-stream-atomic": "^1.0.8",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "capture-stack-trace": "^1.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "cyclist": {
-          "version": "0.2.2",
           "bundled": true,
           "dev": true
         },
@@ -9799,15 +9664,15 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
+          "version": "4.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           },
           "dependencies": {
             "ms": {
-              "version": "2.0.0",
+              "version": "2.1.2",
               "bundled": true,
               "dev": true
             }
@@ -9818,35 +9683,12 @@
           "bundled": true,
           "dev": true
         },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true
-        },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
-          }
-        },
-        "define-properties": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
@@ -9859,13 +9701,8 @@
           "bundled": true,
           "dev": true
         },
-        "detect-indent": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "detect-newline": {
-          "version": "2.1.0",
+        "depd": {
+          "version": "1.1.2",
           "bundled": true,
           "dev": true
         },
@@ -9878,173 +9715,43 @@
             "wrappy": "1"
           }
         },
-        "dot-prop": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "dotenv": {
-          "version": "5.0.1",
+        "diff": {
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "duplexify": {
-          "version": "3.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
         },
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
           }
         },
-        "editor": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "emoji-regex": {
-          "version": "7.0.3",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true
         },
         "encoding": {
-          "version": "0.1.12",
+          "version": "0.1.13",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.4.0"
+            "iconv-lite": "^0.6.2"
           }
         },
         "env-paths": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true
         },
         "err-code": {
-          "version": "1.1.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true
-        },
-        "errno": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prr": "~1.0.1"
-          }
-        },
-        "es-abstract": {
-          "version": "1.12.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.1.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.1",
-            "is-callable": "^1.1.3",
-            "is-regex": "^1.0.4"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "es6-promise": {
-          "version": "4.2.8",
-          "bundled": true,
-          "dev": true
-        },
-        "es6-promisify": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es6-promise": "^4.0.3"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "extend": {
           "version": "3.0.2",
@@ -10056,53 +9763,15 @@
           "bundled": true,
           "dev": true
         },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true
+        },
         "fast-json-stable-stringify": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true
-        },
-        "figgy-pudding": {
-          "version": "3.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "find-npm-prefix": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "flush-write-stream": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.4"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -10110,115 +9779,21 @@
           "dev": true
         },
         "form-data": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
-            "combined-stream": "1.0.6",
+            "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
         },
-        "from2": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
         "fs-minipass": {
-          "version": "1.2.7",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.6.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
-          }
-        },
-        "fs-vacuum": {
-          "version": "1.2.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
-          }
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
-          },
-          "dependencies": {
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "minipass": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -10251,6 +9826,14 @@
               "bundled": true,
               "dev": true
             },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
@@ -10261,54 +9844,6 @@
                 "strip-ansi": "^3.0.0"
               }
             }
-          }
-        },
-        "genfun": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "gentle-fs": {
-          "version": "2.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.2",
-            "chownr": "^1.1.2",
-            "cmd-shim": "^3.0.3",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "infer-owner": "^1.0.4",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
           }
         },
         "getpass": {
@@ -10332,41 +9867,8 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "global-dirs": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ini": "^1.3.4"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "graceful-fs": {
-          "version": "4.2.4",
+          "version": "4.2.6",
           "bundled": true,
           "dev": true
         },
@@ -10382,29 +9884,6 @@
           "requires": {
             "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "6.12.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-              }
-            },
-            "fast-deep-equal": {
-              "version": "3.1.3",
-              "bundled": true,
-              "dev": true
-            },
-            "json-schema-traverse": {
-              "version": "0.4.1",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "has": {
@@ -10416,12 +9895,7 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "has-symbols": {
-          "version": "1.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -10431,22 +9905,26 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.8.8",
+          "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "http-cache-semantics": {
-          "version": "3.8.1",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true
         },
         "http-proxy-agent": {
-          "version": "2.1.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "http-signature": {
@@ -10460,12 +9938,12 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.4",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "humanize-ms": {
@@ -10477,17 +9955,13 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.6.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
-        },
-        "iferr": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
@@ -10497,13 +9971,13 @@
             "minimatch": "^3.0.4"
           }
         },
-        "import-lazy": {
-          "version": "2.1.0",
+        "imurmurhash": {
+          "version": "0.1.4",
           "bundled": true,
           "dev": true
         },
-        "imurmurhash": {
-          "version": "0.1.4",
+        "indent-string": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -10526,18 +10000,23 @@
           "bundled": true,
           "dev": true
         },
+        "ini": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "init-package-json": {
-          "version": "1.10.3",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npm-package-arg": "^8.1.0",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
+            "read-package-json": "^3.0.0",
+            "semver": "^7.3.2",
+            "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
           }
         },
@@ -10547,108 +10026,35 @@
           "dev": true
         },
         "ip-regex": {
-          "version": "2.1.0",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "is-ci": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ci-info": "^1.5.0"
-          },
-          "dependencies": {
-            "ci-info": {
-              "version": "1.6.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "is-cidr": {
-          "version": "3.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "^2.0.10"
+            "cidr-regex": "^3.1.1"
           }
         },
-        "is-date-object": {
-          "version": "1.0.1",
+        "is-core-module": {
+          "version": "2.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-installed-globally": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-npm": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
-        "is-obj": {
+        "is-lambda": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has": "^1.0.1"
-          }
-        },
-        "is-retry-allowed": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.0"
-          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -10673,16 +10079,25 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
+        "json-parse-even-better-errors": {
+          "version": "2.3.1",
           "bundled": true,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stringify-nice": {
+          "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
@@ -10707,347 +10122,165 @@
             "verror": "1.10.0"
           }
         },
-        "latest-version": {
+        "just-diff": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "just-diff-apply": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "leven": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "libnpmaccess": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "minipass": "^3.1.1",
+            "npm-package-arg": "^8.0.0",
+            "npm-registry-fetch": "^9.0.0"
+          }
+        },
+        "libnpmdiff": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/disparity-colors": "^1.0.1",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "binary-extensions": "^2.2.0",
+            "diff": "^5.0.0",
+            "minimatch": "^3.0.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
+            "tar": "^6.1.0"
+          }
+        },
+        "libnpmfund": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/arborist": "^2.0.0"
+          }
+        },
+        "libnpmhook": {
+          "version": "6.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^9.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^9.0.0"
+          }
+        },
+        "libnpmpack": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/run-script": "^1.8.3",
+            "npm-package-arg": "^8.1.0",
+            "pacote": "^11.2.6"
+          }
+        },
+        "libnpmpublish": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^3.0.0",
+            "npm-package-arg": "^8.1.0",
+            "npm-registry-fetch": "^9.0.0",
+            "semver": "^7.1.3",
+            "ssri": "^8.0.0"
+          }
+        },
+        "libnpmsearch": {
           "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "package-json": "^4.0.0"
+            "npm-registry-fetch": "^9.0.0"
           }
         },
-        "lazy-property": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "libcipm": {
-          "version": "4.0.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "ini": "^1.3.5",
-            "lock-verify": "^2.1.0",
-            "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^3.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "pacote": "^9.1.0",
-            "read-package-json": "^2.0.13",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.6.0"
-          }
-        },
-        "libnpm": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "bin-links": "^1.1.2",
-            "bluebird": "^3.5.3",
-            "find-npm-prefix": "^1.0.2",
-            "libnpmaccess": "^3.0.2",
-            "libnpmconfig": "^1.2.1",
-            "libnpmhook": "^5.0.3",
-            "libnpmorg": "^1.0.1",
-            "libnpmpublish": "^1.1.2",
-            "libnpmsearch": "^2.0.2",
-            "libnpmteam": "^1.0.2",
-            "lock-verify": "^2.0.2",
-            "npm-lifecycle": "^3.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.1.0",
-            "npm-profile": "^4.0.2",
-            "npm-registry-fetch": "^4.0.0",
-            "npmlog": "^4.1.2",
-            "pacote": "^9.5.3",
-            "read-package-json": "^2.0.13",
-            "stringify-package": "^1.0.0"
-          }
-        },
-        "libnpmaccess": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "get-stream": "^4.0.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmconfig": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1",
-            "find-up": "^3.0.0",
-            "ini": "^1.3.5"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "libnpmhook": {
-          "version": "5.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmorg": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmpublish": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.0.0",
-            "lodash.clonedeep": "^4.5.0",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^4.0.0",
-            "semver": "^5.5.1",
-            "ssri": "^6.0.1"
-          }
-        },
-        "libnpmsearch": {
+        "libnpmteam": {
           "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
-          }
-        },
-        "libnpmteam": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
             "aproba": "^2.0.0",
-            "figgy-pudding": "^3.4.1",
-            "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^4.0.0"
+            "npm-registry-fetch": "^9.0.0"
           }
         },
-        "libnpx": {
-          "version": "10.2.4",
+        "libnpmversion": {
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^14.2.3"
+            "@npmcli/git": "^2.0.7",
+            "@npmcli/run-script": "^1.8.4",
+            "json-parse-even-better-errors": "^2.3.1",
+            "semver": "^7.3.5",
+            "stringify-package": "^1.0.1"
           }
-        },
-        "lock-verify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "npm-package-arg": "^6.1.0",
-            "semver": "^5.4.1"
-          }
-        },
-        "lockfile": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._baseuniq": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
-          }
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._createcache": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash._getnative": "^3.0.0"
-          }
-        },
-        "lodash._createset": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash._root": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.union": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.uniq": {
-          "version": "4.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.without": {
-          "version": "4.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lowercase-keys": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
         },
         "lru-cache": {
-          "version": "5.1.1",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
+            "yallist": "^4.0.0"
           }
         },
         "make-fetch-happen": {
-          "version": "5.0.2",
+          "version": "8.0.14",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agentkeepalive": "^3.4.1",
-            "cacache": "^12.0.0",
-            "http-cache-semantics": "^3.8.1",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "node-fetch-npm": "^2.0.2",
-            "promise-retry": "^1.1.1",
-            "socks-proxy-agent": "^4.0.0",
-            "ssri": "^6.0.0"
+            "agentkeepalive": "^4.1.3",
+            "cacache": "^15.0.5",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.3",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^1.3.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^5.0.0",
+            "ssri": "^8.0.0"
           }
         },
-        "meant": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "mime-db": {
-          "version": "1.35.0",
+          "version": "1.47.0",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.19",
+          "version": "2.1.30",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "~1.35.0"
+            "mime-db": "1.47.0"
           }
         },
         "minimatch": {
@@ -11058,157 +10291,142 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
+        "minipass": {
+          "version": "3.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
         },
-        "minizlib": {
+        "minipass-collect": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-fetch": {
           "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.9.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
+            "encoding": "^0.1.12",
+            "minipass": "^3.1.0",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.0.0"
           }
         },
-        "mississippi": {
-          "version": "3.0.0",
+        "minipass-flush": {
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "minipass": "^3.0.0"
           }
         },
-        "mkdirp": {
-          "version": "0.5.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "move-concurrently": {
+        "minipass-json-stream": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
+            "jsonparse": "^1.3.1",
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-pipeline": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass-sized": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp-infer-owner": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^1.0.3"
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.3",
           "bundled": true,
           "dev": true
         },
         "mute-stream": {
-          "version": "0.0.7",
+          "version": "0.0.8",
           "bundled": true,
           "dev": true
         },
-        "node-fetch-npm": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "json-parse-better-errors": "^1.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
         "node-gyp": {
-          "version": "5.1.0",
+          "version": "7.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
+            "graceful-fs": "^4.2.3",
+            "nopt": "^5.0.0",
             "npmlog": "^4.1.2",
-            "request": "^2.88.0",
-            "rimraf": "^2.6.3",
-            "semver": "^5.7.1",
-            "tar": "^4.4.12",
-            "which": "^1.3.1"
+            "request": "^2.88.2",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.2",
+            "tar": "^6.0.2",
+            "which": "^2.0.2"
           }
         },
         "nopt": {
-          "version": "4.0.3",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1"
           }
         },
         "normalize-package-data": {
-          "version": "2.5.0",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
+            "hosted-git-info": "^4.0.1",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
-          },
-          "dependencies": {
-            "resolve": {
-              "version": "1.10.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-parse": "^1.0.6"
-              }
-            }
           }
         },
         "npm-audit-report": {
-          "version": "1.3.3",
+          "version": "2.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cli-table3": "^0.5.0",
-            "console-control-strings": "^1.1.0"
+            "chalk": "^4.0.0"
           }
         },
         "npm-bundled": {
@@ -11219,38 +10437,13 @@
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
-        "npm-cache-filename": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "npm-install-checks": {
-          "version": "3.0.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "^7.1.1"
           }
-        },
-        "npm-lifecycle": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.15",
-            "node-gyp": "^5.0.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
-            "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.1"
-          }
-        },
-        "npm-logical-tree": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
@@ -11258,73 +10451,58 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "6.1.1",
+          "version": "8.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.7.1",
-            "osenv": "^0.1.5",
-            "semver": "^5.6.0",
+            "hosted-git-info": "^4.0.1",
+            "semver": "^7.3.4",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.4.8",
+          "version": "2.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1",
+            "glob": "^7.1.6",
+            "ignore-walk": "^3.0.3",
+            "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
-          "version": "3.0.2",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1",
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-install-checks": "^4.0.0",
+            "npm-normalize-package-bin": "^1.0.1",
+            "npm-package-arg": "^8.1.2",
+            "semver": "^7.3.4"
           }
         },
         "npm-profile": {
-          "version": "4.0.4",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.1.2 || 2",
-            "figgy-pudding": "^3.4.1",
-            "npm-registry-fetch": "^4.0.0"
+            "npm-registry-fetch": "^9.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.7",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "JSONStream": "^1.3.4",
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^3.4.1",
-            "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^5.0.0",
-            "npm-package-arg": "^6.1.0",
-            "safe-buffer": "^5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
+            "@npmcli/ci-detect": "^1.0.0",
+            "lru-cache": "^6.0.0",
+            "make-fetch-happen": "^8.0.9",
+            "minipass": "^3.1.3",
+            "minipass-fetch": "^1.3.0",
+            "minipass-json-stream": "^1.0.1",
+            "minizlib": "^2.0.0",
+            "npm-package-arg": "^8.0.0"
           }
         },
         "npm-user-validate": {
@@ -11358,20 +10536,6 @@
           "bundled": true,
           "dev": true
         },
-        "object-keys": {
-          "version": "1.0.12",
-          "bundled": true,
-          "dev": true
-        },
-        "object.getownpropertydescriptors": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.5.1"
-          }
-        },
         "once": {
           "version": "1.4.0",
           "bundled": true,
@@ -11385,140 +10549,52 @@
           "bundled": true,
           "dev": true
         },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "osenv": {
-          "version": "0.1.5",
+        "p-map": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "aggregate-error": "^3.0.0"
           }
         },
         "pacote": {
-          "version": "9.5.12",
+          "version": "11.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.3",
-            "cacache": "^12.0.2",
-            "chownr": "^1.1.2",
-            "figgy-pudding": "^3.5.1",
-            "get-stream": "^4.1.0",
-            "glob": "^7.1.3",
+            "@npmcli/git": "^2.0.1",
+            "@npmcli/installed-package-contents": "^1.0.6",
+            "@npmcli/promise-spawn": "^1.2.0",
+            "@npmcli/run-script": "^1.8.2",
+            "cacache": "^15.0.5",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^5.0.0",
-            "minimatch": "^3.0.4",
-            "minipass": "^2.3.5",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-normalize-package-bin": "^1.0.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.12",
-            "npm-pick-manifest": "^3.0.0",
-            "npm-registry-fetch": "^4.0.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.1",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.6.0",
-            "ssri": "^6.0.1",
-            "tar": "^4.4.10",
-            "unique-filename": "^1.1.1",
-            "which": "^1.3.1"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
+            "minipass": "^3.1.3",
+            "mkdirp": "^1.0.3",
+            "npm-package-arg": "^8.0.1",
+            "npm-packlist": "^2.1.4",
+            "npm-pick-manifest": "^6.0.0",
+            "npm-registry-fetch": "^9.0.0",
+            "promise-retry": "^2.0.1",
+            "read-package-json-fast": "^2.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.1",
+            "tar": "^6.1.0"
           }
         },
-        "parallel-transform": {
-          "version": "1.1.0",
+        "parse-conflict-json": {
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cyclist": "~0.2.2",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.1.5"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "json-parse-even-better-errors": "^2.3.0",
+            "just-diff": "^3.0.1",
+            "just-diff-apply": "^3.0.0"
           }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -11532,18 +10608,18 @@
           "bundled": true,
           "dev": true
         },
-        "pify": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-all-reject-late": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-call-limit": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true
         },
@@ -11553,19 +10629,12 @@
           "dev": true
         },
         "promise-retry": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "err-code": "^1.0.0",
-            "retry": "^0.10.0"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true,
-              "dev": true
-            }
+            "err-code": "^2.0.2",
+            "retry": "^0.12.0"
           }
         },
         "promzard": {
@@ -11576,66 +10645,13 @@
             "read": "1"
           }
         },
-        "proto-list": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true
-        },
-        "protoduck": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "genfun": "^5.0.0"
-          }
-        },
-        "prr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
         "psl": {
-          "version": "1.1.29",
+          "version": "1.8.0",
           "bundled": true,
           "dev": true
-        },
-        "pump": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "pumpify": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
-          },
-          "dependencies": {
-            "pump": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            }
-          }
         },
         "punycode": {
-          "version": "1.4.1",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
@@ -11649,32 +10665,6 @@
           "bundled": true,
           "dev": true
         },
-        "query-string": {
-          "version": "6.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "split-on-first": "^1.0.0",
-            "strict-uri-encode": "^2.0.0"
-          }
-        },
-        "qw": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
         "read": {
           "version": "1.0.7",
           "bundled": true,
@@ -11684,57 +10674,42 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.5",
+          "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2"
-          }
-        },
-        "read-installed": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
-          }
+          "dev": true
         },
         "read-package-json": {
-          "version": "2.1.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
+            "json-parse-even-better-errors": "^2.3.0",
+            "normalize-package-data": "^3.0.0",
             "npm-normalize-package-bin": "^1.0.0"
           }
         },
-        "read-package-tree": {
-          "version": "5.3.1",
+        "read-package-json-fast": {
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "util-promisify": "^2.1.0"
+            "json-parse-even-better-errors": "^2.3.0",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "readable-stream": {
-          "version": "3.6.0",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -11748,25 +10723,8 @@
             "once": "^1.3.0"
           }
         },
-        "registry-auth-token": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
         "request": {
-          "version": "2.88.0",
+          "version": "2.88.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11777,7 +10735,7 @@
             "extend": "~3.0.2",
             "forever-agent": "~0.6.1",
             "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
+            "har-validator": "~5.1.3",
             "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
@@ -11787,25 +10745,30 @@
             "performance-now": "^2.1.0",
             "qs": "~6.5.2",
             "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
+            "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "tough-cookie": {
+              "version": "2.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              }
+            }
           }
         },
-        "require-directory": {
-          "version": "2.1.1",
+        "resolve": {
+          "version": "1.20.0",
           "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
         },
         "retry": {
           "version": "0.12.0",
@@ -11813,26 +10776,11 @@
           "dev": true
         },
         "rimraf": {
-          "version": "2.7.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "run-queue": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^1.1.1"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "safe-buffer": {
@@ -11846,16 +10794,11 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
+          "version": "7.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "^5.0.3"
+            "lru-cache": "^6.0.0"
           }
         },
         "set-blocking": {
@@ -11863,34 +10806,8 @@
           "bundled": true,
           "dev": true
         },
-        "sha": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true
         },
@@ -11900,81 +10817,26 @@
           "dev": true
         },
         "socks": {
-          "version": "2.3.3",
+          "version": "2.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "1.1.5",
+            "ip": "^1.1.5",
             "smart-buffer": "^4.1.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "~4.2.1",
-            "socks": "~2.3.2"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "4.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "es6-promisify": "^5.0.0"
-              }
-            }
-          }
-        },
-        "sorted-object": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "sorted-union-stream": {
-          "version": "2.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
-          },
-          "dependencies": {
-            "from2": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
-              }
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.1.14",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "bundled": true,
-              "dev": true
-            }
+            "agent-base": "6",
+            "debug": "4",
+            "socks": "^2.3.3"
           }
         },
         "spdx-correct": {
-          "version": "3.0.0",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11983,12 +10845,12 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.1.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11997,17 +10859,12 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "split-on-first": {
-          "version": "1.1.0",
+          "version": "3.0.7",
           "bundled": true,
           "dev": true
         },
         "sshpk": {
-          "version": "1.14.2",
+          "version": "1.16.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12023,64 +10880,12 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
+          "version": "8.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1"
+            "minipass": "^3.1.1"
           }
-        },
-        "stream-each": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "stream-iterate": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "stream-shift": "^1.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strict-uri-encode": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
@@ -12096,11 +10901,6 @@
               "bundled": true,
               "dev": true
             },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
@@ -12112,18 +10912,11 @@
           }
         },
         "string_decoder": {
-          "version": "1.3.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.2.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true
-            }
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -12139,102 +10932,29 @@
             "ansi-regex": "^2.0.0"
           }
         },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "supports-color": {
-          "version": "5.4.0",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         },
         "tar": {
-          "version": "4.4.13",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "2.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            }
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0"
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true,
-          "dev": true
-        },
-        "through2": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
           "bundled": true,
           "dev": true
         },
@@ -12243,14 +10963,10 @@
           "bundled": true,
           "dev": true
         },
-        "tough-cookie": {
-          "version": "2.4.3",
+        "treeverse": {
+          "version": "1.0.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
+          "dev": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
@@ -12263,23 +10979,15 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
+          "dev": true
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "bundled": true,
           "dev": true,
-          "optional": true
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "umask": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
         },
         "unique-filename": {
           "version": "1.1.1",
@@ -12290,69 +10998,19 @@
           }
         },
         "unique-slug": {
-          "version": "2.0.0",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
         },
-        "unique-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "crypto-random-string": "^1.0.0"
-          }
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
         "uri-js": {
-          "version": "4.4.0",
+          "version": "4.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "punycode": "^2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
@@ -12360,21 +11018,8 @@
           "bundled": true,
           "dev": true
         },
-        "util-extend": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "util-promisify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object.getownpropertydescriptors": "^2.0.3"
-          }
-        },
         "uuid": {
-          "version": "3.3.3",
+          "version": "3.4.0",
           "bundled": true,
           "dev": true
         },
@@ -12405,6 +11050,11 @@
             "extsprintf": "^1.2.0"
           }
         },
+        "walk-up-path": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
@@ -12414,92 +11064,19 @@
           }
         },
         "which": {
-          "version": "1.3.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.2"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "widest-line": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "worker-farm": {
-          "version": "1.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "errno": "~0.1.7"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -12508,136 +11085,20 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "2.4.3",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
           }
         },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "y18n": {
+        "yallist": {
           "version": "4.0.0",
           "bundled": true,
           "dev": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "find-up": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -12825,9 +11286,9 @@
       "dev": true
     },
     "p-retry": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
+      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
       "dev": true,
       "requires": {
         "@types/retry": "^0.12.0",
@@ -12840,77 +11301,27 @@
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "pac-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
+      "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
       "requires": {
-        "agent-base": "^4.2.0",
-        "debug": "^4.1.1",
-        "get-uri": "^2.0.0",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^3.0.0",
-        "pac-resolver": "^3.0.0",
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4",
+        "get-uri": "3",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "5",
+        "pac-resolver": "^4.1.0",
         "raw-body": "^2.2.0",
-        "socks-proxy-agent": "^4.0.1"
+        "socks-proxy-agent": "5"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "http-proxy-agent": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-          "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
-        },
-        "https-proxy-agent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-          "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.7",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
           }
         },
         "ms": {
@@ -12921,15 +11332,13 @@
       }
     },
     "pac-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
+      "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
       "requires": {
-        "co": "^4.6.0",
-        "degenerator": "^1.0.4",
+        "degenerator": "^2.2.0",
         "ip": "^1.1.5",
-        "netmask": "^1.0.6",
-        "thunkify": "^2.1.2"
+        "netmask": "^2.0.1"
       }
     },
     "package-json": {
@@ -12968,9 +11377,9 @@
       }
     },
     "parse-json": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -13683,10 +12092,19 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
-      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "26.0.0",
@@ -13736,7 +12154,8 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.0",
@@ -13755,77 +12174,26 @@
       }
     },
     "proxy-agent": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
-      "integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
       "requires": {
-        "agent-base": "^4.2.0",
+        "agent-base": "^6.0.0",
         "debug": "4",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^3.0.0",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
         "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^3.0.1",
+        "pac-proxy-agent": "^4.1.0",
         "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^4.0.1"
+        "socks-proxy-agent": "^5.0.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "http-proxy-agent": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-          "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
-        },
-        "https-proxy-agent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-          "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.7",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
           }
         },
         "ms": {
@@ -13879,6 +12247,11 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -13946,12 +12319,12 @@
           }
         },
         "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
           "dev": true,
           "requires": {
-            "is-core-module": "^2.1.0",
+            "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
         },
@@ -14082,6 +12455,7 @@
       "version": "2.3.6",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14100,14 +12474,6 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
-        }
       }
     },
     "redeyed": {
@@ -14135,9 +12501,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
     "registry-auth-token": {
@@ -14239,6 +12605,12 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -14287,16 +12659,6 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "requires": {
         "lowercase-keys": "^1.0.0"
-      }
-    },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -14352,33 +12714,19 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
-    "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
-    },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
-    },
-    "rxjs": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "requires": {
-        "tslib": "^1.9.0"
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -14575,9 +12923,9 @@
       }
     },
     "semantic-release": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.2.3.tgz",
-      "integrity": "sha512-MY1MlowGQrkOR7+leOD8ICkVOC6i1szbwDODdbJ0UdshtMx8Ms0bhpRQmEEliqYKEb5PLv/dqs6zKKuHT7UxTg==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.2.tgz",
+      "integrity": "sha512-TPLWuoe2L2DmgnQEh+OLWW5V1T+ZAa1xWuHXsuPAWEko0BqSdLPl+5+BlQ+D5Bp27S5gDJ1//Y1tgbmvUhnOCw==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -14586,19 +12934,19 @@
         "@semantic-release/npm": "^7.0.0",
         "@semantic-release/release-notes-generator": "^9.0.0",
         "aggregate-error": "^3.0.0",
-        "cosmiconfig": "^6.0.0",
+        "cosmiconfig": "^7.0.0",
         "debug": "^4.0.0",
         "env-ci": "^5.0.0",
-        "execa": "^4.0.0",
+        "execa": "^5.0.0",
         "figures": "^3.0.0",
-        "find-versions": "^3.0.0",
-        "get-stream": "^5.0.0",
+        "find-versions": "^4.0.0",
+        "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
         "hook-std": "^2.0.0",
-        "hosted-git-info": "^3.0.0",
+        "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.15",
-        "marked": "^1.0.0",
-        "marked-terminal": "^4.0.0",
+        "marked": "^2.0.0",
+        "marked-terminal": "^4.1.1",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -14607,9 +12955,61 @@
         "semver": "^7.3.2",
         "semver-diff": "^3.1.1",
         "signale": "^1.2.1",
-        "yargs": "^15.0.1"
+        "yargs": "^16.2.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -14619,23 +13019,49 @@
             "ms": "2.1.2"
           }
         },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+        "execa": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+          "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
           }
         },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        },
         "hosted-git-info": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -14652,10 +13078,28 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "p-reduce": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-          "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "resolve-from": {
@@ -14665,18 +13109,95 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
           "dev": true
         }
       }
@@ -14702,9 +13223,9 @@
       }
     },
     "semver-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
       "dev": true
     },
     "set-blocking": {
@@ -14810,14 +13331,46 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        }
       }
     },
     "smart-buffer": {
@@ -14931,30 +13484,36 @@
       }
     },
     "socks": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
       "requires": {
-        "ip": "1.1.5",
+        "ip": "^1.1.5",
         "smart-buffer": "^4.1.0"
       }
     },
     "socks-proxy-agent": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
       "requires": {
-        "agent-base": "~4.2.1",
-        "socks": "~2.3.2"
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "ms": "2.1.2"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -15054,22 +13613,23 @@
       }
     },
     "split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.2"
+        "readable-stream": "^3.0.0"
       },
       "dependencies": {
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -15237,6 +13797,7 @@
       "version": "1.1.1",
       "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -15339,36 +13900,45 @@
       "dev": true
     },
     "table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.3.0.tgz",
+      "integrity": "sha512-gM9kB7aNIuSagW89Fh+SdL49uhKnVSORxMcV72u/dfptFdqExInNn5M21wgq/Uf5UdJpsboFhNe/0SoNKjaxzg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^8.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0"
       },
       "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "ajv": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+          "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
           }
         },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
         }
       }
     },
@@ -15425,9 +13995,9 @@
       "dev": true
     },
     "tempy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.0.tgz",
-      "integrity": "sha512-eLXG5B1G0mRPHmgH2WydPl5v4jH35qEn3y/rA/aahKhIa91Pn119SsU7n7v/433gtT9ONzC8ISvNHIh2JSTm0w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
       "dev": true,
       "requires": {
         "del": "^6.0.0",
@@ -15544,20 +14114,6 @@
         }
       }
     },
-    "thunkify": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
-      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
-    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -15663,12 +14219,6 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
-    "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -15713,9 +14263,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.2.tgz",
-      "integrity": "sha512-rWYleAvfJPjduYCt+ELvzybNah/zIkRteGXIBO8X0lteRZPGladF61hFi8tU7qKTsF7u6DUQCtT9k00VlFOgkg==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
+      "integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
       "dev": true,
       "optional": true
     },
@@ -15764,8 +14314,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -15925,7 +14474,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utility-types": {
       "version": "3.10.0",
@@ -15939,9 +14489,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "v8-to-istanbul": {
@@ -16174,15 +14724,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
-    },
     "write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -16229,9 +14770,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yallist": {
       "version": "3.1.1",
@@ -16239,9 +14780,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yaml-js": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pkg": "./node_modules/.bin/pkg --out-path=./bin ./package.json; cd bin; rename -f 's/ibm-openapi-validator-(linux|macos|win)/lint-openapi-$1/g' ./ibm-openapi-*"
   },
   "dependencies": {
-    "@stoplight/spectral": "^5.8.1",
+    "@stoplight/spectral": "^5.9.1",
     "chalk": "^4.1.0",
     "commander": "^2.17.1",
     "deepmerge": "^2.1.1",
@@ -44,13 +44,13 @@
     "babel-eslint": "^10.1.0",
     "codecov": "^3.5.0",
     "cz-conventional-changelog": "^2.1.0",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^3.0.1",
-    "eslint-plugin-prettier": "^2.6.2",
+    "eslint": "^7.24.0",
+    "eslint-config-prettier": "^8.2.0",
+    "eslint-plugin-prettier": "^3.4.0",
     "jest": "^26.0.0",
     "pkg": "^4.4.0",
-    "prettier": "^1.14.2",
-    "semantic-release": "^17.0.4",
+    "prettier": "^2.2.1",
+    "semantic-release": "^17.4.2",
     "strip-ansi": "^4.0.0"
   },
   "bin": {

--- a/src/cli-validator/index.js
+++ b/src/cli-validator/index.js
@@ -77,11 +77,11 @@ program.parse(process.argv);
 
 // run the program
 cliValidator(program)
-  .then(exitCode => {
+  .then((exitCode) => {
     process.exitCode = exitCode;
     return exitCode;
   })
-  .catch(err => {
+  .catch((err) => {
     // if err is 2, it is because the message was caught
     // and printed already
     if (err !== 2) {

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -25,7 +25,7 @@ const init = require('./utils/init.js');
 
 // this function processes the input, does the error handling,
 //  and acts as the main function for the program
-const processInput = async function(program) {
+const processInput = async function (program) {
   let args = program.args;
 
   // require that arguments are passed in
@@ -74,15 +74,15 @@ const processInput = async function(program) {
   // ignore files in .validateignore by comparing absolute paths
   const ignoredFiles = await config.ignore();
   const filteredArgs = args.filter(
-    file => !ignoredFiles.includes(path.resolve(file))
+    (file) => !ignoredFiles.includes(path.resolve(file))
   );
 
   // determine which files were removed from args because they were 'ignored'
   // then, print these for the user. this way, the user is alerted to why files
   // aren't validated
-  const filteredFiles = args.filter(file => !filteredArgs.includes(file));
+  const filteredFiles = args.filter((file) => !filteredArgs.includes(file));
   if (filteredFiles.length) console.log();
-  filteredFiles.forEach(filename => {
+  filteredFiles.forEach((filename) => {
     console.log(
       chalk.magenta('[Ignored] ') + path.relative(process.cwd(), filename)
     );
@@ -96,7 +96,7 @@ const processInput = async function(program) {
   const supportedFileTypes = ['json', 'yml', 'yaml'];
   const filesWithValidExtensions = [];
   let unsupportedExtensionsFound = false;
-  args.forEach(arg => {
+  args.forEach((arg) => {
     if (ext.supportedFileExtension(arg, supportedFileTypes)) {
       filesWithValidExtensions.push(arg);
     } else {
@@ -127,10 +127,10 @@ const processInput = async function(program) {
   // every file.
   const filesToValidate = await globby(filesWithValidExtensions);
   const nonExistentFiles = filesWithValidExtensions.filter(
-    file => !filesToValidate.includes(file)
+    (file) => !filesToValidate.includes(file)
   );
   if (nonExistentFiles.length) console.log();
-  nonExistentFiles.forEach(file => {
+  nonExistentFiles.forEach((file) => {
     console.log(
       chalk.yellow('[Warning]') + ` Skipping non-existent file: ${file}`
     );
@@ -171,7 +171,7 @@ const processInput = async function(program) {
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset
   const spectral = new Spectral({
-    computeFingerprint: dedupFunction
+    computeFingerprint: dedupFunction,
   });
   try {
     await spectralValidator.setup(spectral, rulesetFileOverride, configObject);
@@ -307,10 +307,8 @@ const processInput = async function(program) {
         results.errors['warnings-limit'] = [
           {
             path: [],
-            message: `Number of warnings (${numWarnings}) exceeds warnings limit (${
-              limitsObject.warnings
-            }).`
-          }
+            message: `Number of warnings (${numWarnings}) exceeds warnings limit (${limitsObject.warnings}).`,
+          },
         ];
       }
     }

--- a/src/cli-validator/utils/addPathsToComponents.js
+++ b/src/cli-validator/utils/addPathsToComponents.js
@@ -17,9 +17,9 @@ const getPathAsArray = require('./getPathAsArray');
 //
 // adds path to the originating component if it exists
 // modifies the given results object
-module.exports = function(originalResults, unresolvedSpec) {
-  each(originalResults, function(validatorsDict) {
-    each(validatorsDict, function(errors) {
+module.exports = function (originalResults, unresolvedSpec) {
+  each(originalResults, function (validatorsDict) {
+    each(validatorsDict, function (errors) {
       pointToComponents(errors, unresolvedSpec);
     });
   });
@@ -37,14 +37,14 @@ module.exports = function(originalResults, unresolvedSpec) {
 // adds componentPath field to existing errors
 // modifies existing errors in place
 function pointToComponents(errors, unresolvedSpec) {
-  each(errors, function(err) {
+  each(errors, function (err) {
     const pathArray = getPathAsArray(err.path);
     let componentPath = null;
     let refObj = findRef(pathArray, unresolvedSpec);
     while (refObj.refString !== null) {
       componentPath = [
         ...parseRefString(refObj.refString),
-        ...refObj.remainingPath
+        ...refObj.remainingPath,
       ];
       refObj = findRef(componentPath, unresolvedSpec);
     }
@@ -90,7 +90,7 @@ function findRef(pathArray, unresolvedSpec) {
   return {
     refString: ref,
     remainingPath: pathArray.slice(indexOfRef, pathArray.length),
-    validPath: validPath
+    validPath: validPath,
   };
 }
 

--- a/src/cli-validator/utils/buildSwaggerObject.js
+++ b/src/cli-validator/utils/buildSwaggerObject.js
@@ -9,17 +9,17 @@ const apiSchema3 = require('../../plugins/validation/oas3/apis/oas3-schema')
   .default;
 
 const schemas = {
-  '2': {
-    apiSchema: apiSchema2
+  2: {
+    apiSchema: apiSchema2,
   },
-  '3': {
-    apiSchema: apiSchema3
-  }
+  3: {
+    apiSchema: apiSchema3,
+  },
 };
 
 // ### all validations expect an object with three properties: ###
 // ###          jsSpec, resolvedSpec, and specStr              ###
-module.exports = async function(input) {
+module.exports = async function (input) {
   // initialize an object to be passed through all the validators
   const swagger = {};
   const parser = new RefParser();
@@ -52,7 +52,7 @@ module.exports = async function(input) {
   //  describing which schemas to validate against
   swagger.settings = {
     schemas: [apiSchema],
-    testSchema: apiSchema
+    testSchema: apiSchema,
   };
 
   return swagger;

--- a/src/cli-validator/utils/checkVersion.js
+++ b/src/cli-validator/utils/checkVersion.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 // this module can be used to handle any version-specific functionality
 // it will be called immediately when the program is run
 
-module.exports = function(requiredVersion) {
+module.exports = function (requiredVersion) {
   // this is called since the code uses features that require `requiredVersion`
   const isSupportedVersion = semver.gte(process.version, requiredVersion);
   if (!isSupportedVersion) {

--- a/src/cli-validator/utils/circular-references-ibm.js
+++ b/src/cli-validator/utils/circular-references-ibm.js
@@ -5,16 +5,16 @@ const isPlainObject = require('lodash/isPlainObject');
 const isObject = require('lodash/isObject');
 
 // and return them as problems if applicable
-const validate = function({ jsSpec, resolvedSpec }, config) {
+const validate = function ({ jsSpec, resolvedSpec }, config) {
   const result = { error: [], warning: [] };
   config = config.walker;
   const pathsInResolvedSpec = correctSpec(resolvedSpec);
   const actualPaths = convertPaths(jsSpec, pathsInResolvedSpec);
   const checkStatus = config.has_circular_references;
   if (checkStatus !== 'off') {
-    result[checkStatus] = actualPaths.map(path => ({
+    result[checkStatus] = actualPaths.map((path) => ({
       message: 'Swagger object should not contain circular references.',
-      path
+      path,
     }));
   }
   return { errors: result.error, warnings: result.warning };
@@ -22,7 +22,7 @@ const validate = function({ jsSpec, resolvedSpec }, config) {
 
 // this function finds circular references in the resolved spec and
 // cuts them off to allow recursive walks in the validators
-const correctSpec = function(resolvedSpec) {
+const correctSpec = function (resolvedSpec) {
   const paths = [];
 
   function walk(object, path, visitedObjects) {
@@ -41,7 +41,7 @@ const correctSpec = function(resolvedSpec) {
       return null;
     }
 
-    return keys.forEach(function(key) {
+    return keys.forEach(function (key) {
       if (isPlainObject(object[key])) {
         if (visitedObjects.includes(object[key])) {
           paths.push([...path, key]);
@@ -59,9 +59,9 @@ const correctSpec = function(resolvedSpec) {
 
 // this function takes the paths found while correcting the spec and
 // finds where the circular references are happening in the actual spec
-const convertPaths = function(jsSpec, resolvedPaths) {
+const convertPaths = function (jsSpec, resolvedPaths) {
   const realPaths = [];
-  resolvedPaths.forEach(path => {
+  resolvedPaths.forEach((path) => {
     let realPath = [];
     let previous = jsSpec;
     // path is an array of keys leading to the circular reference
@@ -84,7 +84,7 @@ const convertPaths = function(jsSpec, resolvedPaths) {
           // locationArray holds the keys to the references object in the spec
           const locationArray = current.$ref
             .split('/')
-            .filter(refKey => refKey !== '#');
+            .filter((refKey) => refKey !== '#');
           // since we are following a ref to the first object level,
           // realPath needs to be reset
           realPath = [...locationArray];

--- a/src/cli-validator/utils/fileExtensionValidator.js
+++ b/src/cli-validator/utils/fileExtensionValidator.js
@@ -1,6 +1,6 @@
 const last = require('lodash/last');
 
-const getExtension = filename => {
+const getExtension = (filename) => {
   return last(filename.split('.')).toLowerCase();
 };
 

--- a/src/cli-validator/utils/getPathAsArray.js
+++ b/src/cli-validator/utils/getPathAsArray.js
@@ -1,3 +1,3 @@
-module.exports = function(path) {
+module.exports = function (path) {
   return Array.isArray(path) ? path : path.split('.');
 };

--- a/src/cli-validator/utils/init.js
+++ b/src/cli-validator/utils/init.js
@@ -6,12 +6,12 @@ const printError = require('./printError');
 const { defaults } = require('../../.defaultsForValidator');
 const fileToCreate = process.cwd() + '/.validaterc';
 
-module.exports.printDefaults = async function(chalk) {
+module.exports.printDefaults = async function (chalk) {
   const successMessage = `'.validaterc' file created and set to defaults.`;
   return await writeConfigFile(defaults, successMessage, chalk);
 };
 
-module.exports.migrate = async function(chalk) {
+module.exports.migrate = async function (chalk) {
   let oldConfigFile;
   try {
     oldConfigFile = await readCurrentConfig();

--- a/src/cli-validator/utils/jsonResults.js
+++ b/src/cli-validator/utils/jsonResults.js
@@ -29,9 +29,9 @@ function formatResultsAsObject(
 
   const allErrorCategories = ['errors', 'warnings', 'infos', 'hints'];
   const types = errorsOnly ? ['errors'] : allErrorCategories;
-  types.forEach(type => {
-    each(results[type], problems => {
-      problems.forEach(problem => {
+  types.forEach((type) => {
+    each(results[type], (problems) => {
+      problems.forEach((problem) => {
         let path = problem.path;
 
         // path needs to be an array to get the line number

--- a/src/cli-validator/utils/modified-commander.js
+++ b/src/cli-validator/utils/modified-commander.js
@@ -8,7 +8,7 @@ const program = require('commander');
 delete program['unknownOption'];
 
 // reimplementing the funciton
-program.unknownOption = function(flag) {
+program.unknownOption = function (flag) {
   if (this._allowUnknownOption) return;
   console.error();
   console.error("  error: unknown option `%s'", flag);

--- a/src/cli-validator/utils/noDeduplication.js
+++ b/src/cli-validator/utils/noDeduplication.js
@@ -1,7 +1,7 @@
 let globalId = 0;
 
 // assigns a unique id to each error
-module.exports = function() {
+module.exports = function () {
   globalId += 1;
   return globalId;
 };

--- a/src/cli-validator/utils/preprocessFile.js
+++ b/src/cli-validator/utils/preprocessFile.js
@@ -1,4 +1,4 @@
-module.exports = function(originalFile) {
+module.exports = function (originalFile) {
   let processedFile;
 
   // replace all tabs characters (\t) in the original file with 2 spaces

--- a/src/cli-validator/utils/printResults.js
+++ b/src/cli-validator/utils/printResults.js
@@ -23,28 +23,28 @@ module.exports = function print(
     errors: 'bgRed',
     warnings: 'bgYellow',
     infos: 'bgGrey',
-    hints: 'bgGreen'
+    hints: 'bgGreen',
   };
 
   // define an object template in the case that statistics reporting is turned on
   const stats = {
     errors: {
-      total: 0
+      total: 0,
     },
     warnings: {
-      total: 0
+      total: 0,
     },
     infos: {
-      total: 0
+      total: 0,
     },
     hints: {
-      total: 0
-    }
+      total: 0,
+    },
   };
 
   console.log();
 
-  types.forEach(type => {
+  types.forEach((type) => {
     let color = colors[type];
     if (Object.keys(results[type]).length) {
       console.log(chalk[color].bold(`${type}\n`));
@@ -58,7 +58,7 @@ module.exports = function print(
         console.log(`Validator: ${validator}`);
       }
 
-      problems.forEach(problem => {
+      problems.forEach((problem) => {
         // To allow messages with fillins to be grouped properly in the statistics,
         // truncate the message at the first ':'
         const message = problem.message.split(':')[0];
@@ -138,13 +138,13 @@ module.exports = function print(
     }
     console.log('');
 
-    types.forEach(type => {
+    types.forEach((type) => {
       // print the type, either error or warning
       if (stats[type].total) {
         console.log('  ' + chalk.underline.cyan(type));
       }
 
-      Object.keys(stats[type]).forEach(message => {
+      Object.keys(stats[type]).forEach((message) => {
         if (message !== 'total') {
           // calculate percentage
           const number = stats[type][message];

--- a/src/cli-validator/utils/processConfiguration.js
+++ b/src/cli-validator/utils/processConfiguration.js
@@ -15,7 +15,7 @@ defaultObject.spectral.rules = {};
 const deprecatedRuleObject = defaultConfig.deprecated;
 const configOptions = defaultConfig.options;
 
-const printConfigErrors = function(problems, chalk, fileName) {
+const printConfigErrors = function (problems, chalk, fileName) {
   const description = `Invalid configuration in ${chalk.underline(
     fileName
   )} file. See below for details.`;
@@ -23,7 +23,7 @@ const printConfigErrors = function(problems, chalk, fileName) {
   const message = [];
 
   // add all errors for printError
-  problems.forEach(function(problem) {
+  problems.forEach(function (problem) {
     message.push(
       `\n - ${chalk.red(problem.message)}\n   ${chalk.magenta(
         problem.correction
@@ -35,7 +35,7 @@ const printConfigErrors = function(problems, chalk, fileName) {
   }
 };
 
-const validateConfigObject = function(configObject, chalk) {
+const validateConfigObject = function (configObject, chalk) {
   const configErrors = [];
   let validObject = true;
 
@@ -43,7 +43,7 @@ const validateConfigObject = function(configObject, chalk) {
 
   const allowedSpecs = Object.keys(defaultObject);
   const userSpecs = Object.keys(configObject);
-  userSpecs.forEach(spec => {
+  userSpecs.forEach((spec) => {
     // Do not check "spectral" spec rules
     if (spec === 'spectral') {
       return;
@@ -52,7 +52,7 @@ const validateConfigObject = function(configObject, chalk) {
       validObject = false;
       configErrors.push({
         message: `'${spec}' is not a valid spec.`,
-        correction: `Valid specs are: ${allowedSpecs.join(', ')}`
+        correction: `Valid specs are: ${allowedSpecs.join(', ')}`,
       });
       return; // skip rules for categories for invalid spec
     }
@@ -60,12 +60,12 @@ const validateConfigObject = function(configObject, chalk) {
     // check that all categories are valid
     const allowedCategories = Object.keys(defaultObject[spec]);
     const userCategories = Object.keys(configObject[spec]);
-    userCategories.forEach(category => {
+    userCategories.forEach((category) => {
       if (!allowedCategories.includes(category)) {
         validObject = false;
         configErrors.push({
           message: `'${category}' is not a valid category.`,
-          correction: `Valid categories are: ${allowedCategories.join(', ')}`
+          correction: `Valid categories are: ${allowedCategories.join(', ')}`,
         });
         return; // skip rules for invalid category
       }
@@ -73,7 +73,7 @@ const validateConfigObject = function(configObject, chalk) {
       // check that all rules are valid
       const allowedRules = Object.keys(defaultObject[spec][category]);
       const userRules = Object.keys(configObject[spec][category]);
-      userRules.forEach(rule => {
+      userRules.forEach((rule) => {
         if (
           deprecatedRules.includes(rule) ||
           // account for rules with same name in different categories
@@ -95,7 +95,7 @@ const validateConfigObject = function(configObject, chalk) {
           validObject = false;
           configErrors.push({
             message: `'${rule}' is not a valid rule for the ${category} category`,
-            correction: `Valid rules are: ${allowedRules.join(', ')}`
+            correction: `Valid rules are: ${allowedRules.join(', ')}`,
           });
           return; // skip statuses for invalid rule
         }
@@ -119,7 +119,7 @@ const validateConfigObject = function(configObject, chalk) {
             if (!result.valid) {
               configErrors.push({
                 message: `'${configOption}' is not a valid option for the ${rule} rule in the ${category} category.`,
-                correction: `Valid options are: ${result.options.join(', ')}`
+                correction: `Valid options are: ${result.options.join(', ')}`,
               });
               validObject = false;
             }
@@ -132,14 +132,14 @@ const validateConfigObject = function(configObject, chalk) {
           userStatus = 'off';
           configErrors.push({
             message: `Array-value configuration options are not supported for the ${rule} rule in the ${category} category.`,
-            correction: `Valid statuses are: ${allowedStatusValues.join(', ')}`
+            correction: `Valid statuses are: ${allowedStatusValues.join(', ')}`,
           });
         }
         if (!allowedStatusValues.includes(userStatus)) {
           validObject = false;
           configErrors.push({
             message: `'${userStatus}' is not a valid status for the ${rule} rule in the ${category} category.`,
-            correction: `Valid statuses are: ${allowedStatusValues.join(', ')}`
+            correction: `Valid statuses are: ${allowedStatusValues.join(', ')}`,
           });
         }
       });
@@ -150,19 +150,19 @@ const validateConfigObject = function(configObject, chalk) {
   //   and set all missing statuses to their default value
   if (validObject) {
     const requiredSpecs = allowedSpecs;
-    requiredSpecs.forEach(spec => {
+    requiredSpecs.forEach((spec) => {
       if (!userSpecs.includes(spec)) {
         configObject[spec] = {};
       }
       const requiredCategories = Object.keys(defaultObject[spec]);
       const userCategories = Object.keys(configObject[spec]);
-      requiredCategories.forEach(category => {
+      requiredCategories.forEach((category) => {
         if (!userCategories.includes(category)) {
           configObject[spec][category] = {};
         }
         const requiredRules = Object.keys(defaultObject[spec][category]);
         const userRules = Object.keys(configObject[spec][category]);
-        requiredRules.forEach(rule => {
+        requiredRules.forEach((rule) => {
           if (!userRules.includes(rule)) {
             configObject[spec][category][rule] =
               defaultObject[spec][category][rule];
@@ -181,7 +181,11 @@ const validateConfigObject = function(configObject, chalk) {
   return configObject;
 };
 
-const getConfigObject = async function(defaultMode, chalk, configFileOverride) {
+const getConfigObject = async function (
+  defaultMode,
+  chalk,
+  configFileOverride
+) {
   let configObject;
 
   const findUpOpts = {};
@@ -241,7 +245,7 @@ const getConfigObject = async function(defaultMode, chalk, configFileOverride) {
   return configObject;
 };
 
-const getFilesToIgnore = async function() {
+const getFilesToIgnore = async function () {
   // search up the file system for the first instance
   // of the ignore file
   const ignoreFile = await findUp('.validateignore');
@@ -261,12 +265,12 @@ const getFilesToIgnore = async function() {
     // also, ignore any blank lines
     const globsToIgnore = fileAsString
       .split('\n')
-      .filter(line => line.trim().length !== 0)
-      .map(glob => pathToFile + glob);
+      .filter((line) => line.trim().length !== 0)
+      .map((glob) => pathToFile + glob);
 
     filesToIgnore = await globby(globsToIgnore, {
       expandDirectories: true,
-      dot: true
+      dot: true,
     });
   } catch (err) {
     filesToIgnore = [];
@@ -275,11 +279,11 @@ const getFilesToIgnore = async function() {
   return filesToIgnore;
 };
 
-const validateLimits = function(limitsObject, chalk) {
+const validateLimits = function (limitsObject, chalk) {
   const allowedLimits = ['warnings'];
   const limitErrors = [];
 
-  Object.keys(limitsObject).forEach(function(key) {
+  Object.keys(limitsObject).forEach(function (key) {
     if (!allowedLimits.includes(key)) {
       // remove the entry and notify the user
       delete limitsObject[key];
@@ -287,7 +291,7 @@ const validateLimits = function(limitsObject, chalk) {
         message: `"${key}" limit not supported. This value will be ignored.`,
         correction: `Valid limits for .thresholdrc are: ${allowedLimits.join(
           ', '
-        )}.`
+        )}.`,
       });
     } else {
       // valid limit option, ensure the limit given is a number
@@ -296,7 +300,7 @@ const validateLimits = function(limitsObject, chalk) {
         delete limitsObject[key];
         limitErrors.push({
           message: `Value provided for ${key} limit is invalid.`,
-          correction: `${key} limit should be a number.`
+          correction: `${key} limit should be a number.`,
         });
       }
     }
@@ -317,7 +321,7 @@ const validateLimits = function(limitsObject, chalk) {
   return limitsObject;
 };
 
-const getLimits = async function(chalk, limitsFileOverride) {
+const getLimits = async function (chalk, limitsFileOverride) {
   let limitsObject = {};
 
   const findUpOpts = {};
@@ -354,11 +358,11 @@ const getLimits = async function(chalk, limitsFileOverride) {
   return limitsObject;
 };
 
-const validateConfigOption = function(userOption, defaultOption) {
+const validateConfigOption = function (userOption, defaultOption) {
   const result = { valid: true };
   // determine what type of option it is
   let optionType;
-  Object.keys(configOptions).forEach(option => {
+  Object.keys(configOptions).forEach((option) => {
     if (configOptions[option].includes(defaultOption)) {
       optionType = option;
     }
@@ -377,12 +381,15 @@ const validateConfigOption = function(userOption, defaultOption) {
   return result;
 };
 
-const getSpectralRuleset = async function(rulesetFileOverride, defaultRuleset) {
+const getSpectralRuleset = async function (
+  rulesetFileOverride,
+  defaultRuleset
+) {
   // List of ruleset files to search for
   const ruleSetFilesToFind = [
     '.spectral.yaml',
     '.spectral.yml',
-    '.spectral.json'
+    '.spectral.json',
   ];
   if (rulesetFileOverride) {
     ruleSetFilesToFind.splice(0, 0, rulesetFileOverride);

--- a/src/cli-validator/utils/updateNotifier.js
+++ b/src/cli-validator/utils/updateNotifier.js
@@ -7,7 +7,7 @@ const twoDays = 1000 * 60 * 60 * 24 * 2;
 const notifier = updateNotifier({
   pkg,
   shouldNotifyInNpmScript: true,
-  updateCheckInterval: twoDays
+  updateCheckInterval: twoDays,
 });
 
 notifier.notify();

--- a/src/cli-validator/utils/validator.js
+++ b/src/cli-validator/utils/validator.js
@@ -22,12 +22,12 @@ const circularRefsValidator = require('./circular-references-ibm');
 const spectralValidator = require('../../spectral/utils/spectral-validator');
 
 const validators = {
-  '2': {
-    semanticValidators: semanticValidators2
+  2: {
+    semanticValidators: semanticValidators2,
   },
-  '3': {
-    semanticValidators: semanticValidators3
-  }
+  3: {
+    semanticValidators: semanticValidators3,
+  },
 };
 
 // this function runs the validators on the swagger object
@@ -48,7 +48,7 @@ module.exports = function validateSwagger(
     error: false,
     warning: false,
     info: false,
-    hint: false
+    hint: false,
   };
 
   // use version specific and shared validations
@@ -95,7 +95,7 @@ module.exports = function validateSwagger(
 
   // run semantic validators
 
-  Object.keys(semanticValidators).forEach(key => {
+  Object.keys(semanticValidators).forEach((key) => {
     const problem = semanticValidators[key].validate(allSpecs, config);
     if (problem.errors.length) {
       validationResults.errors[key] = [...problem.errors];
@@ -115,7 +115,7 @@ module.exports = function validateSwagger(
     }
   });
 
-  Object.keys(sharedSemanticValidators).forEach(key => {
+  Object.keys(sharedSemanticValidators).forEach((key) => {
     const problem = sharedSemanticValidators[key].validate(allSpecs, config);
     if (problem.errors.length) {
       validationResults.errors[key] = [].concat(
@@ -155,9 +155,9 @@ module.exports = function validateSwagger(
   if (structuralKeys.length) {
     validationResults.error = true;
     validationResults.errors['structural-validator'] = structuralKeys.map(
-      key => ({
+      (key) => ({
         message: `Schema error: ${structuralResults[key].message}`,
-        path: structuralResults[key].path
+        path: structuralResults[key].path,
       })
     );
   }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,14 +7,14 @@ const spectralValidator = require('../spectral/utils/spectral-validator');
 const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 
-module.exports = async function(input, defaultMode = false) {
+module.exports = async function (input, defaultMode = false) {
   // process the config file for the validations &
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset
   let configObject;
   let spectralResults;
   const spectral = new Spectral({
-    computeFingerprint: dedupFunction
+    computeFingerprint: dedupFunction,
   });
 
   try {

--- a/src/path-translator.js
+++ b/src/path-translator.js
@@ -1,6 +1,6 @@
 const get = require('lodash/get');
 
-module.exports.transformPathToArray = function(property, jsSpec) {
+module.exports.transformPathToArray = function (property, jsSpec) {
   const str =
     property.slice(0, 9) === 'instance.' ? property.slice(9) : property;
 
@@ -8,7 +8,7 @@ module.exports.transformPathToArray = function(property, jsSpec) {
 
   str
     .split('.')
-    .map(item => {
+    .map((item) => {
       // 'key[0]' becomes ['key', '0']
       if (item.includes('[')) {
         const index = parseInt(item.match(/\[(.*)\]/)[1]);
@@ -18,7 +18,7 @@ module.exports.transformPathToArray = function(property, jsSpec) {
         return item;
       }
     })
-    .reduce(function(a, b) {
+    .reduce(function (a, b) {
       // flatten!
       return a.concat(b);
     }, [])

--- a/src/plugins/ast/ast.js
+++ b/src/plugins/ast/ast.js
@@ -9,7 +9,7 @@ const cachedCompose = memoize(YAML.compose); // TODO: build a custom cache based
 const MAP_TAG = 'tag:yaml.org,2002:map';
 const SEQ_TAG = 'tag:yaml.org,2002:seq';
 
-const getLineNumberForPath = function(yaml, path) {
+const getLineNumberForPath = function (yaml, path) {
   // Type check
   if (typeof yaml !== 'string') {
     throw new TypeError('yaml should be a string');
@@ -51,7 +51,7 @@ const getLineNumberForPath = function(yaml, path) {
           let nextVal;
           if (value.value.length === 1 && index !== 0 && !!index) {
             nextVal = lodashFind(value.value[0], {
-              value: index.toString()
+              value: index.toString(),
             });
           } else {
             nextVal = value.value[index];
@@ -87,7 +87,7 @@ const getLineNumberForPath = function(yaml, path) {
  * component of path is an item of the array intead of beinf seperated with
  * slash(/) in a string
  */
-const positionRangeForPath = function(yaml, path) {
+const positionRangeForPath = function (yaml, path) {
   // Type check
   if (typeof yaml !== 'string') {
     throw new TypeError('yaml should be a string');
@@ -98,7 +98,7 @@ const positionRangeForPath = function(yaml, path) {
 
   const invalidRange = {
     start: { line: -1, column: -1 },
-    end: { line: -1, column: -1 }
+    end: { line: -1, column: -1 },
   };
   let i = 0;
 
@@ -140,12 +140,12 @@ const positionRangeForPath = function(yaml, path) {
       /* jshint camelcase: false */
       start: {
         line: current.start_mark.line,
-        column: current.start_mark.column
+        column: current.start_mark.column,
       },
       end: {
         line: current.end_mark.line,
-        column: current.end_mark.column
-      }
+        column: current.end_mark.column,
+      },
     };
   }
 };
@@ -158,7 +158,7 @@ const positionRangeForPath = function(yaml, path) {
  * position in the YAML or JSON string with `line` and `column` properties.
  * `line` and `column` number are zero indexed
  */
-const pathForPosition = function(yaml, position) {
+const pathForPosition = function (yaml, position) {
   // Type check
   if (typeof yaml !== 'string') {
     throw new TypeError('yaml should be a string');
@@ -295,7 +295,7 @@ module.exports.getLineNumberForPathAsync = promisifySyncFn(
 );
 
 function promisifySyncFn(fn) {
-  return function(...args) {
-    return new Promise(resolve => resolve(fn(...args)));
+  return function (...args) {
+    return new Promise((resolve) => resolve(fn(...args)));
   };
 }

--- a/src/plugins/utils/findOctetSequencePaths.js
+++ b/src/plugins/utils/findOctetSequencePaths.js
@@ -46,7 +46,7 @@ function arrayOctetSequences(resolvedSchema, path) {
     } catch (err) {
       if (err instanceof TypeError) {
         const escapedPaths = [];
-        const strEscaper = function(strToEscape) {
+        const strEscaper = function (strToEscape) {
           let newStr = '';
           for (let i = 0; i < strToEscape.length; i++) {
             if (strToEscape.charAt(i) == '/') {
@@ -78,7 +78,7 @@ function objectOctetSequences(resolvedSchema, path) {
   const objectPathsToOctetSequence = [];
   const objectProperties = resolvedSchema.properties;
   if (objectProperties) {
-    Object.keys(objectProperties).forEach(function(prop) {
+    Object.keys(objectProperties).forEach(function (prop) {
       const propPath = Array.isArray(path)
         ? path.concat(['properties', prop])
         : `${path}.properties.${prop}`;

--- a/src/plugins/utils/is-response.js
+++ b/src/plugins/utils/is-response.js
@@ -7,7 +7,7 @@ module.exports = (path, isOAS3 = true) => {
     'options',
     'head',
     'patch',
-    'trace'
+    'trace',
   ];
 
   const pathLength = path.length;

--- a/src/plugins/utils/isParameter.js
+++ b/src/plugins/utils/isParameter.js
@@ -8,7 +8,7 @@ module.exports = (path, isOAS3) => {
     'head',
     'patch',
     'trace',
-    'components'
+    'components',
   ];
 
   const inParametersSection = path[path.length - 2] === 'parameters';

--- a/src/plugins/utils/isPrimitiveType.js
+++ b/src/plugins/utils/isPrimitiveType.js
@@ -1,5 +1,5 @@
 // takes a schema object that has a 'type' field
-module.exports = function(schema) {
+module.exports = function (schema) {
   return (
     schema.type &&
     ['boolean', 'integer', 'number', 'string'].includes(schema.type)

--- a/src/plugins/utils/messageCarrier.js
+++ b/src/plugins/utils/messageCarrier.js
@@ -6,7 +6,7 @@ module.exports = class MessageCarrier {
       error: [],
       warning: [],
       info: [],
-      hint: []
+      hint: [],
     };
   }
 
@@ -37,7 +37,7 @@ module.exports = class MessageCarrier {
       this._messages[status].push({
         path,
         message,
-        rule
+        rule,
       });
     }
   }
@@ -50,7 +50,7 @@ module.exports = class MessageCarrier {
         path,
         message,
         authId,
-        rule
+        rule,
       });
     }
   }

--- a/src/plugins/utils/walk.js
+++ b/src/plugins/utils/walk.js
@@ -1,4 +1,4 @@
-const walk = function(obj, path, validation) {
+const walk = function (obj, path, validation) {
   if (typeof obj !== 'object' || obj === null) {
     return;
   }
@@ -19,7 +19,7 @@ const walk = function(obj, path, validation) {
   // recursively walk through the spec
   const childProperties = Object.keys(obj);
   if (childProperties.length) {
-    return childProperties.map(key => {
+    return childProperties.map((key) => {
       return walk(obj[key], [...path, key], validation);
     });
   } else {

--- a/src/plugins/validation/2and3/semantic-validators/info.js
+++ b/src/plugins/validation/2and3/semantic-validators/info.js
@@ -7,7 +7,7 @@
 const isPlainObject = require('lodash/isPlainObject');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec }) {
+module.exports.validate = function ({ jsSpec }) {
   const messages = new MessageCarrier();
 
   const info = jsSpec.info;

--- a/src/plugins/validation/2and3/semantic-validators/items-required-for-array-objects.js
+++ b/src/plugins/validation/2and3/semantic-validators/items-required-for-array-objects.js
@@ -13,7 +13,7 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 const at = require('lodash/at');
 const isPlainObject = require('lodash/isPlainObject');
 
-const reduceObj = function(jsSpec, obj) {
+const reduceObj = function (jsSpec, obj) {
   if (obj['$ref']) {
     const objPath = obj['$ref'].split('/');
     objPath.shift();
@@ -22,14 +22,14 @@ const reduceObj = function(jsSpec, obj) {
   return obj;
 };
 
-const checkReqProp = function(jsSpec, obj, requiredProp) {
+const checkReqProp = function (jsSpec, obj, requiredProp) {
   obj = reduceObj(jsSpec, obj);
   if (obj.properties && obj.properties[requiredProp]) {
     return true;
   } else if (Array.isArray(obj.anyOf) || Array.isArray(obj.oneOf)) {
     const childList = obj.anyOf || obj.oneOf;
     let reqPropDefined = true;
-    childList.forEach(childObj => {
+    childList.forEach((childObj) => {
       if (!checkReqProp(jsSpec, childObj, requiredProp)) {
         reqPropDefined = false;
       }
@@ -37,7 +37,7 @@ const checkReqProp = function(jsSpec, obj, requiredProp) {
     return reqPropDefined;
   } else if (Array.isArray(obj.allOf)) {
     let reqPropDefined = false;
-    obj.allOf.forEach(childObj => {
+    obj.allOf.forEach((childObj) => {
       if (checkReqProp(jsSpec, childObj, requiredProp)) {
         reqPropDefined = true;
       }
@@ -47,10 +47,10 @@ const checkReqProp = function(jsSpec, obj, requiredProp) {
   return false;
 };
 
-module.exports.validate = function({ jsSpec }, config) {
+module.exports.validate = function ({ jsSpec }, config) {
   const messages = new MessageCarrier();
 
-  walk(jsSpec, [], function(obj, path) {
+  walk(jsSpec, [], function (obj, path) {
     // `definitions` for Swagger 2, `schemas` for OAS 3
     // `properties` applies to both
     const modelLocations = ['definitions', 'schemas', 'properties'];

--- a/src/plugins/validation/2and3/semantic-validators/operation-ids.js
+++ b/src/plugins/validation/2and3/semantic-validators/operation-ids.js
@@ -8,7 +8,7 @@ const merge = require('lodash/merge');
 const each = require('lodash/each');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }, config) {
+module.exports.validate = function ({ resolvedSpec }, config) {
   const messages = new MessageCarrier();
 
   config = config.operations;
@@ -21,7 +21,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     'patch',
     'delete',
     'options',
-    'trace'
+    'trace',
   ];
 
   const operations = reduce(
@@ -38,7 +38,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
               pathKey: `${pathKey}`,
               opKey: `${opKey}`,
               path: `paths.${pathKey}.${opKey}`,
-              allPathOperations
+              allPathOperations,
             },
             op
           )
@@ -98,15 +98,15 @@ module.exports.validate = function({ resolvedSpec }, config) {
 
     if (verbs.length > 0) {
       const checkPassed = verbs
-        .map(verb => operationId.startsWith(verb))
-        .some(v => v);
+        .map((verb) => operationId.startsWith(verb))
+        .some((v) => v);
       return { checkPassed, verbs };
     }
 
     return { checkPassed: true };
   };
 
-  operations.forEach(op => {
+  operations.forEach((op) => {
     // wrap in an if, since operationIds are not required
     if (op.operationId) {
       // Assertation 2: OperationId must conform to naming conventions
@@ -120,7 +120,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         ? Object.keys(resolvedSpec.paths).includes(
             op.pathKey.replace('/\\{[A-Za-z0-9-_]+\\}$', '')
           )
-        : Object.keys(resolvedSpec.paths).some(p =>
+        : Object.keys(resolvedSpec.paths).some((p) =>
             p.startsWith(op.pathKey + '/{')
           );
 

--- a/src/plugins/validation/2and3/semantic-validators/operations-shared.js
+++ b/src/plugins/validation/2and3/semantic-validators/operations-shared.js
@@ -20,7 +20,7 @@ const each = require('lodash/each');
 const { checkCase, hasRefProperty } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
+module.exports.validate = function ({ jsSpec, resolvedSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
 
   config = config.operations;
@@ -42,7 +42,7 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
       'patch',
       'delete',
       'options',
-      'trace'
+      'trace',
     ]);
 
     each(pathOps, (op, opKey) => {
@@ -176,7 +176,7 @@ module.exports.validate = function({ jsSpec, resolvedSpec, isOAS3 }, config) {
     });
   });
 
-  unusedTags.forEach(tagName => {
+  unusedTags.forEach((tagName) => {
     messages.addMessage(
       `tags`,
       `A tag is defined but never used: ${tagName}`,

--- a/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
@@ -11,12 +11,12 @@
 const { checkCase, isParameterObject, walk } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec, isOAS3 }, config) {
+module.exports.validate = function ({ jsSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
 
   config = config.parameters;
 
-  walk(jsSpec, [], function(obj, path) {
+  walk(jsSpec, [], function (obj, path) {
     // skip parameters within operations that are excluded
     if (obj['x-sdk-exclude'] === true) {
       return;
@@ -51,8 +51,8 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
             !obj.name ||
             obj.name
               .split('.')
-              .map(s => checkCase(s, caseConvention))
-              .every(v => v);
+              .map((s) => checkCase(s, caseConvention))
+              .every((v) => v);
 
           if (!isCorrectCase) {
             messages.addMessage(

--- a/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
@@ -23,17 +23,17 @@ const allowedOperations = [
   'options',
   'head',
   'patch',
-  'trace'
+  'trace',
 ];
 
-module.exports.validate = function({ resolvedSpec }, config) {
+module.exports.validate = function ({ resolvedSpec }, config) {
   const messages = new MessageCarrier();
 
   config = config.paths;
 
   const pathNames = Object.keys(resolvedSpec.paths);
 
-  pathNames.forEach(pathName => {
+  pathNames.forEach((pathName) => {
     // get all path parameters contained in curly brackets
     const regex = /\{(.*?)\}/g;
     let parameters = pathName.match(regex);
@@ -42,12 +42,12 @@ module.exports.validate = function({ resolvedSpec }, config) {
     if (parameters) {
       // parameter strings will still have curly braces around them
       //   from regex match - take them out
-      parameters = parameters.map(param => {
+      parameters = parameters.map((param) => {
         return param.slice(1, -1);
       });
 
       const path = resolvedSpec.paths[pathName];
-      const operations = Object.keys(path).filter(pathItem =>
+      const operations = Object.keys(path).filter((pathItem) =>
         allowedOperations.includes(pathItem)
       );
 
@@ -55,11 +55,11 @@ module.exports.validate = function({ resolvedSpec }, config) {
       let globalParameters = [];
       if (path.parameters) {
         globalParameters = path.parameters
-          .filter(param => param.in.toLowerCase() === 'path')
-          .map(param => param.name);
+          .filter((param) => param.in.toLowerCase() === 'path')
+          .map((param) => param.name);
       }
 
-      operations.forEach(opName => {
+      operations.forEach((opName) => {
         const operation = path[opName];
 
         // ignore validating excluded operations
@@ -71,14 +71,14 @@ module.exports.validate = function({ resolvedSpec }, config) {
         let givenParameters = [];
         if (operation.parameters) {
           givenParameters = operation.parameters
-            .filter(param => param.in && param.in.toLowerCase() === 'path')
-            .map(param => param.name);
+            .filter((param) => param.in && param.in.toLowerCase() === 'path')
+            .map((param) => param.name);
         }
 
         let accountsForAllParameters = true;
         const missingParameters = [];
 
-        parameters.forEach(name => {
+        parameters.forEach((name) => {
           if (
             !givenParameters.includes(name) &&
             !globalParameters.includes(name)
@@ -91,7 +91,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         if (!accountsForAllParameters) {
           const checkStatus = config.missing_path_parameter;
           if (checkStatus != 'off') {
-            missingParameters.forEach(name => {
+            missingParameters.forEach((name) => {
               messages.addMessage(
                 ['paths', pathName, opName, 'parameters'],
                 `Operation must include a path parameter with name: ${name}.`,
@@ -106,7 +106,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       if (!operations.length) {
         let accountsForAllParameters = true;
         const missingParameters = [];
-        parameters.forEach(name => {
+        parameters.forEach((name) => {
           if (!globalParameters.includes(name)) {
             accountsForAllParameters = false;
             missingParameters.push(name);
@@ -115,7 +115,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         if (!accountsForAllParameters) {
           const checkStatus = config.missing_path_parameter;
           if (checkStatus != 'off') {
-            missingParameters.forEach(name => {
+            missingParameters.forEach((name) => {
               messages.addMessage(
                 ['paths', pathName],
                 `Path parameter must be defined at the path or the operation level: ${name}.`,
@@ -133,24 +133,24 @@ module.exports.validate = function({ resolvedSpec }, config) {
     if (parameters) {
       const pathObj = resolvedSpec.paths[pathName];
       const operationKeys = Object.keys(pathObj).filter(
-        op => allowedOperations.indexOf(op) > -1
+        (op) => allowedOperations.indexOf(op) > -1
       );
       if (operationKeys.length > 1) {
-        parameters.forEach(parameter => {
+        parameters.forEach((parameter) => {
           const operationPathParams = uniqWith(
             flatten(
-              operationKeys.map(op => pathObj[op].parameters).filter(Boolean)
-            ).filter(p => p.name === parameter),
+              operationKeys.map((op) => pathObj[op].parameters).filter(Boolean)
+            ).filter((p) => p.name === parameter),
             isEqual
           );
           if (operationPathParams.length === 1) {
             // All definitions of this path param are the same in the operations
             const checkStatus = config.duplicate_path_parameter || 'off';
             if (checkStatus.match('error|warning')) {
-              operationKeys.forEach(op => {
+              operationKeys.forEach((op) => {
                 if (!pathObj[op].parameters) return;
                 const index = pathObj[op].parameters.findIndex(
-                  p => p.name === parameter
+                  (p) => p.name === parameter
                 );
                 messages.addMessage(
                   ['paths', pathName, op, 'parameters', `${index}`],
@@ -169,7 +169,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     const checkStatus = config.snake_case_only;
     if (checkStatus != 'off') {
       const segments = pathName.split('/');
-      segments.forEach(segment => {
+      segments.forEach((segment) => {
         // the first element will be "" since pathName starts with "/"
         // also, ignore validating the path parameters
         if (segment === '' || segment[0] === '{') {
@@ -193,7 +193,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
         if (checkStatusPath !== 'off') {
           const caseConvention = config.paths_case_convention[1];
           const segments = pathName.split('/');
-          segments.forEach(segment => {
+          segments.forEach((segment) => {
             // the first element will be "" since pathName starts with "/"
             // also, ignore validating the path parameters
             if (segment === '' || segment[0] === '{') {

--- a/src/plugins/validation/2and3/semantic-validators/paths.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths.js
@@ -21,12 +21,12 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 
 const templateRegex = /\{(.*?)\}/g;
 
-module.exports.validate = function({ resolvedSpec }) {
+module.exports.validate = function ({ resolvedSpec }) {
   const messages = new MessageCarrier();
 
   const seenRealPaths = {};
 
-  const tallyRealPath = path => {
+  const tallyRealPath = (path) => {
     // ~~ is a flag for a removed template string
     const realPath = path.replace(templateRegex, '~~');
     const prev = seenRealPaths[realPath];
@@ -82,7 +82,7 @@ module.exports.validate = function({ resolvedSpec }) {
     each(parametersFromPath, (parameterDefinition, i) => {
       const nameAndInComboIndex = findIndex(parametersFromPath, {
         name: parameterDefinition.name,
-        in: parameterDefinition.in
+        in: parameterDefinition.in,
       });
       // comparing the current index against the first found index is good, because
       // it cuts down on error quantity when only two parameters are involved,
@@ -99,7 +99,7 @@ module.exports.validate = function({ resolvedSpec }) {
     });
 
     let pathTemplates = pathName.match(templateRegex) || [];
-    pathTemplates = pathTemplates.map(str =>
+    pathTemplates = pathTemplates.map((str) =>
       str.replace('{', '').replace('}', '')
     );
 
@@ -112,16 +112,14 @@ module.exports.validate = function({ resolvedSpec }) {
       ) {
         messages.addMessage(
           parameterDefinition.$$path || `paths.${pathName}.parameters[${i}]`,
-          `Path parameter was defined but never used: ${
-            parameterDefinition.name
-          }`,
+          `Path parameter was defined but never used: ${parameterDefinition.name}`,
           'error'
         );
       }
     });
 
     if (pathTemplates) {
-      pathTemplates.forEach(parameter => {
+      pathTemplates.forEach((parameter) => {
         // Assertation 2
 
         if (parameter === '') {
@@ -139,9 +137,7 @@ module.exports.validate = function({ resolvedSpec }) {
         if (parameterDefinition.in === 'path') {
           messages.addMessage(
             `paths.${pathName}.parameters[${i}]`,
-            `Path parameter was defined but never used: ${
-              parameterDefinition.name
-            }`,
+            `Path parameter was defined but never used: ${parameterDefinition.name}`,
             'error'
           );
         }

--- a/src/plugins/validation/2and3/semantic-validators/refs.js
+++ b/src/plugins/validation/2and3/semantic-validators/refs.js
@@ -7,7 +7,7 @@ const startsWith = require('lodash/startsWith');
 const each = require('lodash/each');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec, specStr, isOAS3 }) {
+module.exports.validate = function ({ jsSpec, specStr, isOAS3 }) {
   const messages = new MessageCarrier();
 
   if (isOAS3 && !jsSpec.components) {
@@ -26,7 +26,7 @@ module.exports.validate = function({ jsSpec, specStr, isOAS3 }) {
 
   const definitionSectionName = isOAS3 ? 'components' : 'definitions';
   // de-dupe the array, and filter out non-definition refs
-  const definitionsRefs = filter(uniq(refs), v =>
+  const definitionsRefs = filter(uniq(refs), (v) =>
     startsWith(v, `#/${definitionSectionName}`)
   );
 
@@ -42,9 +42,9 @@ module.exports.validate = function({ jsSpec, specStr, isOAS3 }) {
       'requestBodies',
       'headers',
       'links',
-      'callbacks'
+      'callbacks',
     ];
-    definitionTypeList.forEach(function(definitionType) {
+    definitionTypeList.forEach(function (definitionType) {
       if (jsSpec.components && jsSpec.components[definitionType]) {
         recordDefinitionsNotUsed(
           jsSpec.components[definitionType],

--- a/src/plugins/validation/2and3/semantic-validators/responses.js
+++ b/src/plugins/validation/2and3/semantic-validators/responses.js
@@ -15,12 +15,12 @@ function arrayItemsAreRefOrPrimitive(schema) {
   );
 }
 
-module.exports.validate = function({ jsSpec, isOAS3 }, config) {
+module.exports.validate = function ({ jsSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
 
   config = config.responses;
 
-  walk(jsSpec, [], function(obj, path) {
+  walk(jsSpec, [], function (obj, path) {
     const isRef = !!obj.$ref;
 
     if (isResponseObject(path, isOAS3) && !isRef) {
@@ -39,7 +39,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                 mediaType.schema.oneOf;
 
               if (hasCombinedSchema) {
-                combinedSchemaTypes.forEach(schemaType => {
+                combinedSchemaTypes.forEach((schemaType) => {
                   if (mediaType.schema[schemaType]) {
                     for (
                       let i = 0;
@@ -60,7 +60,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
                             mediaTypeKey,
                             'schema',
                             schemaType,
-                            i
+                            i,
                           ],
                           INLINE_SCHEMA_MESSAGE,
                           config.inline_response_schema,

--- a/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -22,14 +22,14 @@ const includes = require('lodash/includes');
 const { checkCase, walk } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec, isOAS3 }, config) {
+module.exports.validate = function ({ jsSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
 
   config = config.schemas;
 
   const schemas = [];
 
-  walk(jsSpec, [], function(obj, path) {
+  walk(jsSpec, [], function (obj, path) {
     const current = path[path.length - 1];
 
     /*
@@ -54,7 +54,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       'definitions',
       'schemas',
       'properties',
-      'parameters'
+      'parameters',
     ];
     if (
       current === 'schema' ||
@@ -216,7 +216,7 @@ function typeFormatErrors(obj, path, isOAS3, messages, checkStatus) {
     'binary',
     'date',
     'date-time',
-    'password'
+    'password',
   ];
   const validTypes = [
     'integer',
@@ -224,7 +224,7 @@ function typeFormatErrors(obj, path, isOAS3, messages, checkStatus) {
     'string',
     'boolean',
     'object',
-    'array'
+    'array',
   ];
   if (!isOAS3) {
     validTypes.push('file');
@@ -634,7 +634,7 @@ function checkProperties(
           propertiesToCompare[key] = {
             type: value.type,
             path: contextPath.concat(['properties', key]).join('.'),
-            printed: false
+            printed: false,
           };
         }
       }

--- a/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/security-definitions-ibm.js
@@ -5,7 +5,7 @@
 const each = require('lodash/each');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
+module.exports.validate = function ({ resolvedSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
 
   config = config.security_definitions;
@@ -32,7 +32,7 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
         if (scheme.flows) {
           each(scheme.flows, (flow, flowType) => {
             if (flow.scopes) {
-              Object.keys(flow.scopes).forEach(scope => {
+              Object.keys(flow.scopes).forEach((scope) => {
                 definedScopes[scope] = {};
                 definedScopes[scope].used = false;
                 definedScopes[scope].scheme = name;
@@ -42,7 +42,7 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
           });
         }
       } else if (scheme.scopes) {
-        Object.keys(scheme.scopes).forEach(scope => {
+        Object.keys(scheme.scopes).forEach((scope) => {
           definedScopes[scope] = {};
           definedScopes[scope].used = false;
           definedScopes[scope].scheme = name;
@@ -72,10 +72,10 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
   });
 
   function flagUsedDefinitions(security) {
-    security.forEach(scheme => {
+    security.forEach((scheme) => {
       const schemeNames = Object.keys(scheme);
 
-      schemeNames.forEach(schemeName => {
+      schemeNames.forEach((schemeName) => {
         // make sure this scheme was in the security definitions, then label as used
         if (definedSchemes[schemeName]) {
           definedSchemes[schemeName].used = true;
@@ -84,7 +84,7 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
           const scopesArray = scheme[schemeName];
 
           if (type.toLowerCase() === 'oauth2') {
-            scopesArray.forEach(scope => {
+            scopesArray.forEach((scope) => {
               if (definedScopes[scope]) {
                 definedScopes[scope].used = true;
               }
@@ -113,9 +113,7 @@ module.exports.validate = function({ resolvedSpec, isOAS3 }, config) {
   each(definedScopes, (info, name) => {
     if (info.used === false) {
       const path = isOAS3
-        ? `components.securitySchemes.${info.scheme}.flows.${
-            info.flow
-          }.scopes.${name}`
+        ? `components.securitySchemes.${info.scheme}.flows.${info.flow}.scopes.${name}`
         : `securityDefinitions.${info.scheme}.scopes.${name}`;
       messages.addMessage(
         path,

--- a/src/plugins/validation/2and3/semantic-validators/security-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/security-ibm.js
@@ -13,7 +13,7 @@
 const each = require('lodash/each');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec, isOAS3 }, config) {
+module.exports.validate = function ({ jsSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
 
   config = config.security;
@@ -27,7 +27,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
   if (jsSpec.security) {
     securityObjects.push({
       security: jsSpec.security,
-      path: 'security'
+      path: 'security',
     });
   }
 
@@ -40,7 +40,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
       if (operation.security) {
         securityObjects.push({
           security: operation.security,
-          path: `paths.${pathName}.${opName}.security`
+          path: `paths.${pathName}.${opName}.security`,
         });
       }
     });
@@ -51,16 +51,16 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
     : jsSpec.securityDefinitions;
 
   if (securityObjects.length) {
-    securityObjects.forEach(obj => {
+    securityObjects.forEach((obj) => {
       validateSecurityObject(obj);
     });
   }
 
   function validateSecurityObject({ security, path }) {
-    security.forEach(schemeObject => {
+    security.forEach((schemeObject) => {
       const schemeNames = Object.keys(schemeObject);
 
-      schemeNames.forEach(schemeName => {
+      schemeNames.forEach((schemeName) => {
         const schemeIsDefined =
           securityDefinitions && securityDefinitions[schemeName];
 
@@ -130,7 +130,7 @@ function checkSwagger2Scopes(scope, definition) {
 function checkOAS3Scopes(scope, definition) {
   let scopeIsDefined = false;
   if (definition.flows) {
-    Object.keys(definition.flows).forEach(flowType => {
+    Object.keys(definition.flows).forEach((flowType) => {
       if (
         definition.flows[flowType].scopes &&
         definition.flows[flowType].scopes[scope]

--- a/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
@@ -9,12 +9,12 @@ const { walk } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
 // Walks an entire spec.
-module.exports.validate = function({ jsSpec, resolvedSpec }, config) {
+module.exports.validate = function ({ jsSpec, resolvedSpec }, config) {
   const messages = new MessageCarrier();
 
   config = config.walker;
 
-  walk(jsSpec, [], function(obj, path) {
+  walk(jsSpec, [], function (obj, path) {
     // check for empty descriptions
     if (obj.description !== undefined && obj.description !== null) {
       const description = obj.description.toString();
@@ -51,7 +51,7 @@ module.exports.validate = function({ jsSpec, resolvedSpec }, config) {
     }
 
     // check for and flag null values - they are not allowed by the spec and are likely mistakes
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
       if (key !== 'default' && obj[key] === null) {
         messages.addMessage(
           [...path, key],

--- a/src/plugins/validation/2and3/semantic-validators/walker.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker.js
@@ -15,12 +15,12 @@ const match = require('matcher');
 const { walk } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec, isOAS3 }, config) {
+module.exports.validate = function ({ jsSpec, isOAS3 }, config) {
   const messages = new MessageCarrier();
 
   config = config.walker;
 
-  walk(jsSpec, [], function(obj, path) {
+  walk(jsSpec, [], function (obj, path) {
     // parent keys that allow non-string "type" properties. for example,
     // having a definition called "type" is allowed
     const allowedParents = isOAS3
@@ -31,14 +31,14 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
           'parameters',
           'requestBodies',
           'headers',
-          'securitySchemes'
+          'securitySchemes',
         ]
       : [
           'definitions',
           'properties',
           'parameters',
           'responses',
-          'securityDefinitions'
+          'securityDefinitions',
         ];
 
     ///// "type" should always have a string-type value, everywhere.
@@ -105,7 +105,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
     }
 
     const keys = Object.keys(obj);
-    keys.forEach(k => {
+    keys.forEach((k) => {
       if (keys.indexOf('$ref') > -1 && k !== '$ref') {
         messages.addMessage(
           path.concat([k]),
@@ -124,7 +124,7 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
 const unacceptableRefPatternsS2 = {
   responses: ['!*#/responses*'],
   schema: ['!*#/definitions*'],
-  parameters: ['!*#/parameters*']
+  parameters: ['!*#/parameters*'],
 };
 
 const unacceptableRefPatternsOAS3 = {
@@ -136,7 +136,7 @@ const unacceptableRefPatternsOAS3 = {
   callbacks: ['!*#/components/callbacks*'],
   examples: ['!*#/components/examples*'],
   headers: ['!*#/components/headers*'],
-  links: ['!*#/components/links*']
+  links: ['!*#/components/links*'],
 };
 
 const exceptionedParents = ['properties'];

--- a/src/plugins/validation/2and3/structural-validation/jsonSchema.js
+++ b/src/plugins/validation/2and3/structural-validation/jsonSchema.js
@@ -6,14 +6,14 @@ module.exports = {
     schemaArray: {
       type: 'array',
       minItems: 1,
-      items: { $ref: '#' }
+      items: { $ref: '#' },
     },
     positiveInteger: {
       type: 'integer',
-      minimum: 0
+      minimum: 0,
     },
     positiveIntegerDefault0: {
-      allOf: [{ $ref: '#/definitions/positiveInteger' }, { default: 0 }]
+      allOf: [{ $ref: '#/definitions/positiveInteger' }, { default: 0 }],
     },
     simpleTypes: {
       enum: [
@@ -23,104 +23,104 @@ module.exports = {
         'null',
         'number',
         'object',
-        'string'
-      ]
+        'string',
+      ],
     },
     stringArray: {
       type: 'array',
       items: { type: 'string' },
       minItems: 1,
-      uniqueItems: true
-    }
+      uniqueItems: true,
+    },
   },
   type: 'object',
   properties: {
     id: {
       type: 'string',
-      format: 'uri'
+      format: 'uri',
     },
     $schema: {
       type: 'string',
-      format: 'uri'
+      format: 'uri',
     },
     title: {
-      type: 'string'
+      type: 'string',
     },
     description: {
-      type: 'string'
+      type: 'string',
     },
     default: {},
     multipleOf: {
       type: 'number',
       minimum: 0,
-      exclusiveMinimum: true
+      exclusiveMinimum: true,
     },
     maximum: {
-      type: 'number'
+      type: 'number',
     },
     exclusiveMaximum: {
       type: 'boolean',
-      default: false
+      default: false,
     },
     minimum: {
-      type: 'number'
+      type: 'number',
     },
     exclusiveMinimum: {
       type: 'boolean',
-      default: false
+      default: false,
     },
     maxLength: { $ref: '#/definitions/positiveInteger' },
     minLength: { $ref: '#/definitions/positiveIntegerDefault0' },
     pattern: {
       type: 'string',
-      format: 'regex'
+      format: 'regex',
     },
     additionalItems: {
       anyOf: [{ type: 'boolean' }, { $ref: '#' }],
-      default: {}
+      default: {},
     },
     items: {
       anyOf: [{ $ref: '#' }, { $ref: '#/definitions/schemaArray' }],
-      default: {}
+      default: {},
     },
     maxItems: { $ref: '#/definitions/positiveInteger' },
     minItems: { $ref: '#/definitions/positiveIntegerDefault0' },
     uniqueItems: {
       type: 'boolean',
-      default: false
+      default: false,
     },
     maxProperties: { $ref: '#/definitions/positiveInteger' },
     minProperties: { $ref: '#/definitions/positiveIntegerDefault0' },
     required: { $ref: '#/definitions/stringArray' },
     additionalProperties: {
       anyOf: [{ type: 'boolean' }, { $ref: '#' }],
-      default: {}
+      default: {},
     },
     definitions: {
       type: 'object',
       additionalProperties: { $ref: '#' },
-      default: {}
+      default: {},
     },
     properties: {
       type: 'object',
       additionalProperties: { $ref: '#' },
-      default: {}
+      default: {},
     },
     patternProperties: {
       type: 'object',
       additionalProperties: { $ref: '#' },
-      default: {}
+      default: {},
     },
     dependencies: {
       type: 'object',
       additionalProperties: {
-        anyOf: [{ $ref: '#' }, { $ref: '#/definitions/stringArray' }]
-      }
+        anyOf: [{ $ref: '#' }, { $ref: '#/definitions/stringArray' }],
+      },
     },
     enum: {
       type: 'array',
       minItems: 1,
-      uniqueItems: true
+      uniqueItems: true,
     },
     type: {
       anyOf: [
@@ -129,18 +129,18 @@ module.exports = {
           type: 'array',
           items: { $ref: '#/definitions/simpleTypes' },
           minItems: 1,
-          uniqueItems: true
-        }
-      ]
+          uniqueItems: true,
+        },
+      ],
     },
     allOf: { $ref: '#/definitions/schemaArray' },
     anyOf: { $ref: '#/definitions/schemaArray' },
     oneOf: { $ref: '#/definitions/schemaArray' },
-    not: { $ref: '#' }
+    not: { $ref: '#' },
   },
   dependencies: {
     exclusiveMaximum: ['maximum'],
-    exclusiveMinimum: ['minimum']
+    exclusiveMinimum: ['minimum'],
   },
-  default: {}
+  default: {},
 };

--- a/src/plugins/validation/2and3/structural-validation/validator.js
+++ b/src/plugins/validation/2and3/structural-validation/validator.js
@@ -7,11 +7,11 @@ const { getLineNumberForPath } = require('../../../ast/ast');
 const validator = new JSONSchema.Validator();
 validator.addSchema(jsonSchema);
 
-module.exports.validate = function({ jsSpec, specStr, settings = {} }) {
-  settings.schemas.forEach(schema => validator.addSchema(schema));
+module.exports.validate = function ({ jsSpec, specStr, settings = {} }) {
+  settings.schemas.forEach((schema) => validator.addSchema(schema));
   return validator
     .validate(jsSpec, settings.testSchema || {})
-    .errors.map(err => {
+    .errors.map((err) => {
       return {
         level: 'error',
         line: getLineNumberForPath(
@@ -21,7 +21,7 @@ module.exports.validate = function({ jsSpec, specStr, settings = {} }) {
         path: err.property.replace('instance.', ''),
         message: err.message,
         source: 'schema',
-        original: err // this won't make it into state, but is still helpful
+        original: err, // this won't make it into state, but is still helpful
       };
     });
 };

--- a/src/plugins/validation/oas3/apis/oas3-schema.js
+++ b/src/plugins/validation/oas3/apis/oas3-schema.js
@@ -6,41 +6,41 @@ module.exports = {
   properties: {
     openapi: {
       type: 'string',
-      pattern: '^3\\.0\\.\\d(-.+)?$'
+      pattern: '^3\\.0\\.\\d(-.+)?$',
     },
     info: {
-      $ref: '#/definitions/Info'
+      $ref: '#/definitions/Info',
     },
     externalDocs: {
-      $ref: '#/definitions/ExternalDocumentation'
+      $ref: '#/definitions/ExternalDocumentation',
     },
     servers: {
       type: 'array',
       items: {
-        $ref: '#/definitions/Server'
-      }
+        $ref: '#/definitions/Server',
+      },
     },
     security: {
       type: 'array',
       items: {
-        $ref: '#/definitions/SecurityRequirement'
-      }
+        $ref: '#/definitions/SecurityRequirement',
+      },
     },
     tags: {
       type: 'array',
       items: {
-        $ref: '#/definitions/Tag'
-      }
+        $ref: '#/definitions/Tag',
+      },
     },
     paths: {
-      $ref: '#/definitions/Paths'
+      $ref: '#/definitions/Paths',
     },
     components: {
-      $ref: '#/definitions/Components'
-    }
+      $ref: '#/definitions/Components',
+    },
   },
   patternProperties: {
-    '^x-': {}
+    '^x-': {},
   },
   additionalProperties: false,
   definitions: {
@@ -50,97 +50,97 @@ module.exports = {
       properties: {
         $ref: {
           type: 'string',
-          format: 'uri-reference'
-        }
-      }
+          format: 'uri-reference',
+        },
+      },
     },
     Info: {
       type: 'object',
       required: ['title', 'version'],
       properties: {
         title: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         termsOfService: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         contact: {
-          $ref: '#/definitions/Contact'
+          $ref: '#/definitions/Contact',
         },
         license: {
-          $ref: '#/definitions/License'
+          $ref: '#/definitions/License',
         },
         version: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Contact: {
       type: 'object',
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         url: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         email: {
           type: 'string',
-          format: 'email'
-        }
+          format: 'email',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     License: {
       type: 'object',
       required: ['name'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         url: {
           type: 'string',
-          format: 'uri-reference'
-        }
+          format: 'uri-reference',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Server: {
       type: 'object',
       required: ['url'],
       properties: {
         url: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         variables: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/ServerVariable'
-          }
-        }
+            $ref: '#/definitions/ServerVariable',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ServerVariable: {
       type: 'object',
@@ -149,20 +149,20 @@ module.exports = {
         enum: {
           type: 'array',
           items: {
-            type: 'string'
-          }
+            type: 'string',
+          },
         },
         default: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Components: {
       type: 'object',
@@ -173,14 +173,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/Schema'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/Schema',
+                },
+              ],
+            },
+          },
         },
         responses: {
           type: 'object',
@@ -188,14 +188,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/Response'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/Response',
+                },
+              ],
+            },
+          },
         },
         parameters: {
           type: 'object',
@@ -203,14 +203,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/Parameter'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/Parameter',
+                },
+              ],
+            },
+          },
         },
         examples: {
           type: 'object',
@@ -218,14 +218,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/Example'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/Example',
+                },
+              ],
+            },
+          },
         },
         requestBodies: {
           type: 'object',
@@ -233,14 +233,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/RequestBody'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/RequestBody',
+                },
+              ],
+            },
+          },
         },
         headers: {
           type: 'object',
@@ -248,14 +248,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/Header'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/Header',
+                },
+              ],
+            },
+          },
         },
         securitySchemes: {
           type: 'object',
@@ -263,14 +263,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/SecurityScheme'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/SecurityScheme',
+                },
+              ],
+            },
+          },
         },
         links: {
           type: 'object',
@@ -278,14 +278,14 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/Link'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/Link',
+                },
+              ],
+            },
+          },
         },
         callbacks: {
           type: 'object',
@@ -293,319 +293,319 @@ module.exports = {
             '^[a-zA-Z0-9\\.\\-_]+$': {
               oneOf: [
                 {
-                  $ref: '#/definitions/Reference'
+                  $ref: '#/definitions/Reference',
                 },
                 {
-                  $ref: '#/definitions/Callback'
-                }
-              ]
-            }
-          }
-        }
+                  $ref: '#/definitions/Callback',
+                },
+              ],
+            },
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Schema: {
       type: 'object',
       properties: {
         title: {
-          type: 'string'
+          type: 'string',
         },
         multipleOf: {
           type: 'number',
           minimum: 0,
-          exclusiveMinimum: true
+          exclusiveMinimum: true,
         },
         maximum: {
-          type: 'number'
+          type: 'number',
         },
         exclusiveMaximum: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         minimum: {
-          type: 'number'
+          type: 'number',
         },
         exclusiveMinimum: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         maxLength: {
           type: 'integer',
-          minimum: 0
+          minimum: 0,
         },
         minLength: {
           type: 'integer',
           minimum: 0,
-          default: 0
+          default: 0,
         },
         pattern: {
           type: 'string',
-          format: 'regex'
+          format: 'regex',
         },
         maxItems: {
           type: 'integer',
-          minimum: 0
+          minimum: 0,
         },
         minItems: {
           type: 'integer',
           minimum: 0,
-          default: 0
+          default: 0,
         },
         uniqueItems: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         maxProperties: {
           type: 'integer',
-          minimum: 0
+          minimum: 0,
         },
         minProperties: {
           type: 'integer',
           minimum: 0,
-          default: 0
+          default: 0,
         },
         required: {
           type: 'array',
           items: {
-            type: 'string'
+            type: 'string',
           },
           minItems: 1,
-          uniqueItems: true
+          uniqueItems: true,
         },
         enum: {
           type: 'array',
           items: {},
           minItems: 1,
-          uniqueItems: true
+          uniqueItems: true,
         },
         type: {
           type: 'string',
-          enum: ['array', 'boolean', 'integer', 'number', 'object', 'string']
+          enum: ['array', 'boolean', 'integer', 'number', 'object', 'string'],
         },
         not: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         allOf: {
           type: 'array',
           items: {
             oneOf: [
               {
-                $ref: '#/definitions/Schema'
+                $ref: '#/definitions/Schema',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         oneOf: {
           type: 'array',
           items: {
             oneOf: [
               {
-                $ref: '#/definitions/Schema'
+                $ref: '#/definitions/Schema',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         anyOf: {
           type: 'array',
           items: {
             oneOf: [
               {
-                $ref: '#/definitions/Schema'
+                $ref: '#/definitions/Schema',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         items: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         properties: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Schema'
+                $ref: '#/definitions/Schema',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         additionalProperties: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
+              $ref: '#/definitions/Reference',
             },
             {
-              type: 'boolean'
-            }
+              type: 'boolean',
+            },
           ],
-          default: true
+          default: true,
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         default: {},
         nullable: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         discriminator: {
-          $ref: '#/definitions/Discriminator'
+          $ref: '#/definitions/Discriminator',
         },
         readOnly: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         writeOnly: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         example: {},
         externalDocs: {
-          $ref: '#/definitions/ExternalDocumentation'
+          $ref: '#/definitions/ExternalDocumentation',
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         xml: {
-          $ref: '#/definitions/XML'
-        }
+          $ref: '#/definitions/XML',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Discriminator: {
       type: 'object',
       required: ['propertyName'],
       properties: {
         propertyName: {
-          type: 'string'
+          type: 'string',
         },
         mapping: {
           type: 'object',
           additionalProperties: {
-            type: 'string'
-          }
-        }
-      }
+            type: 'string',
+          },
+        },
+      },
     },
     XML: {
       type: 'object',
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         namespace: {
           type: 'string',
-          format: 'url'
+          format: 'url',
         },
         prefix: {
-          type: 'string'
+          type: 'string',
         },
         attribute: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         wrapped: {
           type: 'boolean',
-          default: false
-        }
+          default: false,
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Response: {
       type: 'object',
       required: ['description'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         headers: {
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Header'
+                $ref: '#/definitions/Header',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         content: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/MediaType'
-          }
+            $ref: '#/definitions/MediaType',
+          },
         },
         links: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Link'
+                $ref: '#/definitions/Link',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
-        }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     MediaType: {
       oneOf: [
         {
-          $ref: '#/definitions/MediaTypeWithExample'
+          $ref: '#/definitions/MediaTypeWithExample',
         },
         {
-          $ref: '#/definitions/MediaTypeWithExamples'
-        }
-      ]
+          $ref: '#/definitions/MediaTypeWithExamples',
+        },
+      ],
     },
     MediaTypeWithExample: {
       type: 'object',
@@ -613,25 +613,25 @@ module.exports = {
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         example: {},
         encoding: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/Encoding'
-          }
-        }
+            $ref: '#/definitions/Encoding',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     MediaTypeWithExamples: {
       type: 'object',
@@ -640,289 +640,289 @@ module.exports = {
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         examples: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Example'
+                $ref: '#/definitions/Example',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         encoding: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/Encoding'
-          }
-        }
+            $ref: '#/definitions/Encoding',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Example: {
       type: 'object',
       properties: {
         summary: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         value: {},
         externalValue: {
           type: 'string',
-          format: 'uri-reference'
-        }
+          format: 'uri-reference',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Header: {
       oneOf: [
         {
-          $ref: '#/definitions/HeaderWithSchema'
+          $ref: '#/definitions/HeaderWithSchema',
         },
         {
-          $ref: '#/definitions/HeaderWithContent'
-        }
-      ]
+          $ref: '#/definitions/HeaderWithContent',
+        },
+      ],
     },
     HeaderWithSchema: {
       oneOf: [
         {
-          $ref: '#/definitions/HeaderWithSchemaWithExample'
+          $ref: '#/definitions/HeaderWithSchemaWithExample',
         },
         {
-          $ref: '#/definitions/HeaderWithSchemaWithExamples'
-        }
-      ]
+          $ref: '#/definitions/HeaderWithSchemaWithExamples',
+        },
+      ],
     },
     HeaderWithSchemaWithExample: {
       type: 'object',
       required: ['schema'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['simple'],
-          default: 'simple'
+          default: 'simple',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
-        example: {}
+        example: {},
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     HeaderWithSchemaWithExamples: {
       type: 'object',
       required: ['schema', 'examples'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['simple'],
-          default: 'simple'
+          default: 'simple',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         examples: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Example'
+                $ref: '#/definitions/Example',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
-        }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     HeaderWithContent: {
       type: 'object',
       required: ['content'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         content: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/MediaType'
+            $ref: '#/definitions/MediaType',
           },
           minProperties: 1,
-          maxProperties: 1
-        }
+          maxProperties: 1,
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Paths: {
       type: 'object',
       patternProperties: {
         '^\\/': {
-          $ref: '#/definitions/PathItem'
+          $ref: '#/definitions/PathItem',
         },
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     PathItem: {
       type: 'object',
       properties: {
         $ref: {
-          type: 'string'
+          type: 'string',
         },
         summary: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         get: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         put: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         post: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         delete: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         options: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         head: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         patch: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         trace: {
-          $ref: '#/definitions/Operation'
+          $ref: '#/definitions/Operation',
         },
         servers: {
           type: 'array',
           items: {
-            $ref: '#/definitions/Server'
-          }
+            $ref: '#/definitions/Server',
+          },
         },
         parameters: {
           type: 'array',
           items: {
             oneOf: [
               {
-                $ref: '#/definitions/Parameter'
+                $ref: '#/definitions/Parameter',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
-        }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Operation: {
       type: 'object',
@@ -931,81 +931,81 @@ module.exports = {
         tags: {
           type: 'array',
           items: {
-            type: 'string'
-          }
+            type: 'string',
+          },
         },
         summary: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         externalDocs: {
-          $ref: '#/definitions/ExternalDocumentation'
+          $ref: '#/definitions/ExternalDocumentation',
         },
         operationId: {
-          type: 'string'
+          type: 'string',
         },
         parameters: {
           type: 'array',
           items: {
             oneOf: [
               {
-                $ref: '#/definitions/Parameter'
+                $ref: '#/definitions/Parameter',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         requestBody: {
           oneOf: [
             {
-              $ref: '#/definitions/RequestBody'
+              $ref: '#/definitions/RequestBody',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         responses: {
-          $ref: '#/definitions/Responses'
+          $ref: '#/definitions/Responses',
         },
         callbacks: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Callback'
+                $ref: '#/definitions/Callback',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         security: {
           type: 'array',
           items: {
-            $ref: '#/definitions/SecurityRequirement'
-          }
+            $ref: '#/definitions/SecurityRequirement',
+          },
         },
         servers: {
           type: 'array',
           items: {
-            $ref: '#/definitions/Server'
-          }
-        }
+            $ref: '#/definitions/Server',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Responses: {
       type: 'object',
@@ -1013,750 +1013,750 @@ module.exports = {
         default: {
           oneOf: [
             {
-              $ref: '#/definitions/Response'
+              $ref: '#/definitions/Response',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
-        }
+              $ref: '#/definitions/Reference',
+            },
+          ],
+        },
       },
       patternProperties: {
         '[1-5](?:\\d{2}|XX)': {
           oneOf: [
             {
-              $ref: '#/definitions/Response'
+              $ref: '#/definitions/Response',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
-        '^x-': {}
+        '^x-': {},
       },
       minProperties: 1,
       additionalProperties: false,
       not: {
         type: 'object',
         patternProperties: {
-          '^x-': {}
+          '^x-': {},
         },
-        additionalProperties: false
-      }
+        additionalProperties: false,
+      },
     },
     SecurityRequirement: {
       type: 'object',
       additionalProperties: {
         type: 'array',
         items: {
-          type: 'string'
-        }
-      }
+          type: 'string',
+        },
+      },
     },
     Tag: {
       type: 'object',
       required: ['name'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         externalDocs: {
-          $ref: '#/definitions/ExternalDocumentation'
-        }
+          $ref: '#/definitions/ExternalDocumentation',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ExternalDocumentation: {
       type: 'object',
       required: ['url'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         url: {
           type: 'string',
-          format: 'uri-reference'
-        }
+          format: 'uri-reference',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Parameter: {
       oneOf: [
         {
-          $ref: '#/definitions/ParameterWithSchema'
+          $ref: '#/definitions/ParameterWithSchema',
         },
         {
-          $ref: '#/definitions/ParameterWithContent'
-        }
-      ]
+          $ref: '#/definitions/ParameterWithContent',
+        },
+      ],
     },
     ParameterWithSchema: {
       oneOf: [
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExample'
+          $ref: '#/definitions/ParameterWithSchemaWithExample',
         },
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExamples'
-        }
-      ]
+          $ref: '#/definitions/ParameterWithSchemaWithExamples',
+        },
+      ],
     },
     ParameterWithSchemaWithExample: {
       oneOf: [
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExampleInPath'
+          $ref: '#/definitions/ParameterWithSchemaWithExampleInPath',
         },
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExampleInQuery'
+          $ref: '#/definitions/ParameterWithSchemaWithExampleInQuery',
         },
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExampleInHeader'
+          $ref: '#/definitions/ParameterWithSchemaWithExampleInHeader',
         },
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExampleInCookie'
-        }
-      ]
+          $ref: '#/definitions/ParameterWithSchemaWithExampleInCookie',
+        },
+      ],
     },
     ParameterWithSchemaWithExampleInPath: {
       type: 'object',
       required: ['name', 'in', 'schema', 'required'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['path']
+          enum: ['path'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          enum: [true]
+          enum: [true],
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['matrix', 'label', 'simple'],
-          default: 'simple'
+          default: 'simple',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
-        example: {}
+        example: {},
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithSchemaWithExampleInQuery: {
       type: 'object',
       required: ['name', 'in', 'schema'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['query']
+          enum: ['query'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['form', 'spaceDelimited', 'pipeDelimited', 'deepObject'],
-          default: 'form'
+          default: 'form',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
-        example: {}
+        example: {},
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithSchemaWithExampleInHeader: {
       type: 'object',
       required: ['name', 'in', 'schema'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['header']
+          enum: ['header'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['simple'],
-          default: 'simple'
+          default: 'simple',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
-        example: {}
+        example: {},
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithSchemaWithExampleInCookie: {
       type: 'object',
       required: ['name', 'in', 'schema'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['cookie']
+          enum: ['cookie'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['form'],
-          default: 'form'
+          default: 'form',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
-        example: {}
+        example: {},
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithSchemaWithExamples: {
       oneOf: [
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExamplesInPath'
+          $ref: '#/definitions/ParameterWithSchemaWithExamplesInPath',
         },
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExamplesInQuery'
+          $ref: '#/definitions/ParameterWithSchemaWithExamplesInQuery',
         },
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExamplesInHeader'
+          $ref: '#/definitions/ParameterWithSchemaWithExamplesInHeader',
         },
         {
-          $ref: '#/definitions/ParameterWithSchemaWithExamplesInCookie'
-        }
-      ]
+          $ref: '#/definitions/ParameterWithSchemaWithExamplesInCookie',
+        },
+      ],
     },
     ParameterWithSchemaWithExamplesInPath: {
       type: 'object',
       required: ['name', 'in', 'schema', 'required', 'examples'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['path']
+          enum: ['path'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          enum: [true]
+          enum: [true],
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['matrix', 'label', 'simple'],
-          default: 'simple'
+          default: 'simple',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         examples: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Example'
+                $ref: '#/definitions/Example',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
-        }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithSchemaWithExamplesInQuery: {
       type: 'object',
       required: ['name', 'in', 'schema', 'examples'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['query']
+          enum: ['query'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['form', 'spaceDelimited', 'pipeDelimited', 'deepObject'],
-          default: 'form'
+          default: 'form',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         examples: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Example'
+                $ref: '#/definitions/Example',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
-        }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithSchemaWithExamplesInHeader: {
       type: 'object',
       required: ['name', 'in', 'schema', 'examples'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['header']
+          enum: ['header'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['simple'],
-          default: 'simple'
+          default: 'simple',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         examples: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Example'
+                $ref: '#/definitions/Example',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
-        }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithSchemaWithExamplesInCookie: {
       type: 'object',
       required: ['name', 'in', 'schema', 'examples'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['cookie']
+          enum: ['cookie'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         style: {
           type: 'string',
           enum: ['form'],
-          default: 'form'
+          default: 'form',
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/Schema'
+              $ref: '#/definitions/Schema',
             },
             {
-              $ref: '#/definitions/Reference'
-            }
-          ]
+              $ref: '#/definitions/Reference',
+            },
+          ],
         },
         examples: {
           type: 'object',
           additionalProperties: {
             oneOf: [
               {
-                $ref: '#/definitions/Example'
+                $ref: '#/definitions/Example',
               },
               {
-                $ref: '#/definitions/Reference'
-              }
-            ]
-          }
-        }
+                $ref: '#/definitions/Reference',
+              },
+            ],
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithContent: {
       oneOf: [
         {
-          $ref: '#/definitions/ParameterWithContentInPath'
+          $ref: '#/definitions/ParameterWithContentInPath',
         },
         {
-          $ref: '#/definitions/ParameterWithContentNotInPath'
-        }
-      ]
+          $ref: '#/definitions/ParameterWithContentNotInPath',
+        },
+      ],
     },
     ParameterWithContentInPath: {
       type: 'object',
       required: ['name', 'in', 'content'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['path']
+          enum: ['path'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          enum: [true]
+          enum: [true],
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         content: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/MediaType'
+            $ref: '#/definitions/MediaType',
           },
           minProperties: 1,
-          maxProperties: 1
-        }
+          maxProperties: 1,
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ParameterWithContentNotInPath: {
       type: 'object',
       required: ['name', 'in', 'content'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['query', 'header', 'cookie']
+          enum: ['query', 'header', 'cookie'],
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         required: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         allowEmptyValue: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         content: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/MediaType'
+            $ref: '#/definitions/MediaType',
           },
           minProperties: 1,
-          maxProperties: 1
-        }
+          maxProperties: 1,
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     RequestBody: {
       type: 'object',
       required: ['content'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         content: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/MediaType'
-          }
+            $ref: '#/definitions/MediaType',
+          },
         },
         required: {
           type: 'boolean',
-          default: false
-        }
+          default: false,
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     SecurityScheme: {
       oneOf: [
         {
-          $ref: '#/definitions/APIKeySecurityScheme'
+          $ref: '#/definitions/APIKeySecurityScheme',
         },
         {
-          $ref: '#/definitions/HTTPSecurityScheme'
+          $ref: '#/definitions/HTTPSecurityScheme',
         },
         {
-          $ref: '#/definitions/OAuth2SecurityScheme'
+          $ref: '#/definitions/OAuth2SecurityScheme',
         },
         {
-          $ref: '#/definitions/OpenIdConnectSecurityScheme'
-        }
-      ]
+          $ref: '#/definitions/OpenIdConnectSecurityScheme',
+        },
+      ],
     },
     APIKeySecurityScheme: {
       type: 'object',
@@ -1764,33 +1764,33 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['apiKey']
+          enum: ['apiKey'],
         },
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['header', 'query', 'cookie']
+          enum: ['header', 'query', 'cookie'],
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     HTTPSecurityScheme: {
       oneOf: [
         {
-          $ref: '#/definitions/NonBearerHTTPSecurityScheme'
+          $ref: '#/definitions/NonBearerHTTPSecurityScheme',
         },
         {
-          $ref: '#/definitions/BearerHTTPSecurityScheme'
-        }
-      ]
+          $ref: '#/definitions/BearerHTTPSecurityScheme',
+        },
+      ],
     },
     NonBearerHTTPSecurityScheme: {
       not: {
@@ -1798,28 +1798,28 @@ module.exports = {
         properties: {
           scheme: {
             type: 'string',
-            enum: ['bearer']
-          }
-        }
+            enum: ['bearer'],
+          },
+        },
       },
       type: 'object',
       required: ['scheme', 'type'],
       properties: {
         scheme: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         type: {
           type: 'string',
-          enum: ['http']
-        }
+          enum: ['http'],
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     BearerHTTPSecurityScheme: {
       type: 'object',
@@ -1827,23 +1827,23 @@ module.exports = {
       properties: {
         scheme: {
           type: 'string',
-          enum: ['bearer']
+          enum: ['bearer'],
         },
         bearerFormat: {
-          type: 'string'
+          type: 'string',
         },
         type: {
           type: 'string',
-          enum: ['http']
+          enum: ['http'],
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     OAuth2SecurityScheme: {
       type: 'object',
@@ -1851,19 +1851,19 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['oauth2']
+          enum: ['oauth2'],
         },
         flows: {
-          $ref: '#/definitions/OAuthFlows'
+          $ref: '#/definitions/OAuthFlows',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     OpenIdConnectSecurityScheme: {
       type: 'object',
@@ -1871,41 +1871,41 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['openIdConnect']
+          enum: ['openIdConnect'],
         },
         openIdConnectUrl: {
           type: 'string',
-          format: 'url'
+          format: 'url',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     OAuthFlows: {
       type: 'object',
       properties: {
         implicit: {
-          $ref: '#/definitions/ImplicitOAuthFlow'
+          $ref: '#/definitions/ImplicitOAuthFlow',
         },
         password: {
-          $ref: '#/definitions/PasswordOAuthFlow'
+          $ref: '#/definitions/PasswordOAuthFlow',
         },
         clientCredentials: {
-          $ref: '#/definitions/ClientCredentialsFlow'
+          $ref: '#/definitions/ClientCredentialsFlow',
         },
         authorizationCode: {
-          $ref: '#/definitions/AuthorizationCodeOAuthFlow'
-        }
+          $ref: '#/definitions/AuthorizationCodeOAuthFlow',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ImplicitOAuthFlow: {
       type: 'object',
@@ -1913,23 +1913,23 @@ module.exports = {
       properties: {
         authorizationUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         refreshUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         scopes: {
           type: 'object',
           additionalProperties: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     PasswordOAuthFlow: {
       type: 'object',
@@ -1937,23 +1937,23 @@ module.exports = {
       properties: {
         tokenUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         refreshUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         scopes: {
           type: 'object',
           additionalProperties: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     ClientCredentialsFlow: {
       type: 'object',
@@ -1961,23 +1961,23 @@ module.exports = {
       properties: {
         tokenUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         refreshUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         scopes: {
           type: 'object',
           additionalProperties: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     AuthorizationCodeOAuthFlow: {
       type: 'object',
@@ -1985,119 +1985,119 @@ module.exports = {
       properties: {
         authorizationUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         tokenUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         refreshUrl: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         scopes: {
           type: 'object',
           additionalProperties: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Link: {
       oneOf: [
         {
-          $ref: '#/definitions/LinkWithOperationRef'
+          $ref: '#/definitions/LinkWithOperationRef',
         },
         {
-          $ref: '#/definitions/LinkWithOperationId'
-        }
-      ]
+          $ref: '#/definitions/LinkWithOperationId',
+        },
+      ],
     },
     LinkWithOperationRef: {
       type: 'object',
       properties: {
         operationRef: {
           type: 'string',
-          format: 'uri-reference'
+          format: 'uri-reference',
         },
         parameters: {
           type: 'object',
-          additionalProperties: {}
+          additionalProperties: {},
         },
         requestBody: {},
         description: {
-          type: 'string'
+          type: 'string',
         },
         server: {
-          $ref: '#/definitions/Server'
-        }
+          $ref: '#/definitions/Server',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     LinkWithOperationId: {
       type: 'object',
       properties: {
         operationId: {
-          type: 'string'
+          type: 'string',
         },
         parameters: {
           type: 'object',
-          additionalProperties: {}
+          additionalProperties: {},
         },
         requestBody: {},
         description: {
-          type: 'string'
+          type: 'string',
         },
         server: {
-          $ref: '#/definitions/Server'
-        }
+          $ref: '#/definitions/Server',
+        },
       },
       patternProperties: {
-        '^x-': {}
+        '^x-': {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     Callback: {
       type: 'object',
       additionalProperties: {
-        $ref: '#/definitions/PathItem'
+        $ref: '#/definitions/PathItem',
       },
       patternProperties: {
-        '^x-': {}
-      }
+        '^x-': {},
+      },
     },
     Encoding: {
       type: 'object',
       properties: {
         contentType: {
-          type: 'string'
+          type: 'string',
         },
         headers: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/Header'
-          }
+            $ref: '#/definitions/Header',
+          },
         },
         style: {
           type: 'string',
-          enum: ['form', 'spaceDelimited', 'pipeDelimited', 'deepObject']
+          enum: ['form', 'spaceDelimited', 'pipeDelimited', 'deepObject'],
         },
         explode: {
-          type: 'boolean'
+          type: 'boolean',
         },
         allowReserved: {
           type: 'boolean',
-          default: false
-        }
+          default: false,
+        },
       },
-      additionalProperties: false
-    }
-  }
+      additionalProperties: false,
+    },
+  },
 };

--- a/src/plugins/validation/oas3/semantic-validators/discriminator.js
+++ b/src/plugins/validation/oas3/semantic-validators/discriminator.js
@@ -16,7 +16,7 @@ const get = require('lodash/get');
 const isPlainObject = require('lodash/isPlainObject');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec }) {
+module.exports.validate = function ({ jsSpec }) {
   const messages = new MessageCarrier();
 
   const schemas = get(jsSpec, ['components', 'schemas'], []);

--- a/src/plugins/validation/oas3/semantic-validators/openapi.js
+++ b/src/plugins/validation/oas3/semantic-validators/openapi.js
@@ -9,7 +9,7 @@
 
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec }) {
+module.exports.validate = function ({ jsSpec }) {
   const messages = new MessageCarrier();
 
   // Regex taken from Semantic Versioning 2.0.0 documentation to check if string follows Semantic Versioning

--- a/src/plugins/validation/oas3/semantic-validators/operations.js
+++ b/src/plugins/validation/oas3/semantic-validators/operations.js
@@ -14,7 +14,7 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 const findOctetSequencePaths = require('../../../utils/findOctetSequencePaths')
   .findOctetSequencePaths;
 
-module.exports.validate = function({ resolvedSpec, jsSpec }, config) {
+module.exports.validate = function ({ resolvedSpec, jsSpec }, config) {
   const messages = new MessageCarrier();
 
   const configSchemas = config.schemas;
@@ -68,7 +68,7 @@ module.exports.validate = function({ resolvedSpec, jsSpec }, config) {
             'paths',
             pathName,
             opName,
-            'requestBody'
+            'requestBody',
           ]);
 
           // form params do not need names
@@ -119,7 +119,7 @@ function isFormParameter(mimeType) {
   const formDataMimeTypes = [
     'multipart/form-data',
     'application/x-www-form-urlencoded',
-    'application/octet-stream'
+    'application/octet-stream',
   ];
   return formDataMimeTypes.includes(mimeType);
 }

--- a/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
@@ -18,7 +18,7 @@
 
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }, config) {
+module.exports.validate = function ({ resolvedSpec }, config) {
   const messages = new MessageCarrier();
 
   const checkStatus = config.pagination.pagination_style;
@@ -39,7 +39,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     }
 
     // Find first success response code
-    const resp = Object.keys(operation.responses || {}).find(code =>
+    const resp = Object.keys(operation.responses || {}).find((code) =>
       code.startsWith('2')
     );
     // Now get the json content of that response
@@ -58,7 +58,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     // If no array at top level of response, skip this path
     if (
       !Object.values(jsonResponse.schema.properties).some(
-        prop => prop.type === 'array'
+        (prop) => prop.type === 'array'
       )
     ) {
       continue;
@@ -68,7 +68,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     const params = operation.parameters;
     if (
       !params ||
-      !params.some(param => param.name === 'limit' && param.in === 'query')
+      !params.some((param) => param.name === 'limit' && param.in === 'query')
     ) {
       continue;
     }
@@ -78,7 +78,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     // - The `limit` query parameter be type integer, optional, and have default and maximum values.
 
     const limitParamIndex = params.findIndex(
-      param => param.name === 'limit' && param.in === 'query'
+      (param) => param.name === 'limit' && param.in === 'query'
     );
     const limitParam = params[limitParamIndex];
     if (
@@ -99,7 +99,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     // - If the operation has an `offset` query parameter, it must be type integer and optional
 
     const offsetParamIndex = params.findIndex(
-      param => param.name === 'offset' && param.in === 'query'
+      (param) => param.name === 'offset' && param.in === 'query'
     );
     if (offsetParamIndex !== -1) {
       const offsetParam = params[offsetParamIndex];
@@ -121,7 +121,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
 
     const startParamNames = ['start', 'cursor', 'page_token'];
     const startParamIndex = params.findIndex(
-      param =>
+      (param) =>
         param.in === 'query' && startParamNames.indexOf(param.name) !== -1
     );
     if (startParamIndex !== -1) {
@@ -133,9 +133,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       ) {
         messages.addMessage(
           ['paths', path, 'get', 'parameters', startParamIndex],
-          `The ${
-            startParam.name
-          } parameter must be of type string and optional.`,
+          `The ${startParam.name} parameter must be of type string and optional.`,
           checkStatus,
           'pagination_style'
         );
@@ -153,7 +151,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       'content',
       'application/json',
       'schema',
-      'properties'
+      'properties',
     ];
 
     const limitProp = jsonResponse.schema.properties.limit;

--- a/src/plugins/validation/oas3/semantic-validators/parameters.js
+++ b/src/plugins/validation/oas3/semantic-validators/parameters.js
@@ -16,13 +16,13 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 const findOctetSequencePaths = require('../../../utils/findOctetSequencePaths')
   .findOctetSequencePaths;
 
-module.exports.validate = function({ jsSpec }, config) {
+module.exports.validate = function ({ jsSpec }, config) {
   const messages = new MessageCarrier();
 
   const configSchemas = config.schemas;
   config = config.parameters;
 
-  walk(jsSpec, [], function(obj, path) {
+  walk(jsSpec, [], function (obj, path) {
     const isContentsOfParameterObject = isParameterObject(path, true); // 2nd arg is isOAS3
     const isRef = !!obj.$ref;
 
@@ -74,12 +74,12 @@ module.exports.validate = function({ jsSpec }, config) {
           ...findOctetSequencePaths(obj.schema, path.concat(['schema']))
         );
         if (obj.content) {
-          Object.keys(obj.content).forEach(function(mimeType) {
+          Object.keys(obj.content).forEach(function (mimeType) {
             if (mimeType === 'application/json') {
               const paramContentPath = path.concat([
                 'content',
                 mimeType,
-                'schema'
+                'schema',
               ]);
               octetSequencePaths.push(
                 ...findOctetSequencePaths(

--- a/src/plugins/validation/oas3/semantic-validators/responses.js
+++ b/src/plugins/validation/oas3/semantic-validators/responses.js
@@ -20,13 +20,13 @@ const MessageCarrier = require('../../../utils/messageCarrier');
 const findOctetSequencePaths = require('../../../utils/findOctetSequencePaths')
   .findOctetSequencePaths;
 
-module.exports.validate = function({ resolvedSpec }, config) {
+module.exports.validate = function ({ resolvedSpec }, config) {
   const messages = new MessageCarrier();
 
   const configSchemas = config.schemas;
   config = config.responses;
 
-  walk(resolvedSpec, [], function(obj, path) {
+  walk(resolvedSpec, [], function (obj, path) {
     // because we are using the resolved spec here,
     // and only want to validate the responses inside of operations,
     // check that we are within the `paths` object
@@ -118,10 +118,10 @@ module.exports.validate = function({ resolvedSpec }, config) {
 };
 
 function getResponseCodes(responseObj) {
-  const statusCodes = Object.keys(responseObj).filter(code =>
+  const statusCodes = Object.keys(responseObj).filter((code) =>
     isStatusCode(code)
   );
-  const successCodes = statusCodes.filter(code => code.slice(0, 1) === '2');
+  const successCodes = statusCodes.filter((code) => code.slice(0, 1) === '2');
   return [statusCodes, successCodes];
 }
 
@@ -136,16 +136,16 @@ function validateNoBinaryStringsInResponse(
   path,
   binaryStringStatus
 ) {
-  Object.keys(responseObj).forEach(function(responseCode) {
+  Object.keys(responseObj).forEach(function (responseCode) {
     const responseBodyContent = responseObj[responseCode].content;
     if (responseBodyContent) {
-      Object.keys(responseBodyContent).forEach(function(mimeType) {
+      Object.keys(responseBodyContent).forEach(function (mimeType) {
         if (mimeType === 'application/json') {
           const schemaPath = path.concat([
             responseCode,
             'content',
             mimeType,
-            'schema'
+            'schema',
           ]);
           const octetSequencePaths = findOctetSequencePaths(
             responseBodyContent[mimeType].schema,

--- a/src/plugins/validation/oas3/semantic-validators/security-definitions-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/security-definitions-ibm.js
@@ -23,7 +23,7 @@
 const stringValidator = require('validator');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }) {
+module.exports.validate = function ({ resolvedSpec }) {
   const messages = new MessageCarrier();
 
   const API_KEY = 'apiKey';

--- a/src/plugins/validation/swagger2/apis/swagger2-schema.js
+++ b/src/plugins/validation/swagger2/apis/swagger2-schema.js
@@ -7,75 +7,75 @@ module.exports = {
   additionalProperties: false,
   patternProperties: {
     '^x-': {
-      $ref: '#/definitions/vendorExtension'
-    }
+      $ref: '#/definitions/vendorExtension',
+    },
   },
   properties: {
     swagger: {
       type: 'string',
       enum: ['2.0'],
-      description: 'The Swagger version of this document.'
+      description: 'The Swagger version of this document.',
     },
     info: {
-      $ref: '#/definitions/info'
+      $ref: '#/definitions/info',
     },
     host: {
       type: 'string',
       pattern: '^[^{}/ :\\\\]+(?::\\d+)?$',
-      description: "The host (name or ip) of the API. Example: 'swagger.io'"
+      description: "The host (name or ip) of the API. Example: 'swagger.io'",
     },
     basePath: {
       type: 'string',
       pattern: '^/',
-      description: "The base path to the API. Example: '/api'."
+      description: "The base path to the API. Example: '/api'.",
     },
     schemes: {
-      $ref: '#/definitions/schemesList'
+      $ref: '#/definitions/schemesList',
     },
     consumes: {
       description: 'A list of MIME types accepted by the API.',
       allOf: [
         {
-          $ref: '#/definitions/mediaTypeList'
-        }
-      ]
+          $ref: '#/definitions/mediaTypeList',
+        },
+      ],
     },
     produces: {
       description: 'A list of MIME types the API can produce.',
       allOf: [
         {
-          $ref: '#/definitions/mediaTypeList'
-        }
-      ]
+          $ref: '#/definitions/mediaTypeList',
+        },
+      ],
     },
     paths: {
-      $ref: '#/definitions/paths'
+      $ref: '#/definitions/paths',
     },
     definitions: {
-      $ref: '#/definitions/definitions'
+      $ref: '#/definitions/definitions',
     },
     parameters: {
-      $ref: '#/definitions/parameterDefinitions'
+      $ref: '#/definitions/parameterDefinitions',
     },
     responses: {
-      $ref: '#/definitions/responseDefinitions'
+      $ref: '#/definitions/responseDefinitions',
     },
     security: {
-      $ref: '#/definitions/security'
+      $ref: '#/definitions/security',
     },
     securityDefinitions: {
-      $ref: '#/definitions/securityDefinitions'
+      $ref: '#/definitions/securityDefinitions',
     },
     tags: {
       type: 'array',
       items: {
-        $ref: '#/definitions/tag'
+        $ref: '#/definitions/tag',
       },
-      uniqueItems: true
+      uniqueItems: true,
     },
     externalDocs: {
-      $ref: '#/definitions/externalDocs'
-    }
+      $ref: '#/definitions/externalDocs',
+    },
   },
   definitions: {
     info: {
@@ -85,34 +85,34 @@ module.exports = {
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         title: {
           type: 'string',
-          description: 'A unique and precise title of the API.'
+          description: 'A unique and precise title of the API.',
         },
         version: {
           type: 'string',
-          description: 'A semantic version number of the API.'
+          description: 'A semantic version number of the API.',
         },
         description: {
           type: 'string',
           description:
-            'A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed.'
+            'A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed.',
         },
         termsOfService: {
           type: 'string',
-          description: 'The terms of service for the API.'
+          description: 'The terms of service for the API.',
         },
         contact: {
-          $ref: '#/definitions/contact'
+          $ref: '#/definitions/contact',
         },
         license: {
-          $ref: '#/definitions/license'
-        }
-      }
+          $ref: '#/definitions/license',
+        },
+      },
     },
     contact: {
       type: 'object',
@@ -122,24 +122,24 @@ module.exports = {
         name: {
           type: 'string',
           description:
-            'The identifying name of the contact person/organization.'
+            'The identifying name of the contact person/organization.',
         },
         url: {
           type: 'string',
           description: 'The URL pointing to the contact information.',
-          format: 'uri'
+          format: 'uri',
         },
         email: {
           type: 'string',
           description: 'The email address of the contact person/organization.',
-          format: 'email'
-        }
+          format: 'email',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     license: {
       type: 'object',
@@ -149,19 +149,19 @@ module.exports = {
         name: {
           type: 'string',
           description:
-            "The name of the license type. It's encouraged to use an OSI compatible license."
+            "The name of the license type. It's encouraged to use an OSI compatible license.",
         },
         url: {
           type: 'string',
           description: 'The URL pointing to the license.',
-          format: 'uri'
-        }
+          format: 'uri',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     paths: {
       type: 'object',
@@ -169,35 +169,35 @@ module.exports = {
         "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
+          $ref: '#/definitions/vendorExtension',
         },
         '^/': {
-          $ref: '#/definitions/pathItem'
-        }
+          $ref: '#/definitions/pathItem',
+        },
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     definitions: {
       type: 'object',
       additionalProperties: {
-        $ref: '#/definitions/schema'
+        $ref: '#/definitions/schema',
       },
       description:
-        'One or more JSON objects describing the schemas being consumed and produced by the API.'
+        'One or more JSON objects describing the schemas being consumed and produced by the API.',
     },
     parameterDefinitions: {
       type: 'object',
       additionalProperties: {
-        $ref: '#/definitions/parameter'
+        $ref: '#/definitions/parameter',
       },
-      description: 'One or more JSON representations for parameters'
+      description: 'One or more JSON representations for parameters',
     },
     responseDefinitions: {
       type: 'object',
       additionalProperties: {
-        $ref: '#/definitions/response'
+        $ref: '#/definitions/response',
       },
-      description: 'One or more JSON representations for parameters'
+      description: 'One or more JSON representations for parameters',
     },
     externalDocs: {
       type: 'object',
@@ -206,26 +206,26 @@ module.exports = {
       required: ['url'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         url: {
           type: 'string',
-          format: 'uri'
-        }
+          format: 'uri',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     examples: {
       type: 'object',
-      additionalProperties: true
+      additionalProperties: true,
     },
     mimeType: {
       type: 'string',
-      description: 'The MIME type of the HTTP message.'
+      description: 'The MIME type of the HTTP message.',
     },
     operation: {
       type: 'object',
@@ -233,104 +233,104 @@ module.exports = {
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         tags: {
           type: 'array',
           items: {
-            type: 'string'
+            type: 'string',
           },
-          uniqueItems: true
+          uniqueItems: true,
         },
         summary: {
           type: 'string',
-          description: 'A brief summary of the operation.'
+          description: 'A brief summary of the operation.',
         },
         description: {
           type: 'string',
           description:
-            'A longer description of the operation, GitHub Flavored Markdown is allowed.'
+            'A longer description of the operation, GitHub Flavored Markdown is allowed.',
         },
         externalDocs: {
-          $ref: '#/definitions/externalDocs'
+          $ref: '#/definitions/externalDocs',
         },
         operationId: {
           type: 'string',
-          description: 'A unique identifier of the operation.'
+          description: 'A unique identifier of the operation.',
         },
         produces: {
           description: 'A list of MIME types the API can produce.',
           allOf: [
             {
-              $ref: '#/definitions/mediaTypeList'
-            }
-          ]
+              $ref: '#/definitions/mediaTypeList',
+            },
+          ],
         },
         consumes: {
           description: 'A list of MIME types the API can consume.',
           allOf: [
             {
-              $ref: '#/definitions/mediaTypeList'
-            }
-          ]
+              $ref: '#/definitions/mediaTypeList',
+            },
+          ],
         },
         parameters: {
-          $ref: '#/definitions/parametersList'
+          $ref: '#/definitions/parametersList',
         },
         responses: {
-          $ref: '#/definitions/responses'
+          $ref: '#/definitions/responses',
         },
         schemes: {
-          $ref: '#/definitions/schemesList'
+          $ref: '#/definitions/schemesList',
         },
         deprecated: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         security: {
-          $ref: '#/definitions/security'
-        }
-      }
+          $ref: '#/definitions/security',
+        },
+      },
     },
     pathItem: {
       type: 'object',
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         $ref: {
-          type: 'string'
+          type: 'string',
         },
         get: {
-          $ref: '#/definitions/operation'
+          $ref: '#/definitions/operation',
         },
         put: {
-          $ref: '#/definitions/operation'
+          $ref: '#/definitions/operation',
         },
         post: {
-          $ref: '#/definitions/operation'
+          $ref: '#/definitions/operation',
         },
         delete: {
-          $ref: '#/definitions/operation'
+          $ref: '#/definitions/operation',
         },
         options: {
-          $ref: '#/definitions/operation'
+          $ref: '#/definitions/operation',
         },
         head: {
-          $ref: '#/definitions/operation'
+          $ref: '#/definitions/operation',
         },
         patch: {
-          $ref: '#/definitions/operation'
+          $ref: '#/definitions/operation',
         },
         parameters: {
-          $ref: '#/definitions/parametersList'
-        }
-      }
+          $ref: '#/definitions/parametersList',
+        },
+      },
     },
     responses: {
       type: 'object',
@@ -340,68 +340,68 @@ module.exports = {
       additionalProperties: false,
       patternProperties: {
         '^([0-9]{3})$|^(default)$': {
-          $ref: '#/definitions/responseValue'
+          $ref: '#/definitions/responseValue',
         },
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       not: {
         type: 'object',
         additionalProperties: false,
         patternProperties: {
           '^x-': {
-            $ref: '#/definitions/vendorExtension'
-          }
-        }
-      }
+            $ref: '#/definitions/vendorExtension',
+          },
+        },
+      },
     },
     responseValue: {
       oneOf: [
         {
-          $ref: '#/definitions/response'
+          $ref: '#/definitions/response',
         },
         {
-          $ref: '#/definitions/jsonReference'
-        }
-      ]
+          $ref: '#/definitions/jsonReference',
+        },
+      ],
     },
     response: {
       type: 'object',
       required: ['description'],
       properties: {
         description: {
-          type: 'string'
+          type: 'string',
         },
         schema: {
           oneOf: [
             {
-              $ref: '#/definitions/schema'
+              $ref: '#/definitions/schema',
             },
             {
-              $ref: '#/definitions/fileSchema'
-            }
-          ]
+              $ref: '#/definitions/fileSchema',
+            },
+          ],
         },
         headers: {
-          $ref: '#/definitions/headers'
+          $ref: '#/definitions/headers',
         },
         examples: {
-          $ref: '#/definitions/examples'
-        }
+          $ref: '#/definitions/examples',
+        },
       },
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     headers: {
       type: 'object',
       additionalProperties: {
-        $ref: '#/definitions/header'
-      }
+        $ref: '#/definitions/header',
+      },
     },
     header: {
       type: 'object',
@@ -410,370 +410,370 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['string', 'number', 'integer', 'boolean', 'array']
+          enum: ['string', 'number', 'integer', 'boolean', 'array'],
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         items: {
-          $ref: '#/definitions/primitivesItems'
+          $ref: '#/definitions/primitivesItems',
         },
         collectionFormat: {
-          $ref: '#/definitions/collectionFormat'
+          $ref: '#/definitions/collectionFormat',
         },
         default: {
-          $ref: '#/definitions/default'
+          $ref: '#/definitions/default',
         },
         maximum: {
-          $ref: '#/definitions/maximum'
+          $ref: '#/definitions/maximum',
         },
         exclusiveMaximum: {
-          $ref: '#/definitions/exclusiveMaximum'
+          $ref: '#/definitions/exclusiveMaximum',
         },
         minimum: {
-          $ref: '#/definitions/minimum'
+          $ref: '#/definitions/minimum',
         },
         exclusiveMinimum: {
-          $ref: '#/definitions/exclusiveMinimum'
+          $ref: '#/definitions/exclusiveMinimum',
         },
         maxLength: {
-          $ref: '#/definitions/maxLength'
+          $ref: '#/definitions/maxLength',
         },
         minLength: {
-          $ref: '#/definitions/minLength'
+          $ref: '#/definitions/minLength',
         },
         pattern: {
-          $ref: '#/definitions/pattern'
+          $ref: '#/definitions/pattern',
         },
         maxItems: {
-          $ref: '#/definitions/maxItems'
+          $ref: '#/definitions/maxItems',
         },
         minItems: {
-          $ref: '#/definitions/minItems'
+          $ref: '#/definitions/minItems',
         },
         uniqueItems: {
-          $ref: '#/definitions/uniqueItems'
+          $ref: '#/definitions/uniqueItems',
         },
         enum: {
-          $ref: '#/definitions/enum'
+          $ref: '#/definitions/enum',
         },
         multipleOf: {
-          $ref: '#/definitions/multipleOf'
+          $ref: '#/definitions/multipleOf',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     vendorExtension: {
       description: 'Any property starting with x- is valid.',
       additionalProperties: true,
-      additionalItems: true
+      additionalItems: true,
     },
     bodyParameter: {
       type: 'object',
       required: ['name', 'in', 'schema'],
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         description: {
           type: 'string',
           description:
-            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.'
+            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.',
         },
         name: {
           type: 'string',
-          description: 'The name of the parameter.'
+          description: 'The name of the parameter.',
         },
         in: {
           type: 'string',
           description: 'Determines the location of the parameter.',
-          enum: ['body']
+          enum: ['body'],
         },
         required: {
           type: 'boolean',
           description:
             'Determines whether or not this parameter is required or optional.',
-          default: false
+          default: false,
         },
         schema: {
-          $ref: '#/definitions/schema'
-        }
+          $ref: '#/definitions/schema',
+        },
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     headerParameterSubSchema: {
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         required: {
           type: 'boolean',
           description:
             'Determines whether or not this parameter is required or optional.',
-          default: false
+          default: false,
         },
         in: {
           type: 'string',
           description: 'Determines the location of the parameter.',
-          enum: ['header']
+          enum: ['header'],
         },
         description: {
           type: 'string',
           description:
-            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.'
+            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.',
         },
         name: {
           type: 'string',
-          description: 'The name of the parameter.'
+          description: 'The name of the parameter.',
         },
         type: {
           type: 'string',
-          enum: ['string', 'number', 'boolean', 'integer', 'array']
+          enum: ['string', 'number', 'boolean', 'integer', 'array'],
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         items: {
-          $ref: '#/definitions/primitivesItems'
+          $ref: '#/definitions/primitivesItems',
         },
         collectionFormat: {
-          $ref: '#/definitions/collectionFormat'
+          $ref: '#/definitions/collectionFormat',
         },
         default: {
-          $ref: '#/definitions/default'
+          $ref: '#/definitions/default',
         },
         maximum: {
-          $ref: '#/definitions/maximum'
+          $ref: '#/definitions/maximum',
         },
         exclusiveMaximum: {
-          $ref: '#/definitions/exclusiveMaximum'
+          $ref: '#/definitions/exclusiveMaximum',
         },
         minimum: {
-          $ref: '#/definitions/minimum'
+          $ref: '#/definitions/minimum',
         },
         exclusiveMinimum: {
-          $ref: '#/definitions/exclusiveMinimum'
+          $ref: '#/definitions/exclusiveMinimum',
         },
         maxLength: {
-          $ref: '#/definitions/maxLength'
+          $ref: '#/definitions/maxLength',
         },
         minLength: {
-          $ref: '#/definitions/minLength'
+          $ref: '#/definitions/minLength',
         },
         pattern: {
-          $ref: '#/definitions/pattern'
+          $ref: '#/definitions/pattern',
         },
         maxItems: {
-          $ref: '#/definitions/maxItems'
+          $ref: '#/definitions/maxItems',
         },
         minItems: {
-          $ref: '#/definitions/minItems'
+          $ref: '#/definitions/minItems',
         },
         uniqueItems: {
-          $ref: '#/definitions/uniqueItems'
+          $ref: '#/definitions/uniqueItems',
         },
         enum: {
-          $ref: '#/definitions/enum'
+          $ref: '#/definitions/enum',
         },
         multipleOf: {
-          $ref: '#/definitions/multipleOf'
-        }
-      }
+          $ref: '#/definitions/multipleOf',
+        },
+      },
     },
     queryParameterSubSchema: {
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         required: {
           type: 'boolean',
           description:
             'Determines whether or not this parameter is required or optional.',
-          default: false
+          default: false,
         },
         in: {
           type: 'string',
           description: 'Determines the location of the parameter.',
-          enum: ['query']
+          enum: ['query'],
         },
         description: {
           type: 'string',
           description:
-            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.'
+            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.',
         },
         name: {
           type: 'string',
-          description: 'The name of the parameter.'
+          description: 'The name of the parameter.',
         },
         allowEmptyValue: {
           type: 'boolean',
           default: false,
           description:
-            'allows sending a parameter by name only or with an empty value.'
+            'allows sending a parameter by name only or with an empty value.',
         },
         type: {
           type: 'string',
-          enum: ['string', 'number', 'boolean', 'integer', 'array']
+          enum: ['string', 'number', 'boolean', 'integer', 'array'],
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         items: {
-          $ref: '#/definitions/primitivesItems'
+          $ref: '#/definitions/primitivesItems',
         },
         collectionFormat: {
-          $ref: '#/definitions/collectionFormatWithMulti'
+          $ref: '#/definitions/collectionFormatWithMulti',
         },
         default: {
-          $ref: '#/definitions/default'
+          $ref: '#/definitions/default',
         },
         maximum: {
-          $ref: '#/definitions/maximum'
+          $ref: '#/definitions/maximum',
         },
         exclusiveMaximum: {
-          $ref: '#/definitions/exclusiveMaximum'
+          $ref: '#/definitions/exclusiveMaximum',
         },
         minimum: {
-          $ref: '#/definitions/minimum'
+          $ref: '#/definitions/minimum',
         },
         exclusiveMinimum: {
-          $ref: '#/definitions/exclusiveMinimum'
+          $ref: '#/definitions/exclusiveMinimum',
         },
         maxLength: {
-          $ref: '#/definitions/maxLength'
+          $ref: '#/definitions/maxLength',
         },
         minLength: {
-          $ref: '#/definitions/minLength'
+          $ref: '#/definitions/minLength',
         },
         pattern: {
-          $ref: '#/definitions/pattern'
+          $ref: '#/definitions/pattern',
         },
         maxItems: {
-          $ref: '#/definitions/maxItems'
+          $ref: '#/definitions/maxItems',
         },
         minItems: {
-          $ref: '#/definitions/minItems'
+          $ref: '#/definitions/minItems',
         },
         uniqueItems: {
-          $ref: '#/definitions/uniqueItems'
+          $ref: '#/definitions/uniqueItems',
         },
         enum: {
-          $ref: '#/definitions/enum'
+          $ref: '#/definitions/enum',
         },
         multipleOf: {
-          $ref: '#/definitions/multipleOf'
-        }
-      }
+          $ref: '#/definitions/multipleOf',
+        },
+      },
     },
     formDataParameterSubSchema: {
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         required: {
           type: 'boolean',
           description:
             'Determines whether or not this parameter is required or optional.',
-          default: false
+          default: false,
         },
         in: {
           type: 'string',
           description: 'Determines the location of the parameter.',
-          enum: ['formData']
+          enum: ['formData'],
         },
         description: {
           type: 'string',
           description:
-            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.'
+            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.',
         },
         name: {
           type: 'string',
-          description: 'The name of the parameter.'
+          description: 'The name of the parameter.',
         },
         allowEmptyValue: {
           type: 'boolean',
           default: false,
           description:
-            'allows sending a parameter by name only or with an empty value.'
+            'allows sending a parameter by name only or with an empty value.',
         },
         type: {
           type: 'string',
-          enum: ['string', 'number', 'boolean', 'integer', 'array', 'file']
+          enum: ['string', 'number', 'boolean', 'integer', 'array', 'file'],
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         items: {
-          $ref: '#/definitions/primitivesItems'
+          $ref: '#/definitions/primitivesItems',
         },
         collectionFormat: {
-          $ref: '#/definitions/collectionFormatWithMulti'
+          $ref: '#/definitions/collectionFormatWithMulti',
         },
         default: {
-          $ref: '#/definitions/default'
+          $ref: '#/definitions/default',
         },
         maximum: {
-          $ref: '#/definitions/maximum'
+          $ref: '#/definitions/maximum',
         },
         exclusiveMaximum: {
-          $ref: '#/definitions/exclusiveMaximum'
+          $ref: '#/definitions/exclusiveMaximum',
         },
         minimum: {
-          $ref: '#/definitions/minimum'
+          $ref: '#/definitions/minimum',
         },
         exclusiveMinimum: {
-          $ref: '#/definitions/exclusiveMinimum'
+          $ref: '#/definitions/exclusiveMinimum',
         },
         maxLength: {
-          $ref: '#/definitions/maxLength'
+          $ref: '#/definitions/maxLength',
         },
         minLength: {
-          $ref: '#/definitions/minLength'
+          $ref: '#/definitions/minLength',
         },
         pattern: {
-          $ref: '#/definitions/pattern'
+          $ref: '#/definitions/pattern',
         },
         maxItems: {
-          $ref: '#/definitions/maxItems'
+          $ref: '#/definitions/maxItems',
         },
         minItems: {
-          $ref: '#/definitions/minItems'
+          $ref: '#/definitions/minItems',
         },
         uniqueItems: {
-          $ref: '#/definitions/uniqueItems'
+          $ref: '#/definitions/uniqueItems',
         },
         enum: {
-          $ref: '#/definitions/enum'
+          $ref: '#/definitions/enum',
         },
         multipleOf: {
-          $ref: '#/definitions/multipleOf'
-        }
-      }
+          $ref: '#/definitions/multipleOf',
+        },
+      },
     },
     pathParameterSubSchema: {
       additionalProperties: false,
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       required: ['required'],
       properties: {
@@ -781,282 +781,285 @@ module.exports = {
           type: 'boolean',
           enum: [true],
           description:
-            'Determines whether or not this parameter is required or optional.'
+            'Determines whether or not this parameter is required or optional.',
         },
         in: {
           type: 'string',
           description: 'Determines the location of the parameter.',
-          enum: ['path']
+          enum: ['path'],
         },
         description: {
           type: 'string',
           description:
-            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.'
+            'A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.',
         },
         name: {
           type: 'string',
-          description: 'The name of the parameter.'
+          description: 'The name of the parameter.',
         },
         type: {
           type: 'string',
-          enum: ['string', 'number', 'boolean', 'integer', 'array']
+          enum: ['string', 'number', 'boolean', 'integer', 'array'],
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         items: {
-          $ref: '#/definitions/primitivesItems'
+          $ref: '#/definitions/primitivesItems',
         },
         collectionFormat: {
-          $ref: '#/definitions/collectionFormat'
+          $ref: '#/definitions/collectionFormat',
         },
         default: {
-          $ref: '#/definitions/default'
+          $ref: '#/definitions/default',
         },
         maximum: {
-          $ref: '#/definitions/maximum'
+          $ref: '#/definitions/maximum',
         },
         exclusiveMaximum: {
-          $ref: '#/definitions/exclusiveMaximum'
+          $ref: '#/definitions/exclusiveMaximum',
         },
         minimum: {
-          $ref: '#/definitions/minimum'
+          $ref: '#/definitions/minimum',
         },
         exclusiveMinimum: {
-          $ref: '#/definitions/exclusiveMinimum'
+          $ref: '#/definitions/exclusiveMinimum',
         },
         maxLength: {
-          $ref: '#/definitions/maxLength'
+          $ref: '#/definitions/maxLength',
         },
         minLength: {
-          $ref: '#/definitions/minLength'
+          $ref: '#/definitions/minLength',
         },
         pattern: {
-          $ref: '#/definitions/pattern'
+          $ref: '#/definitions/pattern',
         },
         maxItems: {
-          $ref: '#/definitions/maxItems'
+          $ref: '#/definitions/maxItems',
         },
         minItems: {
-          $ref: '#/definitions/minItems'
+          $ref: '#/definitions/minItems',
         },
         uniqueItems: {
-          $ref: '#/definitions/uniqueItems'
+          $ref: '#/definitions/uniqueItems',
         },
         enum: {
-          $ref: '#/definitions/enum'
+          $ref: '#/definitions/enum',
         },
         multipleOf: {
-          $ref: '#/definitions/multipleOf'
-        }
-      }
+          $ref: '#/definitions/multipleOf',
+        },
+      },
     },
     nonBodyParameter: {
       type: 'object',
       required: ['name', 'in', 'type'],
       oneOf: [
         {
-          $ref: '#/definitions/headerParameterSubSchema'
+          $ref: '#/definitions/headerParameterSubSchema',
         },
         {
-          $ref: '#/definitions/formDataParameterSubSchema'
+          $ref: '#/definitions/formDataParameterSubSchema',
         },
         {
-          $ref: '#/definitions/queryParameterSubSchema'
+          $ref: '#/definitions/queryParameterSubSchema',
         },
         {
-          $ref: '#/definitions/pathParameterSubSchema'
-        }
-      ]
+          $ref: '#/definitions/pathParameterSubSchema',
+        },
+      ],
     },
     parameter: {
       oneOf: [
         {
-          $ref: '#/definitions/bodyParameter'
+          $ref: '#/definitions/bodyParameter',
         },
         {
-          $ref: '#/definitions/nonBodyParameter'
-        }
-      ]
+          $ref: '#/definitions/nonBodyParameter',
+        },
+      ],
     },
     schema: {
       type: 'object',
       description: 'A deterministic version of a JSON Schema object.',
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       properties: {
         $ref: {
-          type: 'string'
+          type: 'string',
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         title: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/title'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/title',
         },
         description: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/description'
+          $ref:
+            'http://json-schema.org/draft-04/schema#/properties/description',
         },
         default: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/default'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/default',
         },
         multipleOf: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/multipleOf'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/multipleOf',
         },
         maximum: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/maximum'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/maximum',
         },
         exclusiveMaximum: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum'
+            'http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum',
         },
         minimum: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/minimum'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/minimum',
         },
         exclusiveMinimum: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum'
+            'http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum',
         },
         maxLength: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/positiveInteger'
+            'http://json-schema.org/draft-04/schema#/definitions/positiveInteger',
         },
         minLength: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0'
+            'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0',
         },
         pattern: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/pattern'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/pattern',
         },
         maxItems: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/positiveInteger'
+            'http://json-schema.org/draft-04/schema#/definitions/positiveInteger',
         },
         minItems: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0'
+            'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0',
         },
         uniqueItems: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/uniqueItems'
+          $ref:
+            'http://json-schema.org/draft-04/schema#/properties/uniqueItems',
         },
         maxProperties: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/positiveInteger'
+            'http://json-schema.org/draft-04/schema#/definitions/positiveInteger',
         },
         minProperties: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0'
+            'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0',
         },
         required: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/stringArray'
+            'http://json-schema.org/draft-04/schema#/definitions/stringArray',
         },
         enum: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/enum'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/enum',
         },
         additionalProperties: {
           anyOf: [
             {
-              $ref: '#/definitions/schema'
+              $ref: '#/definitions/schema',
             },
             {
-              type: 'boolean'
-            }
+              type: 'boolean',
+            },
           ],
-          default: {}
+          default: {},
         },
         type: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/type'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/type',
         },
         items: {
           anyOf: [
             {
-              $ref: '#/definitions/schema'
+              $ref: '#/definitions/schema',
             },
             {
               type: 'array',
               minItems: 1,
               items: {
-                $ref: '#/definitions/schema'
-              }
-            }
+                $ref: '#/definitions/schema',
+              },
+            },
           ],
-          default: {}
+          default: {},
         },
         allOf: {
           type: 'array',
           minItems: 1,
           items: {
-            $ref: '#/definitions/schema'
-          }
+            $ref: '#/definitions/schema',
+          },
         },
         properties: {
           type: 'object',
           additionalProperties: {
-            $ref: '#/definitions/schema'
+            $ref: '#/definitions/schema',
           },
-          default: {}
+          default: {},
         },
         discriminator: {
-          type: 'string'
+          type: 'string',
         },
         readOnly: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         xml: {
-          $ref: '#/definitions/xml'
+          $ref: '#/definitions/xml',
         },
         externalDocs: {
-          $ref: '#/definitions/externalDocs'
+          $ref: '#/definitions/externalDocs',
         },
-        example: {}
+        example: {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     fileSchema: {
       type: 'object',
       description: 'A deterministic version of a JSON Schema object.',
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
+          $ref: '#/definitions/vendorExtension',
+        },
       },
       required: ['type'],
       properties: {
         format: {
-          type: 'string'
+          type: 'string',
         },
         title: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/title'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/title',
         },
         description: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/description'
+          $ref:
+            'http://json-schema.org/draft-04/schema#/properties/description',
         },
         default: {
-          $ref: 'http://json-schema.org/draft-04/schema#/properties/default'
+          $ref: 'http://json-schema.org/draft-04/schema#/properties/default',
         },
         required: {
           $ref:
-            'http://json-schema.org/draft-04/schema#/definitions/stringArray'
+            'http://json-schema.org/draft-04/schema#/definitions/stringArray',
         },
         type: {
           type: 'string',
-          enum: ['file']
+          enum: ['file'],
         },
         readOnly: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         externalDocs: {
-          $ref: '#/definitions/externalDocs'
+          $ref: '#/definitions/externalDocs',
         },
-        example: {}
+        example: {},
       },
-      additionalProperties: false
+      additionalProperties: false,
     },
     primitivesItems: {
       type: 'object',
@@ -1064,107 +1067,107 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['string', 'number', 'integer', 'boolean', 'array']
+          enum: ['string', 'number', 'integer', 'boolean', 'array'],
         },
         format: {
-          type: 'string'
+          type: 'string',
         },
         items: {
-          $ref: '#/definitions/primitivesItems'
+          $ref: '#/definitions/primitivesItems',
         },
         collectionFormat: {
-          $ref: '#/definitions/collectionFormat'
+          $ref: '#/definitions/collectionFormat',
         },
         default: {
-          $ref: '#/definitions/default'
+          $ref: '#/definitions/default',
         },
         maximum: {
-          $ref: '#/definitions/maximum'
+          $ref: '#/definitions/maximum',
         },
         exclusiveMaximum: {
-          $ref: '#/definitions/exclusiveMaximum'
+          $ref: '#/definitions/exclusiveMaximum',
         },
         minimum: {
-          $ref: '#/definitions/minimum'
+          $ref: '#/definitions/minimum',
         },
         exclusiveMinimum: {
-          $ref: '#/definitions/exclusiveMinimum'
+          $ref: '#/definitions/exclusiveMinimum',
         },
         maxLength: {
-          $ref: '#/definitions/maxLength'
+          $ref: '#/definitions/maxLength',
         },
         minLength: {
-          $ref: '#/definitions/minLength'
+          $ref: '#/definitions/minLength',
         },
         pattern: {
-          $ref: '#/definitions/pattern'
+          $ref: '#/definitions/pattern',
         },
         maxItems: {
-          $ref: '#/definitions/maxItems'
+          $ref: '#/definitions/maxItems',
         },
         minItems: {
-          $ref: '#/definitions/minItems'
+          $ref: '#/definitions/minItems',
         },
         uniqueItems: {
-          $ref: '#/definitions/uniqueItems'
+          $ref: '#/definitions/uniqueItems',
         },
         enum: {
-          $ref: '#/definitions/enum'
+          $ref: '#/definitions/enum',
         },
         multipleOf: {
-          $ref: '#/definitions/multipleOf'
-        }
+          $ref: '#/definitions/multipleOf',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     security: {
       type: 'array',
       items: {
-        $ref: '#/definitions/securityRequirement'
+        $ref: '#/definitions/securityRequirement',
       },
-      uniqueItems: true
+      uniqueItems: true,
     },
     securityRequirement: {
       type: 'object',
       additionalProperties: {
         type: 'array',
         items: {
-          type: 'string'
+          type: 'string',
         },
-        uniqueItems: true
-      }
+        uniqueItems: true,
+      },
     },
     xml: {
       type: 'object',
       additionalProperties: false,
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         namespace: {
-          type: 'string'
+          type: 'string',
         },
         prefix: {
-          type: 'string'
+          type: 'string',
         },
         attribute: {
           type: 'boolean',
-          default: false
+          default: false,
         },
         wrapped: {
           type: 'boolean',
-          default: false
-        }
+          default: false,
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     tag: {
       type: 'object',
@@ -1172,45 +1175,45 @@ module.exports = {
       required: ['name'],
       properties: {
         name: {
-          type: 'string'
+          type: 'string',
         },
         description: {
-          type: 'string'
+          type: 'string',
         },
         externalDocs: {
-          $ref: '#/definitions/externalDocs'
-        }
+          $ref: '#/definitions/externalDocs',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     securityDefinitions: {
       type: 'object',
       additionalProperties: {
         oneOf: [
           {
-            $ref: '#/definitions/basicAuthenticationSecurity'
+            $ref: '#/definitions/basicAuthenticationSecurity',
           },
           {
-            $ref: '#/definitions/apiKeySecurity'
+            $ref: '#/definitions/apiKeySecurity',
           },
           {
-            $ref: '#/definitions/oauth2ImplicitSecurity'
+            $ref: '#/definitions/oauth2ImplicitSecurity',
           },
           {
-            $ref: '#/definitions/oauth2PasswordSecurity'
+            $ref: '#/definitions/oauth2PasswordSecurity',
           },
           {
-            $ref: '#/definitions/oauth2ApplicationSecurity'
+            $ref: '#/definitions/oauth2ApplicationSecurity',
           },
           {
-            $ref: '#/definitions/oauth2AccessCodeSecurity'
-          }
-        ]
-      }
+            $ref: '#/definitions/oauth2AccessCodeSecurity',
+          },
+        ],
+      },
     },
     basicAuthenticationSecurity: {
       type: 'object',
@@ -1219,17 +1222,17 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['basic']
+          enum: ['basic'],
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     apiKeySecurity: {
       type: 'object',
@@ -1238,24 +1241,24 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['apiKey']
+          enum: ['apiKey'],
         },
         name: {
-          type: 'string'
+          type: 'string',
         },
         in: {
           type: 'string',
-          enum: ['header', 'query']
+          enum: ['header', 'query'],
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     oauth2ImplicitSecurity: {
       type: 'object',
@@ -1264,28 +1267,28 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['oauth2']
+          enum: ['oauth2'],
         },
         flow: {
           type: 'string',
-          enum: ['implicit']
+          enum: ['implicit'],
         },
         scopes: {
-          $ref: '#/definitions/oauth2Scopes'
+          $ref: '#/definitions/oauth2Scopes',
         },
         authorizationUrl: {
           type: 'string',
-          format: 'uri'
+          format: 'uri',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     oauth2PasswordSecurity: {
       type: 'object',
@@ -1294,28 +1297,28 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['oauth2']
+          enum: ['oauth2'],
         },
         flow: {
           type: 'string',
-          enum: ['password']
+          enum: ['password'],
         },
         scopes: {
-          $ref: '#/definitions/oauth2Scopes'
+          $ref: '#/definitions/oauth2Scopes',
         },
         tokenUrl: {
           type: 'string',
-          format: 'uri'
+          format: 'uri',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     oauth2ApplicationSecurity: {
       type: 'object',
@@ -1324,28 +1327,28 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['oauth2']
+          enum: ['oauth2'],
         },
         flow: {
           type: 'string',
-          enum: ['application']
+          enum: ['application'],
         },
         scopes: {
-          $ref: '#/definitions/oauth2Scopes'
+          $ref: '#/definitions/oauth2Scopes',
         },
         tokenUrl: {
           type: 'string',
-          format: 'uri'
+          format: 'uri',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     oauth2AccessCodeSecurity: {
       type: 'object',
@@ -1354,45 +1357,45 @@ module.exports = {
       properties: {
         type: {
           type: 'string',
-          enum: ['oauth2']
+          enum: ['oauth2'],
         },
         flow: {
           type: 'string',
-          enum: ['accessCode']
+          enum: ['accessCode'],
         },
         scopes: {
-          $ref: '#/definitions/oauth2Scopes'
+          $ref: '#/definitions/oauth2Scopes',
         },
         authorizationUrl: {
           type: 'string',
-          format: 'uri'
+          format: 'uri',
         },
         tokenUrl: {
           type: 'string',
-          format: 'uri'
+          format: 'uri',
         },
         description: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       patternProperties: {
         '^x-': {
-          $ref: '#/definitions/vendorExtension'
-        }
-      }
+          $ref: '#/definitions/vendorExtension',
+        },
+      },
     },
     oauth2Scopes: {
       type: 'object',
       additionalProperties: {
-        type: 'string'
-      }
+        type: 'string',
+      },
     },
     mediaTypeList: {
       type: 'array',
       items: {
-        $ref: '#/definitions/mimeType'
+        $ref: '#/definitions/mimeType',
       },
-      uniqueItems: true
+      uniqueItems: true,
     },
     parametersList: {
       type: 'array',
@@ -1401,84 +1404,84 @@ module.exports = {
       items: {
         oneOf: [
           {
-            $ref: '#/definitions/parameter'
+            $ref: '#/definitions/parameter',
           },
           {
-            $ref: '#/definitions/jsonReference'
-          }
-        ]
+            $ref: '#/definitions/jsonReference',
+          },
+        ],
       },
-      uniqueItems: true
+      uniqueItems: true,
     },
     schemesList: {
       type: 'array',
       description: 'The transfer protocol of the API.',
       items: {
         type: 'string',
-        enum: ['http', 'https', 'ws', 'wss']
+        enum: ['http', 'https', 'ws', 'wss'],
       },
-      uniqueItems: true
+      uniqueItems: true,
     },
     collectionFormat: {
       type: 'string',
       enum: ['csv', 'ssv', 'tsv', 'pipes'],
-      default: 'csv'
+      default: 'csv',
     },
     collectionFormatWithMulti: {
       type: 'string',
       enum: ['csv', 'ssv', 'tsv', 'pipes', 'multi'],
-      default: 'csv'
+      default: 'csv',
     },
     title: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/title'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/title',
     },
     description: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/description'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/description',
     },
     default: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/default'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/default',
     },
     multipleOf: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/multipleOf'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/multipleOf',
     },
     maximum: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/maximum'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/maximum',
     },
     exclusiveMaximum: {
       $ref:
-        'http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum'
+        'http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum',
     },
     minimum: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/minimum'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/minimum',
     },
     exclusiveMinimum: {
       $ref:
-        'http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum'
+        'http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum',
     },
     maxLength: {
       $ref:
-        'http://json-schema.org/draft-04/schema#/definitions/positiveInteger'
+        'http://json-schema.org/draft-04/schema#/definitions/positiveInteger',
     },
     minLength: {
       $ref:
-        'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0'
+        'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0',
     },
     pattern: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/pattern'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/pattern',
     },
     maxItems: {
       $ref:
-        'http://json-schema.org/draft-04/schema#/definitions/positiveInteger'
+        'http://json-schema.org/draft-04/schema#/definitions/positiveInteger',
     },
     minItems: {
       $ref:
-        'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0'
+        'http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0',
     },
     uniqueItems: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/uniqueItems'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/uniqueItems',
     },
     enum: {
-      $ref: 'http://json-schema.org/draft-04/schema#/properties/enum'
+      $ref: 'http://json-schema.org/draft-04/schema#/properties/enum',
     },
     jsonReference: {
       type: 'object',
@@ -1486,9 +1489,9 @@ module.exports = {
       additionalProperties: false,
       properties: {
         $ref: {
-          type: 'string'
-        }
-      }
-    }
-  }
+          type: 'string',
+        },
+      },
+    },
+  },
 };

--- a/src/plugins/validation/swagger2/semantic-validators/discriminator.js
+++ b/src/plugins/validation/swagger2/semantic-validators/discriminator.js
@@ -16,7 +16,7 @@ const get = require('lodash/get');
 const includes = require('lodash/includes');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec }) {
+module.exports.validate = function ({ jsSpec }) {
   const messages = new MessageCarrier();
 
   const schemas = get(jsSpec, ['definitions'], []);

--- a/src/plugins/validation/swagger2/semantic-validators/form-data.js
+++ b/src/plugins/validation/swagger2/semantic-validators/form-data.js
@@ -19,7 +19,7 @@ const isPlainObject = require('lodash/isPlainObject');
 const getIn = require('lodash/get');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }) {
+module.exports.validate = function ({ resolvedSpec }) {
   const messages = new MessageCarrier();
 
   if (!isPlainObject(resolvedSpec)) {
@@ -65,7 +65,7 @@ module.exports.validate = function({ resolvedSpec }) {
     // Continue to walk the object tree
     const keys = Object.keys(obj);
     if (keys) {
-      return keys.map(k => walk(obj[k], [...path, k]));
+      return keys.map((k) => walk(obj[k], [...path, k]));
     } else {
       return null;
     }
@@ -76,14 +76,14 @@ module.exports.validate = function({ resolvedSpec }) {
     return (
       isPlainObject(operation) &&
       Array.isArray(operation.consumes) &&
-      operation.consumes.some(c => c === consumes)
+      operation.consumes.some((c) => c === consumes)
     );
   }
 
   // Warn about a typo, formdata => formData
   function assertationTypo(params, path) {
     const formDataWithTypos = params.filter(
-      p => isPlainObject(p) && p['in'] === 'formdata'
+      (p) => isPlainObject(p) && p['in'] === 'formdata'
     );
 
     if (formDataWithTypos.length) {
@@ -106,10 +106,10 @@ module.exports.validate = function({ resolvedSpec }) {
   function assertationOne(params, path) {
     // Assertion 1
     const inBodyIndex = params.findIndex(
-      p => isPlainObject(p) && p['in'] === 'body'
+      (p) => isPlainObject(p) && p['in'] === 'body'
     );
     const formData = params.filter(
-      p => isPlainObject(p) && p['in'] === 'formData'
+      (p) => isPlainObject(p) && p['in'] === 'formData'
     );
     const hasFormData = !!formData.length;
 
@@ -130,7 +130,7 @@ module.exports.validate = function({ resolvedSpec }) {
   // - b. The consumes property must have `multipart/form-data`
   function assertationTwo(params, path, operation) {
     const typeFileIndex = params.findIndex(
-      p => isPlainObject(p) && p.type === 'file'
+      (p) => isPlainObject(p) && p.type === 'file'
     );
     // No type: file?
     if (!~typeFileIndex) {

--- a/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
+++ b/src/plugins/validation/swagger2/semantic-validators/operations-ibm.js
@@ -13,7 +13,7 @@ const map = require('lodash/map');
 const pick = require('lodash/pick');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec }, config) {
+module.exports.validate = function ({ jsSpec }, config) {
   const messages = new MessageCarrier();
 
   config = config.operations;
@@ -29,7 +29,7 @@ module.exports.validate = function({ jsSpec }, config) {
       'put',
       'patch',
       'delete',
-      'options'
+      'options',
     ]);
     each(pathOps, (op, opKey) => {
       // if operation is excluded, don't validate it
@@ -48,7 +48,7 @@ module.exports.validate = function({ jsSpec }, config) {
         // Check for body parameter in path
         let hasBodyParamInPath = false;
         if (path.parameters) {
-          path.parameters.forEach(parameter => {
+          path.parameters.forEach((parameter) => {
             if (parameter.in === 'body') {
               hasBodyParamInPath = true;
             }
@@ -58,7 +58,7 @@ module.exports.validate = function({ jsSpec }, config) {
         // Check for body parameter in operation
         let hasBodyParamInOps = false;
         if (op.parameters) {
-          op.parameters.forEach(parameter => {
+          op.parameters.forEach((parameter) => {
             if (parameter.in === 'body') {
               hasBodyParamInOps = true;
             }
@@ -91,7 +91,7 @@ module.exports.validate = function({ jsSpec }, config) {
         // determine if only success response is a 204
         const responses = op.responses || {};
         const successResponses = Object.keys(responses).filter(
-          code => code.charAt(0) === '2'
+          (code) => code.charAt(0) === '2'
         );
         const onlyHas204 =
           successResponses.length === 1 && successResponses[0] === '204';

--- a/src/plugins/validation/swagger2/semantic-validators/operations.js
+++ b/src/plugins/validation/swagger2/semantic-validators/operations.js
@@ -8,7 +8,7 @@ const findIndex = require('lodash/findIndex');
 const findLastIndex = require('lodash/findLastIndex');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }) {
+module.exports.validate = function ({ resolvedSpec }) {
   const messages = new MessageCarrier();
 
   map(resolvedSpec.paths, (path, pathKey) => {
@@ -19,7 +19,7 @@ module.exports.validate = function({ resolvedSpec }) {
       'put',
       'patch',
       'delete',
-      'options'
+      'options',
     ]);
     each(pathOps, (op, opKey) => {
       if (!op) {

--- a/src/plugins/validation/swagger2/semantic-validators/parameters.js
+++ b/src/plugins/validation/swagger2/semantic-validators/parameters.js
@@ -5,7 +5,7 @@ const isPlainObject = require('lodash/isPlainObject');
 const { isParameterObject, walk } = require('../../../utils');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }) {
+module.exports.validate = function ({ resolvedSpec }) {
   const messages = new MessageCarrier();
 
   walk(resolvedSpec, [], (obj, path) => {

--- a/src/plugins/validation/swagger2/semantic-validators/schema.js
+++ b/src/plugins/validation/swagger2/semantic-validators/schema.js
@@ -1,7 +1,7 @@
 const each = require('lodash/each');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ resolvedSpec }) {
+module.exports.validate = function ({ resolvedSpec }) {
   const messages = new MessageCarrier();
 
   const schemas = [];
@@ -27,8 +27,8 @@ module.exports.validate = function({ resolvedSpec }) {
                   opName,
                   'parameters',
                   parameterIndex.toString(),
-                  'schema'
-                ]
+                  'schema',
+                ],
               });
             }
           });
@@ -44,8 +44,8 @@ module.exports.validate = function({ resolvedSpec }) {
                   opName,
                   'responses',
                   responseName,
-                  'schema'
-                ]
+                  'schema',
+                ],
               });
             }
           });

--- a/src/plugins/validation/swagger2/semantic-validators/security-definitions.js
+++ b/src/plugins/validation/swagger2/semantic-validators/security-definitions.js
@@ -9,7 +9,7 @@
 const isPlainObject = require('lodash/isPlainObject');
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec }) {
+module.exports.validate = function ({ jsSpec }) {
   const messages = new MessageCarrier();
 
   const API_KEY = 'apiKey';

--- a/src/plugins/validation/swagger2/semantic-validators/swagger.js
+++ b/src/plugins/validation/swagger2/semantic-validators/swagger.js
@@ -9,7 +9,7 @@
 
 const MessageCarrier = require('../../../utils/messageCarrier');
 
-module.exports.validate = function({ jsSpec }) {
+module.exports.validate = function ({ jsSpec }) {
   const messages = new MessageCarrier();
 
   const swagger = jsSpec.swagger;

--- a/src/spectral/rulesets/ibm-oas/check-major-version.js
+++ b/src/spectral/rulesets/ibm-oas/check-major-version.js
@@ -4,7 +4,7 @@
 // - Each path has a path segment of the form v followed by a number, and the number is
 //   the same for all paths
 
-module.exports = targetVal => {
+module.exports = (targetVal) => {
   if (targetVal === null || typeof targetVal !== 'object') {
     return;
   }
@@ -14,10 +14,10 @@ module.exports = targetVal => {
   if (oas3) {
     const servers = targetVal['servers'];
     if (servers && Array.isArray(servers)) {
-      const urls = servers.map(o => o['url']);
-      const versions = urls.map(url => getVersion(url));
+      const urls = servers.map((o) => o['url']);
+      const versions = urls.map((url) => getVersion(url));
 
-      if (versions.length > 1 && !versions.every(v => v === versions[0])) {
+      if (versions.length > 1 && !versions.every((v) => v === versions[0])) {
         const uniqueVersions = versions.filter(
           (val, i, self) => self.indexOf(val) === i
         );
@@ -26,8 +26,8 @@ module.exports = targetVal => {
             message:
               'Major version segments of urls in servers object do not match. Found ' +
               uniqueVersions.join(', '),
-            path: ['servers']
-          }
+            path: ['servers'],
+          },
         ];
       }
 
@@ -50,9 +50,9 @@ module.exports = targetVal => {
   const paths = targetVal['paths'];
   if (paths && typeof paths === 'object') {
     const urls = Object.keys(paths);
-    const versions = urls.map(url => getVersion(url));
+    const versions = urls.map((url) => getVersion(url));
 
-    if (versions.length > 1 && !versions.every(v => v === versions[0])) {
+    if (versions.length > 1 && !versions.every((v) => v === versions[0])) {
       const uniqueVersions = versions.filter(
         (val, i, self) => self.indexOf(val) === i
       );
@@ -61,8 +61,8 @@ module.exports = targetVal => {
           message:
             'Major version segments of paths object do not match. Found ' +
             uniqueVersions.join(', '),
-          path: ['paths']
-        }
+          path: ['paths'],
+        },
       ];
     }
 
@@ -76,14 +76,15 @@ module.exports = targetVal => {
     return [
       {
         message:
-          'Major version segment not present in either server URLs or paths'
-      }
+          'Major version segment not present in either server URLs or paths',
+      },
     ];
   } else {
     return [
       {
-        message: 'Major version segment not present in either basePath or paths'
-      }
+        message:
+          'Major version segment not present in either basePath or paths',
+      },
     ];
   }
 };
@@ -92,5 +93,5 @@ module.exports = targetVal => {
 function getVersion(path) {
   const url = new URL(path, 'https://foo.bar');
   const segments = url.pathname.split('/');
-  return segments.find(segment => segment.match(/v[0-9]+/));
+  return segments.find((segment) => segment.match(/v[0-9]+/));
 }

--- a/src/spectral/rulesets/ibm-oas/error-response-schema.js
+++ b/src/spectral/rulesets/ibm-oas/error-response-schema.js
@@ -1,12 +1,12 @@
-module.exports = function(errorResponseSchema, _opts, paths) {
+module.exports = function (errorResponseSchema, _opts, paths) {
   const errors = [];
   const rootPath = paths.target !== void 0 ? paths.target : paths.given;
   if (!schemaIsObjectWithProperties(errorResponseSchema)) {
     return [
       {
         message: 'Error response should be an object with properties',
-        path: rootPath
-      }
+        path: rootPath,
+      },
     ];
   } else {
     errors.push(
@@ -23,13 +23,13 @@ function validateErrorResponseProperties(errorResponseSchema, pathToSchema) {
   if (!hasTraceField(errorResponseProperties)) {
     errors.push({
       message: 'Error response should have a uuid `trace` field',
-      path: [...pathToProperties, 'trace']
+      path: [...pathToProperties, 'trace'],
     });
   }
   if (!validStatusCodeField(errorResponseProperties)) {
     errors.push({
       message: '`status_code` field must be an integer',
-      path: [...pathToProperties, 'status_code']
+      path: [...pathToProperties, 'status_code'],
     });
   }
   if (errorResponseProperties.errors) {
@@ -37,7 +37,7 @@ function validateErrorResponseProperties(errorResponseSchema, pathToSchema) {
     if (errorResponseProperties.errors.type !== 'array') {
       errors.push({
         message: '`errors` field should be an array of error models',
-        path: [...pathToProperties, 'errors']
+        path: [...pathToProperties, 'errors'],
       });
     } else {
       // `errors` is error model container, so validate the items
@@ -46,7 +46,7 @@ function validateErrorResponseProperties(errorResponseSchema, pathToSchema) {
         ...validateErrorModelSchema(errorResponseProperties.errors.items, [
           ...pathToProperties,
           'errors',
-          'items'
+          'items',
         ])
       );
     }
@@ -55,7 +55,7 @@ function validateErrorResponseProperties(errorResponseSchema, pathToSchema) {
     errors.push(
       ...validateErrorModelSchema(errorResponseProperties.error, [
         ...pathToProperties,
-        'error'
+        'error',
       ])
     );
   } else {
@@ -70,7 +70,7 @@ function validateErrorModelSchema(errorModelSchema, pathToSchema) {
   if (!schemaIsObjectWithProperties(errorModelSchema)) {
     errors.push({
       message: 'Error Model should be an object with properties',
-      path: pathToSchema
+      path: pathToSchema,
     });
   } else {
     // error model has properties, validate the properties
@@ -78,20 +78,20 @@ function validateErrorModelSchema(errorModelSchema, pathToSchema) {
       errors.push({
         message:
           'Error Model should contain `code` field, a snake-case, string error code',
-        path: [...pathToSchema, 'properties', 'code']
+        path: [...pathToSchema, 'properties', 'code'],
       });
     }
     if (!hasMessageField(errorModelSchema.properties)) {
       errors.push({
         message: 'Error Model should contain a string, `message`, field',
-        path: [...pathToSchema, 'properties', 'message']
+        path: [...pathToSchema, 'properties', 'message'],
       });
     }
     if (!hasMoreInfoField(errorModelSchema.properties)) {
       errors.push({
         message:
           'Error Model should contain `more_info` field that contains a URL with more info about the error',
-        path: [...pathToSchema, 'properties', 'more_info']
+        path: [...pathToSchema, 'properties', 'more_info'],
       });
     }
   }

--- a/src/spectral/rulesets/ibm-oas/response-example-provided.js
+++ b/src/spectral/rulesets/ibm-oas/response-example-provided.js
@@ -1,9 +1,9 @@
-module.exports = function(response) {
+module.exports = function (response) {
   if (!responseLevelExamples(response) && !schemaLevelExample(response)) {
     return [
       {
-        message: 'Response bodies should include an example response'
-      }
+        message: 'Response bodies should include an example response',
+      },
     ];
   }
 };

--- a/src/spectral/utils/spectral-validator.js
+++ b/src/spectral/utils/spectral-validator.js
@@ -9,7 +9,7 @@ const path = require('path');
 const defaultSpectralRulesetURI =
   __dirname + '/../rulesets/.defaultsForSpectral.yaml';
 
-const parseResults = function(results, debug) {
+const parseResults = function (results, debug) {
   const messages = new MessageCarrier();
 
   if (results) {
@@ -55,7 +55,7 @@ const parseResults = function(results, debug) {
 };
 
 // setup: registers the oas2/oas3 formats, and attempts to load the ruleset file
-const setup = async function(spectral, rulesetFileOverride, configObject) {
+const setup = async function (spectral, rulesetFileOverride, configObject) {
   if (!spectral) {
     const message =
       'Error (spectral-validator): An instance of spectral has not been initialized.';
@@ -105,7 +105,7 @@ function setupStaticAssets(staticAssets, defaultSpectralRulesetURI) {
 
   // register custom functions
   const customFunctionsDirURI = path.join(parentDirectory, 'ibm-oas');
-  fs.readdirSync(customFunctionsDirURI).forEach(function(customFunctionFile) {
+  fs.readdirSync(customFunctionsDirURI).forEach(function (customFunctionFile) {
     const customFunctionURI = path.join(
       customFunctionsDirURI,
       customFunctionFile
@@ -120,5 +120,5 @@ function setupStaticAssets(staticAssets, defaultSpectralRulesetURI) {
 
 module.exports = {
   parseResults,
-  setup
+  setup,
 };

--- a/test/cli-validator/mockFiles/err-warn-in-memory.js
+++ b/test/cli-validator/mockFiles/err-warn-in-memory.js
@@ -7,12 +7,12 @@ module.exports = {
     title: 'Swagger Petstore',
     termsOfService: 'http://swagger.io/terms/',
     contact: {
-      email: 'apiteam@swagger.io'
+      email: 'apiteam@swagger.io',
     },
     license: {
       name: 'Apache 2.0',
-      url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-    }
+      url: 'http://www.apache.org/licenses/LICENSE-2.0.html',
+    },
   },
   host: 'petstore.swagger.io',
   basePath: '/v2',
@@ -22,21 +22,21 @@ module.exports = {
       description: 'Everything about your Pets',
       externalDocs: {
         description: 'Find out more',
-        url: 'http://swagger.io'
-      }
+        url: 'http://swagger.io',
+      },
     },
     {
       name: 'store',
-      description: 'Access to Petstore orders'
+      description: 'Access to Petstore orders',
     },
     {
       name: 'user',
       description: 'Operations about user',
       externalDocs: {
         description: 'Find out more about our store',
-        url: 'http://swagger.io'
-      }
-    }
+        url: 'http://swagger.io',
+      },
+    },
   ],
   schemes: ['http'],
   paths: {
@@ -54,20 +54,20 @@ module.exports = {
             description: 'Pet object that needs to be added to the store',
             required: true,
             schema: {
-              $ref: '#/definitions/Pet'
-            }
-          }
+              $ref: '#/definitions/Pet',
+            },
+          },
         ],
         responses: {
-          '405': {
-            description: 'Invalid input'
-          }
+          405: {
+            description: 'Invalid input',
+          },
         },
         security: [
           {
-            petstore_auth: ['write:pets', 'read:pets']
-          }
-        ]
+            petstore_auth: ['write:pets', 'read:pets'],
+          },
+        ],
       },
       put: {
         tags: ['pet'],
@@ -82,27 +82,27 @@ module.exports = {
             description: 'Pet object that needs to be added to the store',
             required: true,
             schema: {
-              $ref: '#/definitions/Pet'
-            }
-          }
+              $ref: '#/definitions/Pet',
+            },
+          },
         ],
         responses: {
-          '400': {
-            description: 'Invalid ID supplied'
+          400: {
+            description: 'Invalid ID supplied',
           },
-          '404': {
-            description: 'Pet not found'
+          404: {
+            description: 'Pet not found',
           },
-          '405': {
-            description: 'Validation exception'
-          }
+          405: {
+            description: 'Validation exception',
+          },
         },
         security: [
           {
-            petstore_auth: ['write:pets', 'read:pets']
-          }
-        ]
-      }
+            petstore_auth: ['write:pets', 'read:pets'],
+          },
+        ],
+      },
     },
     '/pet/find_by_status': {
       get: {
@@ -122,32 +122,32 @@ module.exports = {
             items: {
               type: 'string',
               enum: ['available', 'pending', 'sold'],
-              default: 'available'
+              default: 'available',
             },
-            collectionFormat: 'multi'
-          }
+            collectionFormat: 'multi',
+          },
         ],
         responses: {
-          '200': {
+          200: {
             description: 'successful operation',
             schema: {
               type: 'array',
               items: {
-                $ref: '#/definitions/Pet'
-              }
-            }
+                $ref: '#/definitions/Pet',
+              },
+            },
           },
-          '400': {
-            description: 'Invalid status value'
-          }
+          400: {
+            description: 'Invalid status value',
+          },
         },
         security: [
           {
-            petstore_auth: ['write:pets', 'read:pets']
-          }
-        ]
-      }
-    }
+            petstore_auth: ['write:pets', 'read:pets'],
+          },
+        ],
+      },
+    },
   },
   securityDefinitions: {
     petstore_auth: {
@@ -156,14 +156,14 @@ module.exports = {
       flow: 'implicit',
       scopes: {
         'write:pets': 'modify pets in your account',
-        'read:pets': 'read your pets'
-      }
+        'read:pets': 'read your pets',
+      },
     },
     api_key: {
       type: 'apiKey',
       name: 'api_key',
-      in: 'header'
-    }
+      in: 'header',
+    },
   },
   definitions: {
     Category: {
@@ -171,16 +171,16 @@ module.exports = {
       properties: {
         id: {
           type: 'integer',
-          format: 'int64'
+          format: 'int64',
         },
         name: {
           type: 'string',
-          description: 'string'
-        }
+          description: 'string',
+        },
       },
       xml: {
-        name: 'Category'
-      }
+        name: 'Category',
+      },
     },
     Tag: {
       type: 'object',
@@ -188,16 +188,16 @@ module.exports = {
         id: {
           type: 'integer',
           format: 'int64',
-          description: 'string'
+          description: 'string',
         },
         name: {
           type: 'string',
-          description: 'string'
-        }
+          description: 'string',
+        },
       },
       xml: {
-        name: 'Tag'
-      }
+        name: 'Tag',
+      },
     },
     Pet: {
       type: 'object',
@@ -206,51 +206,51 @@ module.exports = {
         id: {
           type: 'integer',
           format: 'int64',
-          description: 'string'
+          description: 'string',
         },
         category: {
-          $ref: '#/definitions/Category'
+          $ref: '#/definitions/Category',
         },
         name: {
           type: 'string',
           example: 'doggie',
-          description: 'string'
+          description: 'string',
         },
         photoUrls: {
           type: 'array',
           description: 'string',
           xml: {
             name: 'photoUrl',
-            wrapped: true
+            wrapped: true,
           },
           items: {
-            type: 'string'
-          }
+            type: 'string',
+          },
         },
         tags: {
           type: 'array',
           description: 'string',
           xml: {
             name: 'tag',
-            wrapped: true
+            wrapped: true,
           },
           items: {
-            $ref: '#/definitions/Tag'
-          }
+            $ref: '#/definitions/Tag',
+          },
         },
         status: {
           type: 'string',
           description: 'pet status in the store',
-          enum: ['available', 'pending', 'sold']
-        }
+          enum: ['available', 'pending', 'sold'],
+        },
       },
       xml: {
-        name: 'Pet'
-      }
-    }
+        name: 'Pet',
+      },
+    },
   },
   externalDocs: {
     description: 'Find out more about Swagger',
-    url: 'http://swagger.io'
-  }
+    url: 'http://swagger.io',
+  },
 };

--- a/test/cli-validator/tests/circular-refs-validator.test.js
+++ b/test/cli-validator/tests/circular-refs-validator.test.js
@@ -2,8 +2,8 @@ const commandLineValidator = require('../../../src/cli-validator/runValidator');
 const circularRefsValidator = require('../../../src/cli-validator/utils/circular-references-ibm');
 const { getCapturedText } = require('../../test-utils');
 
-describe('cli tool - test circular reference module', function() {
-  it('should correctly validate a file with circular references', async function() {
+describe('cli tool - test circular reference module', function () {
+  it('should correctly validate a file with circular references', async function () {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
     const program = {};
@@ -30,12 +30,12 @@ describe('cli tool - test circular reference module', function() {
     ).toEqual(true);
   });
 
-  it('should correct an arbitrary object with cyclic paths', function() {
+  it('should correct an arbitrary object with cyclic paths', function () {
     const testObject = {};
     const nestedObject = {
       foo: {
-        bar: testObject
-      }
+        bar: testObject,
+      },
     };
     testObject.key = nestedObject;
 
@@ -43,20 +43,20 @@ describe('cli tool - test circular reference module', function() {
     expect(paths[0].join('.')).toEqual('key.foo.bar');
   });
 
-  it('should correctly convert a resolved path to a real one using refs', function() {
+  it('should correctly convert a resolved path to a real one using refs', function () {
     const testObject = {
       first: {
         second: {
-          $ref: '#/definitions/something'
-        }
+          $ref: '#/definitions/something',
+        },
       },
       definitions: {
         something: {
           foo: {
-            $ref: '#/definitions/something'
-          }
-        }
-      }
+            $ref: '#/definitions/something',
+          },
+        },
+      },
     };
 
     const resolvedPaths = [['first', 'second', 'foo']];
@@ -64,7 +64,7 @@ describe('cli tool - test circular reference module', function() {
     expect(realPath[0]).toEqual('definitions.something.foo');
   });
 
-  it('should correctly validate a file using the composite pattern', async function() {
+  it('should correctly validate a file using the composite pattern', async function () {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
     const program = {};

--- a/test/cli-validator/tests/config-file-validator.test.js
+++ b/test/cli-validator/tests/config-file-validator.test.js
@@ -9,7 +9,7 @@ const { defaults, options } = require('../../../src/.defaultsForValidator');
 const configFileValidator = require('../../../src/cli-validator/utils/processConfiguration')
   .validate;
 
-describe('cli tool - test config file validator', function() {
+describe('cli tool - test config file validator', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('cli tool - test config file validator', function() {
     consoleSpy.mockRestore();
   });
 
-  it('should print no errors with a clean config object', function() {
+  it('should print no errors with a clean config object', function () {
     // defaults should not throw any errors in the validator
     const config = defaults;
 
@@ -31,23 +31,23 @@ describe('cli tool - test config file validator', function() {
     expect(capturedText.length).toEqual(0);
   });
 
-  it('should print an error for an unsupported spec', function() {
+  it('should print an error for an unsupported spec', function () {
     const config = {
       openApi4: {
         operations: {
           no_operation_id: 'warning',
           no_summary: 'warning',
-          no_array_responses: 'error'
+          no_array_responses: 'error',
         },
         nonValidCategory: {
           no_parameter_description: 'error',
           snake_case_only: 'warning',
-          invalid_type_format_pair: 'error'
+          invalid_type_format_pair: 'error',
         },
         walker: {
-          no_empty_descriptions: 'error'
-        }
-      }
+          no_empty_descriptions: 'error',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -62,23 +62,23 @@ describe('cli tool - test config file validator', function() {
     );
   });
 
-  it('should print an error for an unsupported category', function() {
+  it('should print an error for an unsupported category', function () {
     const config = {
       shared: {
         operations: {
           no_operation_id: 'warning',
           no_summary: 'warning',
-          no_array_responses: 'error'
+          no_array_responses: 'error',
         },
         nonValidCategory: {
           no_parameter_description: 'error',
           snake_case_only: 'warning',
-          invalid_type_format_pair: 'error'
+          invalid_type_format_pair: 'error',
         },
         walker: {
-          no_empty_descriptions: 'error'
-        }
-      }
+          no_empty_descriptions: 'error',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -93,23 +93,23 @@ describe('cli tool - test config file validator', function() {
     );
   });
 
-  it('should print an error for an unsupported rule name', function() {
+  it('should print an error for an unsupported rule name', function () {
     const config = {
       shared: {
         operations: {
           nonValidRule: 'error',
           no_operation_id: 'warning',
           no_summary: 'warning',
-          no_array_responses: 'error'
+          no_array_responses: 'error',
         },
         parameters: {
           no_parameter_description: 'error',
-          invalid_type_format_pair: 'error'
+          invalid_type_format_pair: 'error',
         },
         walker: {
-          no_empty_descriptions: 'error'
-        }
-      }
+          no_empty_descriptions: 'error',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -124,15 +124,15 @@ describe('cli tool - test config file validator', function() {
     );
   });
 
-  it('should print an error for an unsupported rule status', function() {
+  it('should print an error for an unsupported rule status', function () {
     const config = {
       swagger2: {
         operations: {
           no_consumes_for_put_or_post: 'error',
           get_op_has_consumes: 'warning',
-          no_produces: 'nonValidStatus'
-        }
-      }
+          no_produces: 'nonValidStatus',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -147,15 +147,15 @@ describe('cli tool - test config file validator', function() {
     );
   });
 
-  it('should fill in default values for rules that are not included', function() {
+  it('should fill in default values for rules that are not included', function () {
     const config = {
       shared: {
         operations: {
           no_operation_id: 'warning',
           no_summary: 'warning',
-          no_array_responses: 'error'
-        }
-      }
+          no_array_responses: 'error',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -170,15 +170,15 @@ describe('cli tool - test config file validator', function() {
     expect(defaultSchemas).toEqual(configSchemas);
   });
 
-  it('should print no errors with a config object that includes a deprecated rule', function() {
+  it('should print no errors with a config object that includes a deprecated rule', function () {
     const config = {
       swagger2: {
         operations: {
           no_consumes_for_put_or_post: 'error',
           get_op_has_consumes: 'warning',
-          no_produces_for_get: 'warning'
-        }
-      }
+          no_produces_for_get: 'warning',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -192,15 +192,15 @@ describe('cli tool - test config file validator', function() {
   });
 
   // deprecated rule with the period in it
-  it('should print no errors with a config object that includes a nested deprecated rule', function() {
+  it('should print no errors with a config object that includes a nested deprecated rule', function () {
     const config = {
       shared: {
         parameters: {
           snake_case_only: 'error',
           content_type_parameter: 'error',
-          accept_type_parameter: 'error'
-        }
-      }
+          accept_type_parameter: 'error',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -214,13 +214,13 @@ describe('cli tool - test config file validator', function() {
   });
 
   // just a string when supposed to be an array, corrects the array when string is valid
-  it('should create array when given a valid status string for rules with config options', function() {
+  it('should create array when given a valid status string for rules with config options', function () {
     const config = {
       shared: {
         parameters: {
-          param_name_case_convention: 'error'
-        }
-      }
+          param_name_case_convention: 'error',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -237,13 +237,13 @@ describe('cli tool - test config file validator', function() {
   });
 
   // just a string when supposed to be an array, throws error when string is invalid
-  it('should error when given an invalid status string for rules with config options', function() {
+  it('should error when given an invalid status string for rules with config options', function () {
     const config = {
       shared: {
         parameters: {
-          param_name_case_convention: 'snake_case'
-        }
-      }
+          param_name_case_convention: 'snake_case',
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -259,13 +259,13 @@ describe('cli tool - test config file validator', function() {
   });
 
   // handles empty array
-  it('should error when given an empty array for rules with config options', function() {
+  it('should error when given an empty array for rules with config options', function () {
     const config = {
       shared: {
         parameters: {
-          param_name_case_convention: []
-        }
-      }
+          param_name_case_convention: [],
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -281,13 +281,13 @@ describe('cli tool - test config file validator', function() {
   });
 
   // handles array with one value that is valid
-  it('should not error when given an array with one valid status for a rule with config options', function() {
+  it('should not error when given an array with one valid status for a rule with config options', function () {
     const config = {
       shared: {
         parameters: {
-          param_name_case_convention: ['error']
-        }
-      }
+          param_name_case_convention: ['error'],
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -301,13 +301,13 @@ describe('cli tool - test config file validator', function() {
   });
 
   // handles array with only one value that is not valid
-  it('should error when given an array with one invalid status for rule with config options', function() {
+  it('should error when given an array with one invalid status for rule with config options', function () {
     const config = {
       shared: {
         parameters: {
-          param_name_case_convention: ['camel_case']
-        }
-      }
+          param_name_case_convention: ['camel_case'],
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -322,13 +322,13 @@ describe('cli tool - test config file validator', function() {
     );
   });
 
-  it('should error when given an array for rules without config options', function() {
+  it('should error when given an array for rules without config options', function () {
     const config = {
       shared: {
         parameters: {
-          no_parameter_description: ['error', 'camel_case']
-        }
-      }
+          no_parameter_description: ['error', 'camel_case'],
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);
@@ -343,13 +343,13 @@ describe('cli tool - test config file validator', function() {
     );
   });
 
-  it('should error when given an invalid config option', function() {
+  it('should error when given an invalid config option', function () {
     const config = {
       shared: {
         parameters: {
-          param_name_case_convention: ['error', 'nowordseparatorscase']
-        }
-      }
+          param_name_case_convention: ['error', 'nowordseparatorscase'],
+        },
+      },
     };
 
     const res = configFileValidator(config, chalk);

--- a/test/cli-validator/tests/error-handling.test.js
+++ b/test/cli-validator/tests/error-handling.test.js
@@ -4,7 +4,7 @@ const { getCapturedText } = require('../../test-utils');
 // for an explanation of the text interceptor, see the comments for the
 // first test in expectedOutput.js
 
-describe('cli tool - test error handling', function() {
+describe('cli tool - test error handling', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('cli tool - test error handling', function() {
     consoleSpy.mockRestore();
   });
 
-  const helpMessage = function() {
+  const helpMessage = function () {
     console.log('\n  Usage: validate-swagger [options] <file>\n\n');
     console.log('  Options:\n');
     console.log(
@@ -25,7 +25,7 @@ describe('cli tool - test error handling', function() {
     console.log('    -h, --help                     output usage information');
   };
 
-  it('should return an error when there is no filename given', async function() {
+  it('should return an error when there is no filename given', async function () {
     const program = {};
     program.args = [];
     program.default_mode = true;
@@ -57,7 +57,7 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when there is no file extension', async function() {
+  it('should return an error when there is no file extension', async function () {
     const program = {};
     program.args = ['json'];
     program.default_mode = true;
@@ -85,7 +85,7 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when there is an invalid file extension', async function() {
+  it('should return an error when there is an invalid file extension', async function () {
     const program = {};
     program.args = ['badExtension.jsob'];
     program.default_mode = true;
@@ -113,7 +113,7 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when a file contains an invalid object', async function() {
+  it('should return an error when a file contains an invalid object', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/bad-json.json'];
     program.default_mode = true;
@@ -137,7 +137,7 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when a json file has duplicated key mappings', async function() {
+  it('should return an error when a json file has duplicated key mappings', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/duplicate-keys.json'];
     program.default_mode = true;
@@ -161,7 +161,7 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when the swagger contains a reference to a missing object', async function() {
+  it('should return an error when the swagger contains a reference to a missing object', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/missing-object.yml'];
     program.default_mode = true;
@@ -185,7 +185,7 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when the swagger contains a trailing comma', async function() {
+  it('should return an error when the swagger contains a trailing comma', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/trailing-comma.json'];
     program.default_mode = true;

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -9,7 +9,7 @@ const count = (array, regex) => {
   return array.reduce((a, v) => (v.match(regex) ? a + 1 : a), 0);
 };
 
-describe('cli tool - test expected output - Swagger 2', function() {
+describe('cli tool - test expected output - Swagger 2', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     consoleSpy.mockRestore();
   });
 
-  it('should not produce any errors or warnings from mockFiles/clean.yml', async function() {
+  it('should not produce any errors or warnings from mockFiles/clean.yml', async function () {
     // set up mock user input
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/clean.yml'];
@@ -37,7 +37,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(capturedText[1].trim()).toEqual('');
   });
 
-  it('should produce errors, then warnings from mockFiles/err-and-warn.yaml', async function() {
+  it('should produce errors, then warnings from mockFiles/err-and-warn.yaml', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.default_mode = true;
@@ -49,7 +49,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
 
     expect(exitCode).toEqual(1);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       if (line.includes('errors')) {
         whichProblems.push('errors');
       }
@@ -62,7 +62,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(whichProblems[1]).toEqual('warnings');
   });
 
-  it('should display the associated rule with each error and warning', async function() {
+  it('should display the associated rule with each error and warning', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.default_mode = true;
@@ -78,7 +78,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(messageCount).toEqual(ruleCount);
   });
 
-  it('should include the validator version in JSON output', async function() {
+  it('should include the validator version in JSON output', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/clean.yml'];
     program.default_mode = true;
@@ -94,7 +94,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(jsonOutput.version).toBe(expectedValidatorVersion);
   });
 
-  it('should include the validator version in JSON output for the inCodeValidator', async function() {
+  it('should include the validator version in JSON output for the inCodeValidator', async function () {
     const content = fs
       .readFileSync('./test/cli-validator/mockFiles/clean.yml')
       .toString();
@@ -108,7 +108,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(validationResults.version).toBe(expectedValidatorVersion);
   });
 
-  it('should include the associated rule with each error and warning in JSON output', async function() {
+  it('should include the associated rule with each error and warning in JSON output', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.default_mode = true;
@@ -132,10 +132,10 @@ describe('cli tool - test expected output - Swagger 2', function() {
       []
     );
 
-    allMessages.forEach(msg => expect(msg).toHaveProperty('rule'));
+    allMessages.forEach((msg) => expect(msg).toHaveProperty('rule'));
   });
 
-  it('should include the associated rule in return value of in-memory validator', async function() {
+  it('should include the associated rule in return value of in-memory validator', async function () {
     const content = fs
       .readFileSync('./test/cli-validator/mockFiles/err-and-warn.yaml')
       .toString();
@@ -149,13 +149,15 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 
-    validationResults.errors.forEach(msg => expect(msg).toHaveProperty('rule'));
-    validationResults.warnings.forEach(msg =>
+    validationResults.errors.forEach((msg) =>
+      expect(msg).toHaveProperty('rule')
+    );
+    validationResults.warnings.forEach((msg) =>
       expect(msg).toHaveProperty('rule')
     );
   });
 
-  it('should print the correct line numbers for each error/warning', async function() {
+  it('should print the correct line numbers for each error/warning', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.default_mode = true;
@@ -186,7 +188,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(capturedText[53].match(/\S+/g)[2]).toEqual('126');
   });
 
-  it('should return exit code of 0 if there are only warnings', async function() {
+  it('should return exit code of 0 if there are only warnings', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/just-warn.yml'];
     program.default_mode = true;
@@ -200,12 +202,12 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(allOutput.includes('warnings')).toEqual(true);
   });
 
-  it('should handle an array of file names', async function() {
+  it('should handle an array of file names', async function () {
     const program = {};
     program.args = [
       './test/cli-validator/mockFiles/err-and-warn.yaml',
       'notAFile.json',
-      './test/cli-validator/mockFiles/clean.yml'
+      './test/cli-validator/mockFiles/clean.yml',
     ];
     program.default_mode = true;
 
@@ -233,7 +235,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     ).toEqual(true);
   });
 
-  it('should return errors and warnings using the in-memory module', async function() {
+  it('should return errors and warnings using the in-memory module', async function () {
     const defaultMode = true;
     const validationResults = await inCodeValidator(
       swaggerInMemory,
@@ -246,7 +248,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(validationResults.warnings.length).toBeGreaterThan(0);
   });
 
-  it('should not produce any errors or warnings from mockFiles/clean-with-tabs.yml', async function() {
+  it('should not produce any errors or warnings from mockFiles/clean-with-tabs.yml', async function () {
     // set up mock user input
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/clean-with-tabs.yml'];
@@ -264,7 +266,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
   });
 });
 
-describe('test expected output - OpenAPI 3', function() {
+describe('test expected output - OpenAPI 3', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -275,7 +277,7 @@ describe('test expected output - OpenAPI 3', function() {
     consoleSpy.mockRestore();
   });
 
-  it('should not produce any errors or warnings from a clean file', async function() {
+  it('should not produce any errors or warnings from a clean file', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/oas3/clean.yml'];
     program.default_mode = true;
@@ -291,7 +293,7 @@ describe('test expected output - OpenAPI 3', function() {
     );
   });
 
-  it('should catch problems in a multi-file spec from an outside directory', async function() {
+  it('should catch problems in a multi-file spec from an outside directory', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/multi-file-spec/main.yaml'];
     program.default_mode = true;
@@ -310,7 +312,7 @@ describe('test expected output - OpenAPI 3', function() {
     );
   });
 
-  it('should display the associated rule with each error and warning', async function() {
+  it('should display the associated rule with each error and warning', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/oas3/err-and-warn.yaml'];
     program.default_mode = true;
@@ -326,7 +328,7 @@ describe('test expected output - OpenAPI 3', function() {
     expect(messageCount).toEqual(ruleCount);
   });
 
-  it('should include the associated rule with each error and warning in JSON output', async function() {
+  it('should include the associated rule with each error and warning in JSON output', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/oas3/err-and-warn.yaml'];
     program.default_mode = true;
@@ -350,10 +352,10 @@ describe('test expected output - OpenAPI 3', function() {
       []
     );
 
-    allMessages.forEach(msg => expect(msg).toHaveProperty('rule'));
+    allMessages.forEach((msg) => expect(msg).toHaveProperty('rule'));
   });
 
-  it('should include the associated rule in return value of in-memory validator', async function() {
+  it('should include the associated rule in return value of in-memory validator', async function () {
     const content = fs
       .readFileSync('./test/cli-validator/mockFiles/oas3/err-and-warn.yaml')
       .toString();
@@ -367,13 +369,15 @@ describe('test expected output - OpenAPI 3', function() {
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 
-    validationResults.errors.forEach(msg => expect(msg).toHaveProperty('rule'));
-    validationResults.warnings.forEach(msg =>
+    validationResults.errors.forEach((msg) =>
+      expect(msg).toHaveProperty('rule')
+    );
+    validationResults.warnings.forEach((msg) =>
       expect(msg).toHaveProperty('rule')
     );
   });
 
-  it('should include the path to the component (if it exists) when in verbose mode', async function() {
+  it('should include the path to the component (if it exists) when in verbose mode', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/oas3/testoneof.yaml'];
     program.default_mode = true;
@@ -388,7 +392,7 @@ describe('test expected output - OpenAPI 3', function() {
     expect(allText).toContain('Component Line');
   });
 
-  it('should include the path to the component (if it exists) when in verbose mode and json mode', async function() {
+  it('should include the path to the component (if it exists) when in verbose mode and json mode', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/oas3/testoneof.yaml'];
     program.default_mode = true;
@@ -405,7 +409,7 @@ describe('test expected output - OpenAPI 3', function() {
       'responses',
       'Ok',
       'content',
-      'application/json'
+      'application/json',
     ]);
     expect(jsonOutput.warnings[4].componentLine).toEqual(6);
   });

--- a/test/cli-validator/tests/info-and-hint.test.js
+++ b/test/cli-validator/tests/info-and-hint.test.js
@@ -4,8 +4,8 @@ const { getCapturedText } = require('../../test-utils');
 
 const defaultConfig = require('../../../src/.defaultsForValidator').defaults;
 
-describe('test info and hint rules - OAS3', function() {
-  it('test info and hint rules', async function() {
+describe('test info and hint rules - OAS3', function () {
+  it('test info and hint rules', async function () {
     // Create custom config with some info and hint settings
     const customConfig = JSON.parse(JSON.stringify(defaultConfig));
     customConfig['shared']['schemas']['no_schema_description'] = 'info';

--- a/test/cli-validator/tests/option-handling.test.js
+++ b/test/cli-validator/tests/option-handling.test.js
@@ -3,13 +3,13 @@ const commandLineValidator = require('../../../src/cli-validator/runValidator');
 const modifiedCommander = require('../../../src/cli-validator/utils/modified-commander');
 const {
   getCapturedText,
-  getCapturedTextWithColor
+  getCapturedTextWithColor,
 } = require('../../test-utils');
 
 // for an explanation of the text interceptor,
 // see the comments for the first test in expectedOutput.js
 
-describe('cli tool - test option handling', function() {
+describe('cli tool - test option handling', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('cli tool - test option handling', function() {
     consoleSpy.mockRestore();
   });
 
-  it('should color output by default @skip-ci', async function() {
+  it('should color output by default @skip-ci', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.default_mode = true;
@@ -28,14 +28,14 @@ describe('cli tool - test option handling', function() {
     await commandLineValidator(program);
     const capturedText = getCapturedTextWithColor(consoleSpy.mock.calls);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       if (line !== '\n') {
         expect(line).not.toEqual(stripAnsiFrom(line));
       }
     });
   });
 
-  it('should not color output when -n option is given', async function() {
+  it('should not color output when -n option is given', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.no_colors = true;
@@ -44,12 +44,12 @@ describe('cli tool - test option handling', function() {
     await commandLineValidator(program);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       expect(line).toEqual(stripAnsiFrom(line));
     });
   });
 
-  it('should not print validator source file by default', async function() {
+  it('should not print validator source file by default', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.default_mode = true;
@@ -57,12 +57,12 @@ describe('cli tool - test option handling', function() {
     await commandLineValidator(program);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       expect(line.includes('Validator')).toEqual(false);
     });
   });
 
-  it('should print validator source file when -p option is given', async function() {
+  it('should print validator source file when -p option is given', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.print_validator_modules = true;
@@ -73,7 +73,7 @@ describe('cli tool - test option handling', function() {
 
     let validatorsPrinted = false;
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       if (line.includes('Validator')) {
         validatorsPrinted = true;
       }
@@ -82,7 +82,7 @@ describe('cli tool - test option handling', function() {
     expect(validatorsPrinted).toEqual(true);
   });
 
-  it('should print only errors when the -e command is given', async function() {
+  it('should print only errors when the -e command is given', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.errors_only = true;
@@ -91,12 +91,12 @@ describe('cli tool - test option handling', function() {
     await commandLineValidator(program);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       expect(line.includes('warnings')).toEqual(false);
     });
   });
 
-  it('should print correct statistics report when -s option is given', async function() {
+  it('should print correct statistics report when -s option is given', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.report_statistics = true;
@@ -107,7 +107,7 @@ describe('cli tool - test option handling', function() {
 
     let statisticsReported = false;
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       if (line.includes('statistics')) {
         statisticsReported = true;
       }
@@ -117,7 +117,9 @@ describe('cli tool - test option handling', function() {
     //   example output would be [ '33%', ':', 'operationIds', 'must', 'be', 'unique' ]
     expect(statisticsReported).toEqual(true);
 
-    const statsSection = capturedText.findIndex(x => x.includes('statistics'));
+    const statsSection = capturedText.findIndex((x) =>
+      x.includes('statistics')
+    );
 
     // totals
     expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('5');
@@ -156,7 +158,7 @@ describe('cli tool - test option handling', function() {
     expect(capturedText[statsSection + 16].match(/\S+/g)[1]).toEqual('(13%)');
   });
 
-  it('should not print statistics report by default', async function() {
+  it('should not print statistics report by default', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.default_mode = true;
@@ -164,12 +166,12 @@ describe('cli tool - test option handling', function() {
     await commandLineValidator(program);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       expect(line.includes('statistics')).toEqual(false);
     });
   });
 
-  it('should print json output when -j option is given', async function() {
+  it('should print json output when -j option is given', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.json = true;
@@ -194,7 +196,7 @@ describe('cli tool - test option handling', function() {
     );
   });
 
-  it('should print only errors as json output when -j -e option is given', async function() {
+  it('should print only errors as json output when -j -e option is given', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/err-and-warn.yaml'];
     program.json = true;
@@ -209,7 +211,7 @@ describe('cli tool - test option handling', function() {
     expect(outputObject.warnings).toEqual(undefined);
   });
 
-  it('should change output for overridden options when config file is manually specified', async function() {
+  it('should change output for overridden options when config file is manually specified', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/just-warn.yml'];
     program.config =
@@ -226,7 +228,7 @@ describe('cli tool - test option handling', function() {
     let inErrorBlock = false;
     let inWarningBlock = false;
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       if (line.includes('errors')) {
         inErrorBlock = true;
         inWarningBlock = false;
@@ -245,7 +247,7 @@ describe('cli tool - test option handling', function() {
     expect(errorCount).toEqual(3); // without the config this value is 0
   });
 
-  it('should return an error and usage menu when there is an unknown option', async function() {
+  it('should return an error and usage menu when there is an unknown option', async function () {
     const noop = () => {};
     const errorStub = jest.spyOn(console, 'error').mockImplementation(noop);
     const exitStub = jest.spyOn(process, 'exit').mockImplementation(noop);

--- a/test/cli-validator/tests/threshold-validator.test.js
+++ b/test/cli-validator/tests/threshold-validator.test.js
@@ -4,7 +4,7 @@
 const commandLineValidator = require('../../../src/cli-validator/runValidator');
 const { getCapturedText } = require('../../test-utils');
 
-describe('test the .thresholdrc limits', function() {
+describe('test the .thresholdrc limits', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('test the .thresholdrc limits', function() {
     consoleSpy.mockRestore();
   });
 
-  it('should show error and set exit code to 1 when warning limit exceeded', async function() {
+  it('should show error and set exit code to 1 when warning limit exceeded', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/circular-refs.yml'];
     program.limits =
@@ -30,7 +30,7 @@ describe('test the .thresholdrc limits', function() {
     expect(capturedText[2].slice(14, 32)).toEqual(`Number of warnings`);
   });
 
-  it('should print errors for unsupported limit options and invalid limit values', async function() {
+  it('should print errors for unsupported limit options and invalid limit values', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/clean.yml'];
     program.limits =
@@ -52,7 +52,7 @@ describe('test the .thresholdrc limits', function() {
     expect(allOutput.includes('Value provided for warnings')).toEqual(true);
   });
 
-  it('should give exit code 0 when warnings limit not exceeded', async function() {
+  it('should give exit code 0 when warnings limit not exceeded', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/clean.yml'];
     program.limits =
@@ -64,7 +64,7 @@ describe('test the .thresholdrc limits', function() {
     expect(exitCode).toEqual(0);
   });
 
-  it('should give an error for invalid JSON', async function() {
+  it('should give an error for invalid JSON', async function () {
     const program = {};
     program.args = ['./test/cli-validator/mockFiles/clean.yml'];
     program.limits =

--- a/test/cli-validator/tests/utils/addPathsToComponents.test.js
+++ b/test/cli-validator/tests/utils/addPathsToComponents.test.js
@@ -1,21 +1,21 @@
 const addPathsToComponents = require('../../../../src/cli-validator/utils/addPathsToComponents');
 
-describe('test postprocessing util - test component path finding', function() {
-  it('should correctly add component paths', function() {
+describe('test postprocessing util - test component path finding', function () {
+  it('should correctly add component paths', function () {
     const unresolvedSpec = {
       paths: {
         '/path1': {
           get: {
             responses: {
-              '200': {
-                $ref: '#/components/responses/GenericResponse'
+              200: {
+                $ref: '#/components/responses/GenericResponse',
               },
-              '201': {
-                $ref: '#/components/responses/GenericResponse'
-              }
-            }
-          }
-        }
+              201: {
+                $ref: '#/components/responses/GenericResponse',
+              },
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -23,23 +23,23 @@ describe('test postprocessing util - test component path finding', function() {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/GenericSchema'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/GenericSchema',
+                },
+              },
+            },
+          },
         },
         schemas: {
           GenericSchema: {
             type: 'object',
             properties: {
               stringProp: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      }
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     };
     // mimicing errors from a resolved spec
     const originalResults = {
@@ -49,16 +49,16 @@ describe('test postprocessing util - test component path finding', function() {
             message: 'simple error message',
             path:
               'paths./path1.get.responses.200.content.application/json.schema.properties.stringProp',
-            rule: 'made_up_rule'
+            rule: 'made_up_rule',
           },
           {
             message: 'simple error message',
             path:
               'paths./path1.get.responses.201.content.application/json.schema.properties.stringProp',
-            rule: 'made_up_rule'
-          }
-        ]
-      }
+            rule: 'made_up_rule',
+          },
+        ],
+      },
     };
     addPathsToComponents(originalResults, unresolvedSpec);
     const errors = originalResults.errors['validator-name'];
@@ -68,27 +68,27 @@ describe('test postprocessing util - test component path finding', function() {
       'schemas',
       'GenericSchema',
       'properties',
-      'stringProp'
+      'stringProp',
     ]);
     expect(errors[1].componentPath).toEqual([
       'components',
       'schemas',
       'GenericSchema',
       'properties',
-      'stringProp'
+      'stringProp',
     ]);
   });
 
-  it('should correctly add component paths when an array index is in the path', function() {
+  it('should correctly add component paths when an array index is in the path', function () {
     const unresolvedSpec = {
       paths: {
         '/path1': {
           post: {
             requestBody: {
-              $ref: '#/components/requestBodies/OneOfRequest'
-            }
-          }
-        }
+              $ref: '#/components/requestBodies/OneOfRequest',
+            },
+          },
+        },
       },
       components: {
         requestBodies: {
@@ -96,41 +96,41 @@ describe('test postprocessing util - test component path finding', function() {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/OneOfSchema'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/OneOfSchema',
+                },
+              },
+            },
+          },
         },
         schemas: {
           OneOfSchema: {
             oneOf: [
               {
-                $ref: '#/components/schemas/Cat'
+                $ref: '#/components/schemas/Cat',
               },
               {
-                $ref: '#/components/schemas/Dog'
-              }
-            ]
+                $ref: '#/components/schemas/Dog',
+              },
+            ],
           },
           Cat: {
             type: 'object',
             properties: {
               meows: {
-                type: 'boolean'
-              }
-            }
+                type: 'boolean',
+              },
+            },
           },
           Dog: {
             type: 'object',
             properties: {
               barks: {
-                type: 'boolean'
-              }
-            }
-          }
-        }
-      }
+                type: 'boolean',
+              },
+            },
+          },
+        },
+      },
     };
     // mimicing errors from a resolved spec
     const originalResults = {
@@ -140,7 +140,7 @@ describe('test postprocessing util - test component path finding', function() {
             message: 'simple error message',
             path:
               'paths./path1.post.requestBody.content.application/json.schema.oneOf.0.properties.meows',
-            rule: 'made_up_rule'
+            rule: 'made_up_rule',
           },
           {
             message: 'simple error message with array path',
@@ -155,9 +155,9 @@ describe('test postprocessing util - test component path finding', function() {
               'oneOf',
               '0',
               'properties',
-              'meows'
+              'meows',
             ],
-            rule: 'made_up_rule'
+            rule: 'made_up_rule',
           },
           {
             message: 'simple error message with array path with a number index',
@@ -172,12 +172,12 @@ describe('test postprocessing util - test component path finding', function() {
               'oneOf',
               0,
               'properties',
-              'meows'
+              'meows',
             ],
-            rule: 'made_up_rule'
-          }
-        ]
-      }
+            rule: 'made_up_rule',
+          },
+        ],
+      },
     };
     addPathsToComponents(originalResults, unresolvedSpec);
     const errors = originalResults.errors['validator-name'];
@@ -187,50 +187,50 @@ describe('test postprocessing util - test component path finding', function() {
       'schemas',
       'Cat',
       'properties',
-      'meows'
+      'meows',
     ]);
     expect(errors[1].componentPath).toEqual([
       'components',
       'schemas',
       'Cat',
       'properties',
-      'meows'
+      'meows',
     ]);
     expect(errors[2].componentPath).toEqual([
       'components',
       'schemas',
       'Cat',
       'properties',
-      'meows'
+      'meows',
     ]);
   });
 
-  it('should not add a component path when the error path is invalid', function() {
+  it('should not add a component path when the error path is invalid', function () {
     const unresolvedSpec = {
       paths: {
         '/path1': {
           get: {
             responses: {
-              '200': {
+              200: {
                 content: {
                   'application/json': {
                     schema: {
-                      $ref: '#/components/schemas/GenericSchema'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      $ref: '#/components/schemas/GenericSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         schemas: {
           GenericSchema: {
-            type: 'string'
-          }
-        }
-      }
+            type: 'string',
+          },
+        },
+      },
     };
     // invalid error path
     const originalResults = {
@@ -240,10 +240,10 @@ describe('test postprocessing util - test component path finding', function() {
             message: 'simple error message',
             path:
               'paths./path1.get.requestBody.content.application/json.schema',
-            rule: 'made_up_rule'
-          }
-        ]
-      }
+            rule: 'made_up_rule',
+          },
+        ],
+      },
     };
     addPathsToComponents(originalResults, unresolvedSpec);
     const errors = originalResults.errors['validator-name'];
@@ -251,24 +251,24 @@ describe('test postprocessing util - test component path finding', function() {
     expect(errors[0].componentPath).toBeUndefined();
   });
 
-  it('should not add a component path when the ref is invalid', function() {
+  it('should not add a component path when the ref is invalid', function () {
     const unresolvedSpec = {
       paths: {
         '/path1': {
           get: {
             responses: {
-              '200': {
+              200: {
                 content: {
                   'application/json': {
                     schema: {
-                      $ref: '#/components/schemas/SchemaDoesntExist'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      $ref: '#/components/schemas/SchemaDoesntExist',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         schemas: {
@@ -276,12 +276,12 @@ describe('test postprocessing util - test component path finding', function() {
             type: 'object',
             properties: {
               stringProp: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      }
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     };
 
     // invalid error path
@@ -292,10 +292,10 @@ describe('test postprocessing util - test component path finding', function() {
             message: 'simple error message',
             path:
               'paths./path1.get.responses.200.content.application/json.schema.stringProp',
-            rule: 'made_up_rule'
-          }
-        ]
-      }
+            rule: 'made_up_rule',
+          },
+        ],
+      },
     };
 
     addPathsToComponents(originalResults, unresolvedSpec);
@@ -304,7 +304,7 @@ describe('test postprocessing util - test component path finding', function() {
     expect(errors[0].componentPath).toBeUndefined();
   });
 
-  it('should not add a component path when the ref is invalid', function() {
+  it('should not add a component path when the ref is invalid', function () {
     const unresolvedSpec = {
       swagger: '2.0',
       paths: {
@@ -320,12 +320,12 @@ describe('test postprocessing util - test component path finding', function() {
                 description: 'Pet object that needs to be added to the store',
                 required: true,
                 schema: {
-                  $ref: '#/definitions/Pet'
-                }
-              }
-            ]
-          }
-        }
+                  $ref: '#/definitions/Pet',
+                },
+              },
+            ],
+          },
+        },
       },
       definitions: {
         Pet: {
@@ -333,15 +333,15 @@ describe('test postprocessing util - test component path finding', function() {
           properties: {
             id: {
               type: 'integer',
-              format: 'int64'
+              format: 'int64',
             },
             name: {
               type: 'string',
-              description: 'string'
-            }
-          }
-        }
-      }
+              description: 'string',
+            },
+          },
+        },
+      },
     };
 
     const originalResults = {
@@ -350,10 +350,10 @@ describe('test postprocessing util - test component path finding', function() {
           {
             message: 'simple error message',
             path: 'paths./pet.post.parameters.0.schema.properties.id',
-            rule: 'made_up_rule'
-          }
-        ]
-      }
+            rule: 'made_up_rule',
+          },
+        ],
+      },
     };
 
     addPathsToComponents(originalResults, unresolvedSpec);
@@ -363,7 +363,7 @@ describe('test postprocessing util - test component path finding', function() {
       'definitions',
       'Pet',
       'properties',
-      'id'
+      'id',
     ]);
   });
 });

--- a/test/plugins/ast/ast-manager.test.js
+++ b/test/plugins/ast/ast-manager.test.js
@@ -1,20 +1,20 @@
 const expect = require('expect');
 const {
   pathForPosition,
-  positionRangeForPath
+  positionRangeForPath,
 } = require('../../../src/plugins/ast/ast');
 
-describe('ASTManager', function() {
-  describe('#pathForPosition', function() {
-    describe('out of range', function() {
-      it('returns empty array for out of range row', function() {
+describe('ASTManager', function () {
+  describe('#pathForPosition', function () {
+    describe('out of range', function () {
+      it('returns empty array for out of range row', function () {
         const position = { line: 3, column: 0 };
         const path = pathForPosition('swagger: 2.0', position);
 
         expect(path).toEqual([]);
       });
 
-      it('returns empty array for out of range column', function() {
+      it('returns empty array for out of range column', function () {
         const position = { line: 0, column: 100 };
         const path = pathForPosition('swagger: 2.0', position);
 
@@ -22,15 +22,15 @@ describe('ASTManager', function() {
       });
     });
 
-    describe('when document is a simple hash `swagger: 2.0`', function() {
-      it('should return empty array when pointer is at middle of the hash key', function() {
+    describe('when document is a simple hash `swagger: 2.0`', function () {
+      it('should return empty array when pointer is at middle of the hash key', function () {
         const position = { line: 0, column: 3 };
         const path = pathForPosition('swagger: 2.0', position);
 
         expect(path).toEqual([]);
       });
 
-      it("should return ['swagger'] when pointer is at the value", function() {
+      it("should return ['swagger'] when pointer is at the value", function () {
         const position = { line: 0, column: 10 };
         const path = pathForPosition('swagger: 2.0', position);
 
@@ -38,30 +38,30 @@ describe('ASTManager', function() {
       });
     });
 
-    describe("when document is an array: ['abc', 'cde']", function() {
+    describe("when document is an array: ['abc', 'cde']", function () {
       const yaml = [
         /*
         0
         01234567 */
         /* 0 */ '- abc',
-        /* 1 */ '- def'
+        /* 1 */ '- def',
       ].join('\n');
 
-      it('should return empty array when pointer is at array dash', function() {
+      it('should return empty array when pointer is at array dash', function () {
         const position = { line: 0, column: 0 };
         const path = pathForPosition(yaml, position);
 
         expect(path).toEqual([]);
       });
 
-      it("should return ['0'] when pointer is at abc", function() {
+      it("should return ['0'] when pointer is at abc", function () {
         const position = { line: 0, column: 3 };
         const path = pathForPosition(yaml, position);
 
         expect(path).toEqual(['0']);
       });
 
-      it("should return ['1'] when pointer is at abc", function() {
+      it("should return ['1'] when pointer is at abc", function () {
         const position = { line: 1, column: 3 };
         const path = pathForPosition(yaml, position);
 
@@ -69,7 +69,7 @@ describe('ASTManager', function() {
       });
     });
 
-    describe('when document is an array of arrays', function() {
+    describe('when document is an array of arrays', function () {
       const yaml = [
         /*
         0         10
@@ -79,10 +79,10 @@ describe('ASTManager', function() {
         /* 2 */ ' - def',
         /* 3 */ '-',
         /* 4 */ ' - ABC',
-        /* 5 */ ' - DEF'
+        /* 5 */ ' - DEF',
       ].join('\n');
 
-      it("should return ['0', '0'] when pointer is at 'abc'", function() {
+      it("should return ['0', '0'] when pointer is at 'abc'", function () {
         const position = { line: 1, column: 5 };
         const path = pathForPosition(yaml, position);
 
@@ -90,7 +90,7 @@ describe('ASTManager', function() {
       });
     });
 
-    describe('when document is an array of hashs', function() {
+    describe('when document is an array of hashs', function () {
       const yaml = [
         /*
         0         10
@@ -98,24 +98,24 @@ describe('ASTManager', function() {
         /* 0 */ '- key: value',
         /* 1 */ '  num: 1',
         /* 2 */ '- name: Tesla',
-        /* 3 */ '  year: 2016'
+        /* 3 */ '  year: 2016',
       ].join('\n');
 
-      it("should return ['0'] when pointer is at 'key'", function() {
+      it("should return ['0'] when pointer is at 'key'", function () {
         const position = { line: 0, column: 3 };
         const path = pathForPosition(yaml, position);
 
         expect(path).toEqual(['0']);
       });
 
-      it("should return ['0', 'key'] when pointer is at 'value'", function() {
+      it("should return ['0', 'key'] when pointer is at 'value'", function () {
         const position = { line: 0, column: 9 };
         const path = pathForPosition(yaml, position);
 
         expect(path).toEqual(['0', 'key']);
       });
 
-      it("should return ['1', 'year'] when pointer is at '2016'", function() {
+      it("should return ['1', 'year'] when pointer is at '2016'", function () {
         const position = { line: 3, column: 10 };
         const path = pathForPosition(yaml, position);
 
@@ -123,7 +123,7 @@ describe('ASTManager', function() {
       });
     });
 
-    describe('full document', function() {
+    describe('full document', function () {
       const yaml = [
         /*
         0         10        20        30
@@ -136,10 +136,10 @@ describe('ASTManager', function() {
         /* 5 */ '    name: Sahar',
         /* 6 */ '    url: github.com',
         /* 7 */ '    email: me@example.com',
-        /* 8 */ '                         '
+        /* 8 */ '                         ',
       ].join('\n');
 
-      it("should return ['info', 'contact', 'email'] when pointer is at me@", function() {
+      it("should return ['info', 'contact', 'email'] when pointer is at me@", function () {
         const position = { line: 7, column: 13 };
         const path = pathForPosition(yaml, position);
 
@@ -148,8 +148,8 @@ describe('ASTManager', function() {
     });
   });
 
-  describe('#positionRangeForPath', function() {
-    it('return {{-1, -1}, {-1, -1}} for invalid paths', function() {
+  describe('#positionRangeForPath', function () {
+    it('return {{-1, -1}, {-1, -1}} for invalid paths', function () {
       const yaml = ['key: value', 'anotherKey: value'].join('\n');
 
       const position = positionRangeForPath(yaml, ['invalid']);
@@ -158,45 +158,45 @@ describe('ASTManager', function() {
       expect(position.end).toEqual({ line: -1, column: -1 });
     });
 
-    describe('when document is a simple hash `swagger: 2.0`', function() {
+    describe('when document is a simple hash `swagger: 2.0`', function () {
       const yaml = 'swagger: 2.0';
 
-      it('return {0, 0} for start of empty array path (root)', function() {
+      it('return {0, 0} for start of empty array path (root)', function () {
         const position = positionRangeForPath(yaml, []);
 
         expect(position.start).toEqual({ line: 0, column: 0 });
       });
 
-      it('return {0, 12} for end of empty array path (root)', function() {
+      it('return {0, 12} for end of empty array path (root)', function () {
         const position = positionRangeForPath(yaml, []);
 
         expect(position.end).toEqual({ line: 0, column: 12 });
       });
 
-      it("return {0, 9} for start of ['swagger']", function() {
+      it("return {0, 9} for start of ['swagger']", function () {
         const position = positionRangeForPath(yaml, ['swagger']);
 
         expect(position.start).toEqual({ line: 0, column: 9 });
       });
 
-      it("return {0, 12} for end of ['swagger']", function() {
+      it("return {0, 12} for end of ['swagger']", function () {
         const position = positionRangeForPath(yaml, ['swagger']);
 
         expect(position.end).toEqual({ line: 0, column: 12 });
       });
     });
 
-    describe('when document is an array of primitives', function() {
+    describe('when document is an array of primitives', function () {
       const yaml = ['key:', '  - value1', '  - value2'].join('\n');
 
-      it("returns {1, 4} for ['key', '0']", function() {
+      it("returns {1, 4} for ['key', '0']", function () {
         const position = positionRangeForPath(yaml, ['key', '0']);
 
         expect(position.start).toEqual({ line: 1, column: 4 });
       });
     });
 
-    describe('full document', function() {
+    describe('full document', function () {
       const yaml = [
         /*
         0         10        20        30
@@ -209,30 +209,30 @@ describe('ASTManager', function() {
         /* 5 */ '    name: Sahar',
         /* 6 */ '    url: github.com',
         /* 7 */ '    email: me@example.com',
-        /* 8 */ '                         '
+        /* 8 */ '                         ',
       ].join('\n');
 
-      it("returns {2, 2} for start of ['info']", function() {
+      it("returns {2, 2} for start of ['info']", function () {
         const position = positionRangeForPath(yaml, ['info']);
 
         expect(position.start).toEqual({ line: 2, column: 2 });
       });
 
-      it("returns {5, 10} for start of ['info', 'contact', 'name']", function() {
+      it("returns {5, 10} for start of ['info', 'contact', 'name']", function () {
         const position = positionRangeForPath(yaml, [
           'info',
           'contact',
-          'name'
+          'name',
         ]);
 
         expect(position.start).toEqual({ line: 5, column: 10 });
       });
 
-      it("returns {5, 15} for end of ['info', 'contact', 'name']", function() {
+      it("returns {5, 15} for end of ['info', 'contact', 'name']", function () {
         const position = positionRangeForPath(yaml, [
           'info',
           'contact',
-          'name'
+          'name',
         ]);
 
         expect(position.end).toEqual({ line: 5, column: 15 });

--- a/test/plugins/path-translator.js
+++ b/test/plugins/path-translator.js
@@ -1,17 +1,17 @@
 const expect = require('expect');
 const { transformPathToArray } = require('../../src/path-translator');
 
-describe('validation plugin - path translator', function() {
-  describe('string paths', function() {
-    it('should translate a simple string path to an array', function() {
+describe('validation plugin - path translator', function () {
+  describe('string paths', function () {
+    it('should translate a simple string path to an array', function () {
       // Given
       const jsSpec = {
         one: {
           a: 'a thing',
           b: 'another thing',
-          c: 'one more thing'
+          c: 'one more thing',
         },
-        two: 2
+        two: 2,
       };
 
       const path = 'instance.one.a';
@@ -20,7 +20,7 @@ describe('validation plugin - path translator', function() {
       expect(transformPathToArray(path, jsSpec)).toEqual(['one', 'a']);
     });
 
-    it('should translate an ambiguous string path to an array', function() {
+    it('should translate an ambiguous string path to an array', function () {
       // Since JSONSchema uses periods to mark different properties,
       // a key with a period in it is ambiguous, because it can mean at least two things.
       // In our case, the path can mean:
@@ -31,12 +31,12 @@ describe('validation plugin - path translator', function() {
         'google.com': {
           a: 'a thing',
           b: 'another thing',
-          c: 'one more thing'
+          c: 'one more thing',
         },
         'gmail.com': {
           d: 'more stuff',
-          e: 'even more stuff'
-        }
+          e: 'even more stuff',
+        },
       };
 
       const path = 'instance.google.com.a';
@@ -45,7 +45,7 @@ describe('validation plugin - path translator', function() {
       expect(transformPathToArray(path, jsSpec)).toEqual(['google.com', 'a']);
     });
 
-    it('should translate an doubly ambiguous string path to an array', function() {
+    it('should translate an doubly ambiguous string path to an array', function () {
       // Since JSONSchema uses periods to mark different properties,
       // a key with two periods in it (like "www.google.com") is doubly ambiguous,
       // because it can mean at least three things.
@@ -55,12 +55,12 @@ describe('validation plugin - path translator', function() {
         'www.google.com': {
           a: 'a thing',
           b: 'another thing',
-          c: 'one more thing'
+          c: 'one more thing',
         },
         'gmail.com': {
           d: 'more stuff',
-          e: 'even more stuff'
-        }
+          e: 'even more stuff',
+        },
       };
 
       const path = 'instance.www.google.com.a';
@@ -68,22 +68,22 @@ describe('validation plugin - path translator', function() {
       // Then
       expect(transformPathToArray(path, jsSpec)).toEqual([
         'www.google.com',
-        'a'
+        'a',
       ]);
     });
 
-    it('should return null for an invalid path', function() {
+    it('should return null for an invalid path', function () {
       // Given
       const jsSpec = {
         'google.com': {
           a: 'a thing',
           b: 'another thing',
-          c: 'one more thing'
+          c: 'one more thing',
         },
         'gmail.com': {
           d: 'more stuff',
-          e: 'even more stuff'
-        }
+          e: 'even more stuff',
+        },
       };
 
       const path = 'instance.google.net.a';
@@ -92,7 +92,7 @@ describe('validation plugin - path translator', function() {
       expect(transformPathToArray(path, jsSpec)).toEqual(null);
     });
 
-    it('should return inline array indices in their own value', function() {
+    it('should return inline array indices in their own value', function () {
       // "a[1]" => ["a", "1"]
 
       // Given
@@ -100,12 +100,12 @@ describe('validation plugin - path translator', function() {
         'google.com': {
           a: ['hello', 'here is the target'],
           b: 'another thing',
-          c: 'one more thing'
+          c: 'one more thing',
         },
         'gmail.com': {
           d: 'more stuff',
-          e: 'even more stuff'
-        }
+          e: 'even more stuff',
+        },
       };
 
       const path = 'instance.google.com.a[1]';
@@ -114,27 +114,27 @@ describe('validation plugin - path translator', function() {
       expect(transformPathToArray(path, jsSpec)).toEqual([
         'google.com',
         'a',
-        '1'
+        '1',
       ]);
     });
 
-    it('should return the correct path when the last part is ambiguous', function() {
+    it('should return the correct path when the last part is ambiguous', function () {
       // Given
       const jsSpec = {
         'google.com': {
           a: [
             'hello',
             {
-              'gmail.com': 1234
-            }
+              'gmail.com': 1234,
+            },
           ],
           b: 'another thing',
-          c: 'one more thing'
+          c: 'one more thing',
         },
         'gmail.com': {
           d: 'more stuff',
-          e: 'even more stuff'
-        }
+          e: 'even more stuff',
+        },
       };
 
       const path = 'instance.google.com.a[1].gmail.com';
@@ -144,27 +144,27 @@ describe('validation plugin - path translator', function() {
         'google.com',
         'a',
         '1',
-        'gmail.com'
+        'gmail.com',
       ]);
     });
 
-    it('should return the correct path when the last part is doubly ambiguous', function() {
+    it('should return the correct path when the last part is doubly ambiguous', function () {
       // Given
       const jsSpec = {
         'google.com': {
           a: [
             'hello',
             {
-              'www.gmail.com': 1234
-            }
+              'www.gmail.com': 1234,
+            },
           ],
           b: 'another thing',
-          c: 'one more thing'
+          c: 'one more thing',
         },
         'gmail.com': {
           d: 'more stuff',
-          e: 'even more stuff'
-        }
+          e: 'even more stuff',
+        },
       };
 
       const path = 'instance.google.com.a[1].www.gmail.com';
@@ -174,7 +174,7 @@ describe('validation plugin - path translator', function() {
         'google.com',
         'a',
         '1',
-        'www.gmail.com'
+        'www.gmail.com',
       ]);
     });
   });

--- a/test/plugins/utils/case-convention-check.test.js
+++ b/test/plugins/utils/case-convention-check.test.js
@@ -1,166 +1,166 @@
 const expect = require('expect');
 const checkCase = require('../../../src/plugins/utils/caseConventionCheck');
 
-describe('case convention regex tests', function() {
-  describe('lower snake case tests', function() {
+describe('case convention regex tests', function () {
+  describe('lower snake case tests', function () {
     const convention = 'lower_snake_case';
 
-    it('sha1 is snake case', function() {
+    it('sha1 is snake case', function () {
       const string = 'sha1';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('good_case_string is snake case', function() {
+    it('good_case_string is snake case', function () {
       const string = 'good_case_string';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('badCaseString is NOT snake case', function() {
+    it('badCaseString is NOT snake case', function () {
       const string = 'badCaseString';
       expect(checkCase(string, convention)).toEqual(false);
     });
   });
 
-  describe('upper snake case tests', function() {
+  describe('upper snake case tests', function () {
     const convention = 'upper_snake_case';
 
-    it('SHA1 is upper snake case', function() {
+    it('SHA1 is upper snake case', function () {
       const string = 'SHA1';
       expect(checkCase(string, convention)).toEqual(true);
     });
-    it('sha1 is NOT upper snake case', function() {
+    it('sha1 is NOT upper snake case', function () {
       const string = 'sha1';
       expect(checkCase(string, convention)).toEqual(false);
     });
 
-    it('good_case_string is NOT upper_snake_case', function() {
+    it('good_case_string is NOT upper_snake_case', function () {
       const string = 'good_case_string';
       expect(checkCase(string, convention)).toEqual(false);
     });
 
-    it('GOOD_CASE_STRING is upper_snake_case', function() {
+    it('GOOD_CASE_STRING is upper_snake_case', function () {
       const string = 'GOOD_CASE_STRING';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('badCaseString is NOT upper_snake_case', function() {
+    it('badCaseString is NOT upper_snake_case', function () {
       const string = 'badCaseString';
       expect(checkCase(string, convention)).toEqual(false);
     });
   });
 
-  describe('upper camel case tests', function() {
+  describe('upper camel case tests', function () {
     const convention = 'upper_camel_case';
-    it('Sha1 is upper camel case', function() {
+    it('Sha1 is upper camel case', function () {
       const string = 'Sha1';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('GoodCaseString is upper camel case', function() {
+    it('GoodCaseString is upper camel case', function () {
       const string = 'GoodCaseString';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('badCaseString is NOT upper camel case', function() {
+    it('badCaseString is NOT upper camel case', function () {
       const string = 'badCaseString';
       expect(checkCase(string, convention)).toEqual(false);
     });
 
-    it('does not hang on long identifiers', function() {
+    it('does not hang on long identifiers', function () {
       const string = 'downloadGeneratedApplicationUsingGET';
       expect(checkCase(string, convention)).toEqual(false);
     });
   });
 
-  describe('lower camel case tests', function() {
+  describe('lower camel case tests', function () {
     const convention = 'lower_camel_case';
-    it('sha1 is lower camel case', function() {
+    it('sha1 is lower camel case', function () {
       const string = 'sha1';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('goodCaseString is lower camel case', function() {
+    it('goodCaseString is lower camel case', function () {
       const string = 'goodCaseString';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('BadCaseString is NOT lower camel case', function() {
+    it('BadCaseString is NOT lower camel case', function () {
       const string = 'BadCaseString';
       expect(checkCase(string, convention)).toEqual(false);
     });
 
-    it('does not hang on long identifiers', function() {
+    it('does not hang on long identifiers', function () {
       const string = 'downloadGeneratedApplicationUsingGET';
       expect(checkCase(string, convention)).toEqual(false);
     });
   });
 
-  describe('k8s camel case tests', function() {
+  describe('k8s camel case tests', function () {
     const convention = 'k8s_camel_case';
-    it('apiVersion is k8s camel case', function() {
+    it('apiVersion is k8s camel case', function () {
       const string = 'apiVersion';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('hostPID is k8s camel case', function() {
+    it('hostPID is k8s camel case', function () {
       const string = 'hostPID';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('ApiVersion is NOT k8s camel case', function() {
+    it('ApiVersion is NOT k8s camel case', function () {
       const string = 'ApiVersion';
       expect(checkCase(string, convention)).toEqual(false);
     });
 
-    it('isGIFOrJPEG is k8s camel case', function() {
+    it('isGIFOrJPEG is k8s camel case', function () {
       const string = 'isGIFOrJPEG';
       expect(checkCase(string, convention)).toEqual(true);
     });
   });
 
-  describe('lower dash case tests', function() {
+  describe('lower dash case tests', function () {
     const convention = 'lower_dash_case';
-    it('sha1 is lower dash case', function() {
+    it('sha1 is lower dash case', function () {
       const string = 'sha1';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('good-case-string is lower dash case', function() {
+    it('good-case-string is lower dash case', function () {
       const string = 'good-case-string';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('Bad-Case-String is NOT lower dash case', function() {
+    it('Bad-Case-String is NOT lower dash case', function () {
       const string = 'Bad-Case-String';
       expect(checkCase(string, convention)).toEqual(false);
     });
   });
-  describe('upper dash case tests', function() {
+  describe('upper dash case tests', function () {
     const convention = 'upper_dash_case';
-    it('sha1 is NOT upper_dash_case', function() {
+    it('sha1 is NOT upper_dash_case', function () {
       const string = 'sha1';
       expect(checkCase(string, convention)).toEqual(false);
     });
 
-    it('SHA1 is upper_dash_case', function() {
+    it('SHA1 is upper_dash_case', function () {
       const string = 'SHA1';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('bad-case-string is NOT upper_dash_case', function() {
+    it('bad-case-string is NOT upper_dash_case', function () {
       const string = 'bad-case-string';
       expect(checkCase(string, convention)).toEqual(false);
     });
-    it('GOOD-CASE-STRING is upper_dash_case', function() {
+    it('GOOD-CASE-STRING is upper_dash_case', function () {
       const string = 'GOOD-CASE-STRING';
       expect(checkCase(string, convention)).toEqual(true);
     });
 
-    it('Bad-Case-String is NOT upper_dash_case', function() {
+    it('Bad-Case-String is NOT upper_dash_case', function () {
       const string = 'Bad-Case-String';
       expect(checkCase(string, convention)).toEqual(false);
     });
-    it('badCaseString is NOT upper_dash_case', function() {
+    it('badCaseString is NOT upper_dash_case', function () {
       const string = 'badCaseString';
       expect(checkCase(string, convention)).toEqual(false);
     });

--- a/test/plugins/utils/find-octet-sequence-paths.test.js
+++ b/test/plugins/utils/find-octet-sequence-paths.test.js
@@ -11,47 +11,47 @@ function arrayEquals(a, b) {
   );
 }
 
-describe('falsy values should return an empty array', function() {
-  describe('undefined should return an empty array', function() {
-    it('undefined is falsy', function() {
+describe('falsy values should return an empty array', function () {
+  describe('undefined should return an empty array', function () {
+    it('undefined is falsy', function () {
       expect(arrayEquals(findOctetSequencePaths(undefined, []), []));
     });
   });
 
-  describe('null should return an empty array', function() {
-    it('null is falsy', function() {
+  describe('null should return an empty array', function () {
+    it('null is falsy', function () {
       expect(arrayEquals(findOctetSequencePaths(null, []), []));
     });
   });
 
-  describe('NaN should return an empty array', function() {
-    it('NaN is falsy', function() {
+  describe('NaN should return an empty array', function () {
+    it('NaN is falsy', function () {
       expect(arrayEquals(findOctetSequencePaths(NaN, []), []));
     });
   });
 
-  describe('0 should return an empty array', function() {
-    it('0 is falsy', function() {
+  describe('0 should return an empty array', function () {
+    it('0 is falsy', function () {
       expect(arrayEquals(findOctetSequencePaths(0, []), []));
     });
   });
 
-  describe('The Empty String should return an empty array', function() {
-    it('The Empty String is falsy', function() {
+  describe('The Empty String should return an empty array', function () {
+    it('The Empty String is falsy', function () {
       expect(arrayEquals(findOctetSequencePaths('', []), []));
     });
   });
 
-  describe('false should return an empty array', function() {
-    it('false is falsy', function() {
+  describe('false should return an empty array', function () {
+    it('false is falsy', function () {
       expect(findOctetSequencePaths(false, [])).toEqual([]);
     });
   });
 });
 
-describe('binary format string schemas should return the passed path', function() {
-  describe('binary format strings should include the path in string form', function() {
-    it('should return an array with string elements', function() {
+describe('binary format string schemas should return the passed path', function () {
+  describe('binary format strings should include the path in string form', function () {
+    it('should return an array with string elements', function () {
       const schemaObj = { type: 'string', format: 'binary' };
       const path = ['path1.get'];
 
@@ -60,56 +60,56 @@ describe('binary format string schemas should return the passed path', function(
   });
 });
 
-describe('object-type schemas must extract values from the resolved schema', function() {
+describe('object-type schemas must extract values from the resolved schema', function () {
   const schemaObj = { type: 'object' };
   const path = ['path1.get'];
-  it('falsy properties should not append to the path', function() {
+  it('falsy properties should not append to the path', function () {
     schemaObj.properties = false;
 
     expect(arrayEquals(findOctetSequencePaths(schemaObj, path), path));
   });
 
-  it('truthy properties should be added to the octet paths', function() {
+  it('truthy properties should be added to the octet paths', function () {
     schemaObj.properties = { one: { type: 'string', format: 'binary' } };
     const expectedOut = ['path1.get', 'path1.get.properties.one'];
 
     expect(arrayEquals(findOctetSequencePaths(schemaObj, path), expectedOut));
   });
 
-  it('truthy properties should be recursively added to the octet paths', function() {
+  it('truthy properties should be recursively added to the octet paths', function () {
     schemaObj.properties = {
       one: {
         type: 'object',
-        properties: { two: { type: 'string', format: 'binary' } }
-      }
+        properties: { two: { type: 'string', format: 'binary' } },
+      },
     };
     const expectedOut = [
       'path1.get',
       'path1.get.properties.one',
-      'path1.get.properties.one.properties.two'
+      'path1.get.properties.one.properties.two',
     ];
 
     expect(arrayEquals(findOctetSequencePaths(schemaObj, path), expectedOut));
   });
 });
 
-describe('array-type schemas require the proper values in proper fields', function() {
+describe('array-type schemas require the proper values in proper fields', function () {
   const schemaObj = { type: 'array', items: null };
 
-  it('should throw with a full path if the proper structure is not provided', function() {
+  it('should throw with a full path if the proper structure is not provided', function () {
     const path = ['path1.get'];
 
-    expect(function() {
+    expect(function () {
       findOctetSequencePaths(schemaObj, path);
     }).toThrow(
       'items.type and items.format must resolve for the path "path1.get"'
     );
   });
 
-  it('should escape forward-slashes in the path', function() {
+  it('should escape forward-slashes in the path', function () {
     const path = ['path1/get'];
 
-    expect(function() {
+    expect(function () {
       findOctetSequencePaths(schemaObj, path);
     }).toThrow(
       'items.type and items.format must resolve for the path "path1\\/get"'

--- a/test/plugins/utils/has-ref-property.test.js
+++ b/test/plugins/utils/has-ref-property.test.js
@@ -7,18 +7,18 @@ const spec = {
       post: {
         description: 'a simple operation',
         requestBody: {
-          $ref: 'external.yaml#/resource-post-request-body'
+          $ref: 'external.yaml#/resource-post-request-body',
         },
         responses: {
-          '200': {
-            description: 'a simple response'
+          200: {
+            description: 'a simple response',
           },
-          '400': {
-            $ref: '#/components/responses/ErrorResponse'
-          }
-        }
-      }
-    }
+          400: {
+            $ref: '#/components/responses/ErrorResponse',
+          },
+        },
+      },
+    },
   },
   components: {
     responses: {
@@ -27,13 +27,13 @@ const spec = {
         content: {
           'application/json': {
             schema: {
-              $ref: 'external.yaml#/error-response-schema'
-            }
-          }
-        }
-      }
-    }
-  }
+              $ref: 'external.yaml#/error-response-schema',
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
 describe('has ref property - util', () => {
@@ -81,7 +81,7 @@ describe('has ref property - util', () => {
       '400',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ];
     const hasRef = hasRefProperty(spec, path);
 

--- a/test/plugins/utils/is-response.test.js
+++ b/test/plugins/utils/is-response.test.js
@@ -33,7 +33,7 @@ describe('is response object - util', () => {
         'schemas',
         'MySchema',
         'properties',
-        'responses'
+        'responses',
       ];
       expect(isResponseObject(path, isOas3)).toBe(false);
     });

--- a/test/plugins/utils/isPrimitiveType.test.js
+++ b/test/plugins/utils/isPrimitiveType.test.js
@@ -5,8 +5,8 @@ describe('isPrimitiveType - util', () => {
   it('should return true when the schema uses a primitive type', () => {
     const exampleObject = {
       schema: {
-        type: 'string'
-      }
+        type: 'string',
+      },
     };
 
     expect(isPrimitiveType(exampleObject.schema)).toBe(true);
@@ -17,9 +17,9 @@ describe('isPrimitiveType - util', () => {
       schema: {
         type: 'array',
         items: {
-          type: 'boolean'
-        }
-      }
+          type: 'boolean',
+        },
+      },
     };
 
     expect(isPrimitiveType(exampleObject.schema.items)).toBe(true);
@@ -31,10 +31,10 @@ describe('isPrimitiveType - util', () => {
         type: 'object',
         properties: {
           exampleProp: {
-            type: 'string'
-          }
-        }
-      }
+            type: 'string',
+          },
+        },
+      },
     };
 
     expect(isPrimitiveType(exampleObject.schema)).toBe(false);

--- a/test/plugins/utils/message-carrier.test.js
+++ b/test/plugins/utils/message-carrier.test.js
@@ -1,8 +1,8 @@
 const expect = require('expect');
 const MessageCarrier = require('../../../src/plugins/utils/messageCarrier');
 
-describe('MessageCarrier tests', function() {
-  it('get errors returns all errors added', function() {
+describe('MessageCarrier tests', function () {
+  it('get errors returns all errors added', function () {
     const messages = new MessageCarrier();
 
     messages.addMessage(['paths', '/example', 'get'], 'message1', 'error');
@@ -12,16 +12,16 @@ describe('MessageCarrier tests', function() {
     expect(messages.errors[0]).toEqual({
       path: ['paths', '/example', 'get'],
       message: 'message1',
-      rule: 'builtin'
+      rule: 'builtin',
     });
     expect(messages.errors[1]).toEqual({
       path: ['paths', '/example', 'post'],
       message: 'message2',
-      rule: 'builtin'
+      rule: 'builtin',
     });
   });
 
-  it('get warnings returns all warnings added', function() {
+  it('get warnings returns all warnings added', function () {
     const messages = new MessageCarrier();
 
     messages.addMessage('paths./example.get', 'message1', 'warning');
@@ -31,16 +31,16 @@ describe('MessageCarrier tests', function() {
     expect(messages.warnings[0]).toEqual({
       path: 'paths./example.get',
       message: 'message1',
-      rule: 'builtin'
+      rule: 'builtin',
     });
     expect(messages.warnings[1]).toEqual({
       path: 'paths./example.post',
       message: 'message2',
-      rule: 'builtin'
+      rule: 'builtin',
     });
   });
 
-  it('get messages returns a dictionary with the list of errors and warnings', function() {
+  it('get messages returns a dictionary with the list of errors and warnings', function () {
     const messages = new MessageCarrier();
 
     messages.addMessage(['paths', '/example', 'get'], 'message1', 'error');
@@ -56,17 +56,17 @@ describe('MessageCarrier tests', function() {
     expect(messageDict.error[0]).toEqual({
       path: ['paths', '/example', 'get'],
       message: 'message1',
-      rule: 'builtin'
+      rule: 'builtin',
     });
     expect(messageDict.warning.length).toEqual(1);
     expect(messageDict.warning[0]).toEqual({
       path: 'paths./example.get.requestBody',
       message: 'message3',
-      rule: 'builtin'
+      rule: 'builtin',
     });
   });
 
-  it('addMessage does not add errors and warnings when status is off', function() {
+  it('addMessage does not add errors and warnings when status is off', function () {
     const messages = new MessageCarrier();
 
     messages.addMessage(['paths', '/example', 'get'], 'message1', 'off');
@@ -77,7 +77,7 @@ describe('MessageCarrier tests', function() {
     expect(messages.warnings.length).toEqual(0);
   });
 
-  it('addMessageWithAuthId does not add errors and warnings when status is off', function() {
+  it('addMessageWithAuthId does not add errors and warnings when status is off', function () {
     const messages = new MessageCarrier();
 
     messages.addMessageWithAuthId(
@@ -100,7 +100,7 @@ describe('MessageCarrier tests', function() {
     expect(messages.warnings.length).toEqual(0);
   });
 
-  it('addMessageWithAuthId adds errors and includes the authId in the error', function() {
+  it('addMessageWithAuthId adds errors and includes the authId in the error', function () {
     const messages = new MessageCarrier();
 
     messages.addMessageWithAuthId(
@@ -128,7 +128,7 @@ describe('MessageCarrier tests', function() {
     expect(messages.errors[1].rule).toEqual('builtin');
   });
 
-  it('addMessageWithAuthId adds warnings and includes the authId in the warning', function() {
+  it('addMessageWithAuthId adds warnings and includes the authId in the warning', function () {
     const messages = new MessageCarrier();
 
     messages.addMessageWithAuthId(
@@ -158,9 +158,9 @@ describe('MessageCarrier tests', function() {
     expect(messages.warnings[1].rule).toEqual('builtin');
   });
 
-  it('providing addMessageWithAuthId a valid key in config should set rule to that key', function() {
+  it('providing addMessageWithAuthId a valid key in config should set rule to that key', function () {
     const config = {
-      valid_rule: 'warning'
+      valid_rule: 'warning',
     };
 
     const messages = new MessageCarrier();
@@ -194,13 +194,13 @@ describe('MessageCarrier tests', function() {
       path: ['paths', '/example', 'get'],
       message: 'message1',
       authId: 'authId1',
-      rule: 'valid_rule'
+      rule: 'valid_rule',
     });
     expect(messages.warnings[1]).toEqual({
       path: ['paths', '/example', 'post'],
       message: 'message2',
       authId: 'authId2',
-      rule: 'valid_rule'
+      rule: 'valid_rule',
     });
   });
 });

--- a/test/plugins/validation/2and3/info.test.js
+++ b/test/plugins/validation/2and3/info.test.js
@@ -1,14 +1,14 @@
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/info');
 
 describe('validation plugin - semantic - info', () => {
   //this is for openapi object
   it('should return an error when a parameter does not have info', () => {
     const spec = {
-      Openapi: '3.0.0'
+      Openapi: '3.0.0',
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -21,7 +21,7 @@ describe('validation plugin - semantic - info', () => {
   it('should return an error when a info is not defined as a proper object', () => {
     const spec = {
       Openapi: '3.0.0',
-      info: 'abc'
+      info: 'abc',
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -36,8 +36,8 @@ describe('validation plugin - semantic - info', () => {
       Openapi: '3.0.0',
       info: {
         title: 32,
-        version: '32'
-      }
+        version: '32',
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -52,8 +52,8 @@ describe('validation plugin - semantic - info', () => {
       Openapi: '3.0.0',
       info: {
         title: '32',
-        version: 32
-      }
+        version: 32,
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -67,8 +67,8 @@ describe('validation plugin - semantic - info', () => {
     const spec = {
       Openapi: '3.0.0',
       info: {
-        version: '32'
-      }
+        version: '32',
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -82,8 +82,8 @@ describe('validation plugin - semantic - info', () => {
     const spec = {
       Openapi: '3.0.0',
       info: {
-        title: '32'
-      }
+        title: '32',
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);

--- a/test/plugins/validation/2and3/items-required-for-array-objects.test.js
+++ b/test/plugins/validation/2and3/items-required-for-array-objects.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/items-required-for-array-objects');
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
@@ -10,7 +10,7 @@ describe('validation plugin - semantic - items required for array objects - Swag
       swagger: '2.0',
       info: {
         version: '1.0.0',
-        title: 'Swagger Petstore'
+        title: 'Swagger Petstore',
       },
       paths: {
         '/pets': {
@@ -18,21 +18,21 @@ describe('validation plugin - semantic - items required for array objects - Swag
             description:
               'Returns all pets from the system that the user has access to',
             responses: {
-              '200': {
+              200: {
                 description: 'pet response',
                 headers: {
                   'X-MyHeader': {
-                    type: 'array'
-                  }
-                }
+                    type: 'array',
+                  },
+                },
               },
               default: {
-                description: 'unexpected error'
-              }
-            }
-          }
-        }
-      }
+                description: 'unexpected error',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -44,7 +44,7 @@ describe('validation plugin - semantic - items required for array objects - Swag
       'responses',
       '200',
       'headers',
-      'X-MyHeader'
+      'X-MyHeader',
     ]);
     expect(res.errors[0].message).toEqual(
       "Headers with 'array' type require an 'items' property"
@@ -57,7 +57,7 @@ describe('validation plugin - semantic - items required for array objects - Swag
       swagger: '2.0',
       info: {
         version: '1.0.0',
-        title: 'Swagger Petstore'
+        title: 'Swagger Petstore',
       },
       paths: {
         '/pets': {
@@ -65,24 +65,24 @@ describe('validation plugin - semantic - items required for array objects - Swag
             description:
               'Returns all pets from the system that the user has access to',
             responses: {
-              '200': {
+              200: {
                 description: 'pet response',
                 headers: {
                   'X-MyHeader': {
                     type: 'array',
                     items: {
-                      type: 'string'
-                    }
-                  }
-                }
+                      type: 'string',
+                    },
+                  },
+                },
               },
               default: {
-                description: 'unexpected error'
-              }
-            }
-          }
-        }
-      }
+                description: 'unexpected error',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -94,9 +94,9 @@ describe('validation plugin - semantic - items required for array objects - Swag
     const spec = {
       definitions: {
         TestObject: {
-          type: 'array'
-        }
-      }
+          type: 'array',
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -115,11 +115,11 @@ describe('validation plugin - semantic - items required for array objects - Swag
           type: 'object',
           properties: {
             arrayProperty: {
-              type: 'array'
-            }
-          }
-        }
-      }
+              type: 'array',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -143,24 +143,24 @@ describe('validation plugin - semantic - items required for array objects - Open
             description:
               'Returns all pets from the system that the user has access to',
             responses: {
-              '200': {
+              200: {
                 description: 'pet response',
                 headers: {
                   'X-MyHeader': {
                     description: 'fake header',
                     schema: {
-                      type: 'array'
-                    }
-                  }
-                }
+                      type: 'array',
+                    },
+                  },
+                },
               },
               default: {
-                description: 'unexpected error'
-              }
-            }
-          }
-        }
-      }
+                description: 'unexpected error',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -182,7 +182,7 @@ describe('validation plugin - semantic - items required for array objects - Open
             description:
               'Returns all pets from the system that the user has access to',
             responses: {
-              '200': {
+              200: {
                 description: 'pet response',
                 headers: {
                   'X-MyHeader': {
@@ -191,20 +191,20 @@ describe('validation plugin - semantic - items required for array objects - Open
                       type: 'array',
                       items: [
                         {
-                          type: 'string'
-                        }
-                      ]
-                    }
-                  }
-                }
+                          type: 'string',
+                        },
+                      ],
+                    },
+                  },
+                },
               },
               default: {
-                description: 'unexpected error'
-              }
-            }
-          }
-        }
-      }
+                description: 'unexpected error',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -227,12 +227,12 @@ describe('validation plugin - semantic - items required for array objects - Open
             required: ['ImportantProperty'],
             properties: {
               OptionalProperty: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      }
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -253,28 +253,28 @@ describe('validation plugin - semantic - items required for array objects - Open
           RefProp: {
             properties: {
               OptionalProperty: {
-                type: `string`
-              }
-            }
+                type: `string`,
+              },
+            },
           },
           TestObject: {
             type: 'object',
             required: ['ImportantProperty'],
             oneOf: [
               {
-                $ref: '#/components/schemas/RefProp'
+                $ref: '#/components/schemas/RefProp',
               },
               {
                 properties: {
                   ImportantProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -295,28 +295,28 @@ describe('validation plugin - semantic - items required for array objects - Open
           RefProp: {
             properties: {
               OptionalProperty: {
-                type: `string`
-              }
-            }
+                type: `string`,
+              },
+            },
           },
           TestObject: {
             type: 'object',
             required: ['ImportantProperty'],
             anyOf: [
               {
-                $ref: '#/components/schemas/RefProp'
+                $ref: '#/components/schemas/RefProp',
               },
               {
                 properties: {
                   ImportantProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -337,42 +337,42 @@ describe('validation plugin - semantic - items required for array objects - Open
           NestedRefProp: {
             properties: {
               ImportantProperty: {
-                type: `string`
-              }
-            }
+                type: `string`,
+              },
+            },
           },
           RefProp: {
             anyOf: [
               {
-                $ref: '#/components/schemas/NestedRefProp'
+                $ref: '#/components/schemas/NestedRefProp',
               },
               {
                 properties: {
                   ImportantProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
+                    type: 'string',
+                  },
+                },
+              },
+            ],
           },
           TestObject: {
             type: 'object',
             required: ['ImportantProperty'],
             anyOf: [
               {
-                $ref: '#/components/schemas/RefProp'
+                $ref: '#/components/schemas/RefProp',
               },
               {
                 properties: {
                   ImportantProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -387,42 +387,42 @@ describe('validation plugin - semantic - items required for array objects - Open
           NestedRefProp: {
             properties: {
               ImportantProperty: {
-                type: `string`
-              }
-            }
+                type: `string`,
+              },
+            },
           },
           RefProp: {
             allOf: [
               {
-                $ref: '#/components/schemas/NestedRefProp'
+                $ref: '#/components/schemas/NestedRefProp',
               },
               {
                 properties: {
                   OptionalProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
+                    type: 'string',
+                  },
+                },
+              },
+            ],
           },
           TestObject: {
             type: 'object',
             required: ['ImportantProperty'],
             anyOf: [
               {
-                $ref: '#/components/schemas/RefProp'
+                $ref: '#/components/schemas/RefProp',
               },
               {
                 properties: {
                   ImportantProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -437,42 +437,42 @@ describe('validation plugin - semantic - items required for array objects - Open
           NestedRefProp: {
             properties: {
               ImportantProperty: {
-                type: `string`
-              }
-            }
+                type: `string`,
+              },
+            },
           },
           RefProp: {
             allOf: [
               {
-                $ref: '#/components/schemas/NestedRefProp'
+                $ref: '#/components/schemas/NestedRefProp',
               },
               {
                 properties: {
                   OptionalProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
+                    type: 'string',
+                  },
+                },
+              },
+            ],
           },
           TestObject: {
             type: 'object',
             required: ['ImportantProperty'],
             allOf: [
               {
-                $ref: '#/components/schemas/RefProp'
+                $ref: '#/components/schemas/RefProp',
               },
               {
                 properties: {
                   OptionalProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -487,28 +487,28 @@ describe('validation plugin - semantic - items required for array objects - Open
           RefProp: {
             properties: {
               OptionalProperty: {
-                type: `string`
-              }
-            }
+                type: `string`,
+              },
+            },
           },
           TestObject: {
             type: 'object',
             required: ['ImportantProperty'],
             allOf: [
               {
-                $ref: '#/components/schemas/RefProp'
+                $ref: '#/components/schemas/RefProp',
               },
               {
                 properties: {
                   OptionalProperty: {
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -529,11 +529,11 @@ describe('validation plugin - semantic - items required for array objects - Open
           TestObject: {
             type: 'array',
             items: {
-              type: 'string'
-            }
-          }
-        }
-      }
+              type: 'string',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);

--- a/test/plugins/validation/2and3/operation-ids.test.js
+++ b/test/plugins/validation/2and3/operation-ids.test.js
@@ -1,74 +1,74 @@
 const expect = require('expect');
 const resolver = require('json-schema-ref-parser');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/operation-ids');
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
-describe('validation plugin - semantic - operation-ids', function() {
-  it('should complain about operationId naming convention', async function() {
+describe('validation plugin - semantic - operation-ids', function () {
+  it('should complain about operationId naming convention', async function () {
     const spec = {
       paths: {
         '/books': {
           get: {
-            operationId: 'getBooks'
+            operationId: 'getBooks',
           },
           post: {
-            operationId: 'changeBooks'
-          }
+            operationId: 'changeBooks',
+          },
         },
         '/coffee': {
           get: {
-            operationId: 'get_books'
+            operationId: 'get_books',
           },
           post: {
-            operationId: 'change_books'
-          }
+            operationId: 'change_books',
+          },
         },
         '/books/{id}': {
           parameters: [
             {
               name: 'id',
-              in: 'path'
-            }
+              in: 'path',
+            },
           ],
           get: {
-            operationId: 'listBooks'
+            operationId: 'listBooks',
           },
           delete: {
-            operationId: 'removeBook'
+            operationId: 'removeBook',
           },
           post: {
-            operationId: 'updatesBook'
+            operationId: 'updatesBook',
           },
           put: {
-            operationId: 'changeBook'
+            operationId: 'changeBook',
           },
           patch: {
-            operationId: 'changeBook2'
-          }
+            operationId: 'changeBook2',
+          },
         },
         '/coffee/{id}': {
           parameters: [
             {
               name: 'id',
-              in: 'path'
-            }
+              in: 'path',
+            },
           ],
           get: {
-            operationId: 'listCoffee'
+            operationId: 'listCoffee',
           },
           delete: {
-            operationId: 'removeCoffee'
+            operationId: 'removeCoffee',
           },
           post: {
-            operationId: 'changeCoffee'
+            operationId: 'changeCoffee',
           },
           put: {
-            operationId: 'changeCoffee2'
-          }
-        }
-      }
+            operationId: 'changeCoffee2',
+          },
+        },
+      },
     };
 
     const resolvedSpec = await resolver.dereference(spec);
@@ -82,78 +82,78 @@ describe('validation plugin - semantic - operation-ids', function() {
     );
   });
 
-  it('should not complain about operationId naming convention', async function() {
+  it('should not complain about operationId naming convention', async function () {
     const spec = {
       paths: {
         '/books': {
           get: {
-            operationId: 'listBooks'
+            operationId: 'listBooks',
           },
           post: {
-            operationId: 'addBooks'
+            operationId: 'addBooks',
           },
           delete: {
-            operationId: 'deleteAllBooks'
-          }
+            operationId: 'deleteAllBooks',
+          },
         },
         '/coffee': {
           get: {
-            operationId: 'list_coffee'
+            operationId: 'list_coffee',
           },
           post: {
-            operationId: 'add_coffee'
-          }
+            operationId: 'add_coffee',
+          },
         },
         '/books/{id}': {
           parameters: [
             {
               name: 'id',
-              in: 'path'
-            }
+              in: 'path',
+            },
           ],
           get: {
-            operationId: 'getBook'
+            operationId: 'getBook',
           },
           delete: {
-            operationId: 'deleteBook'
+            operationId: 'deleteBook',
           },
           post: {
-            operationId: 'addBook'
+            operationId: 'addBook',
           },
           put: {
-            operationId: 'replaceBook'
+            operationId: 'replaceBook',
           },
           patch: {
-            operationId: 'updateBook'
+            operationId: 'updateBook',
           },
           head: {
-            operationId: 'headBook'
-          }
+            operationId: 'headBook',
+          },
         },
         '/coffee/{id}': {
           parameters: [
             {
               name: 'id',
-              in: 'path'
-            }
+              in: 'path',
+            },
           ],
           get: {
-            operationId: 'get_coffee'
+            operationId: 'get_coffee',
           },
           delete: {
-            operationId: 'delete_coffee'
+            operationId: 'delete_coffee',
           },
           post: {
-            operationId: 'create_coffee'
+            operationId: 'create_coffee',
           },
           put: {
-            operationId: 'replace_coffee'
+            operationId: 'replace_coffee',
           },
           patch: {
-            operationId: 'update_coffee'
-          }
-        }
-      }
+            operationId: 'update_coffee',
+          },
+        },
+      },
     };
 
     const resolvedSpec = await resolver.dereference(spec);

--- a/test/plugins/validation/2and3/operations-shared.test.js
+++ b/test/plugins/validation/2and3/operations-shared.test.js
@@ -1,14 +1,14 @@
 const expect = require('expect');
 const resolver = require('json-schema-ref-parser');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/operations-shared');
 
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
-describe('validation plugin - semantic - operations-shared', function() {
-  describe('Swagger 2', function() {
-    it('should complain about a missing operationId', function() {
+describe('validation plugin - semantic - operations-shared', function () {
+  describe('Swagger 2', function () {
+    it('should complain about a missing operationId', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -23,15 +23,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -43,7 +43,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should complain about an empty operationId', function() {
+    it('should complain about an empty operationId', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -59,15 +59,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -79,7 +79,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should complain about a missing summary', function() {
+    it('should complain about a missing summary', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -94,15 +94,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -114,7 +114,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should complain about an empty summary', function() {
+    it('should complain about an empty summary', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -130,15 +130,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -150,7 +150,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should not complain about anything when x-sdk-exclude is true', function() {
+    it('should not complain about anything when x-sdk-exclude is true', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -165,15 +165,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -181,7 +181,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should complain about an anonymous array response model', function() {
+    it('should complain about an anonymous array response model', function () {
       const spec = {
         paths: {
           '/stuff': {
@@ -195,14 +195,14 @@ describe('validation plugin - semantic - operations-shared', function() {
                   schema: {
                     type: 'array',
                     items: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -216,7 +216,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should complain about an anonymous array response model - from a $ref', async function() {
+    it('should complain about an anonymous array response model - from a $ref', async function () {
       const spec = {
         paths: {
           '/stuff': {
@@ -228,21 +228,21 @@ describe('validation plugin - semantic - operations-shared', function() {
                 200: {
                   description: 'successful operation',
                   schema: {
-                    $ref: '#/responses/Success'
-                  }
-                }
-              }
-            }
-          }
+                    $ref: '#/responses/Success',
+                  },
+                },
+              },
+            },
+          },
         },
         responses: {
           Success: {
             type: 'array',
             items: {
-              type: 'string'
-            }
-          }
-        }
+              type: 'string',
+            },
+          },
+        },
       };
 
       const resolvedSpec = await resolver.dereference(spec);
@@ -258,7 +258,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should complain about an anonymous array response model with no type but an `items` field', function() {
+    it('should complain about an anonymous array response model with no type but an `items` field', function () {
       const spec = {
         paths: {
           '/stuff': {
@@ -271,14 +271,14 @@ describe('validation plugin - semantic - operations-shared', function() {
                   description: 'successful operation',
                   schema: {
                     items: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -292,7 +292,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should not complain about an empty summary within a vendor extension', function() {
+    it('should not complain about an empty summary within a vendor extension', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -308,15 +308,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -324,7 +324,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should report required parameters before optional parameters', function() {
+    it('should report required parameters before optional parameters', function () {
       const spec = {
         paths: {
           '/stuff': {
@@ -336,24 +336,24 @@ describe('validation plugin - semantic - operations-shared', function() {
                 {
                   name: 'foo',
                   in: 'query',
-                  type: 'string'
+                  type: 'string',
                 },
                 {
                   name: 'bar',
                   in: 'query',
                   type: 'string',
-                  required: true
+                  required: true,
                 },
                 {
                   name: 'baz',
                   in: 'query',
                   type: 'string',
-                  required: true
-                }
-              ]
-            }
-          }
-        }
+                  required: true,
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -368,7 +368,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       );
     });
 
-    it('should report required ref parameters before optional ref parameters', async function() {
+    it('should report required ref parameters before optional ref parameters', async function () {
       const spec = {
         paths: {
           '/stuff': {
@@ -378,37 +378,37 @@ describe('validation plugin - semantic - operations-shared', function() {
               produces: ['application/json'],
               parameters: [
                 {
-                  $ref: '#/parameters/fooParam'
+                  $ref: '#/parameters/fooParam',
                 },
                 {
-                  $ref: '#/parameters/barParam'
+                  $ref: '#/parameters/barParam',
                 },
                 {
-                  $ref: '#/parameters/bazParam'
-                }
-              ]
-            }
-          }
+                  $ref: '#/parameters/bazParam',
+                },
+              ],
+            },
+          },
         },
         parameters: {
           fooParam: {
             name: 'foo',
             in: 'query',
-            type: 'string'
+            type: 'string',
           },
           barParam: {
             name: 'bar',
             in: 'query',
             type: 'string',
-            required: true
+            required: true,
           },
           bazParam: {
             name: 'foo',
             in: 'query',
             type: 'string',
-            required: true
-          }
-        }
+            required: true,
+          },
+        },
       };
 
       const resolvedSpec = await resolver.dereference(spec);
@@ -425,7 +425,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       );
     });
 
-    it('should not complain if required ref parameters appear before a required parameter', async function() {
+    it('should not complain if required ref parameters appear before a required parameter', async function () {
       const spec = {
         paths: {
           '/fake/{id}': {
@@ -435,21 +435,21 @@ describe('validation plugin - semantic - operations-shared', function() {
               produces: ['application/json'],
               parameters: [
                 {
-                  $ref: '#/parameters/Authorization'
+                  $ref: '#/parameters/Authorization',
                 },
                 {
-                  $ref: '#/parameters/ProjectId'
+                  $ref: '#/parameters/ProjectId',
                 },
                 {
                   name: 'id',
                   in: 'path',
                   type: 'string',
                   required: true,
-                  description: 'something'
-                }
-              ]
-            }
-          }
+                  description: 'something',
+                },
+              ],
+            },
+          },
         },
         parameters: {
           Authorization: {
@@ -458,14 +458,14 @@ describe('validation plugin - semantic - operations-shared', function() {
             description: 'Identity Access Management (IAM) bearer token.',
             required: true,
             type: 'string',
-            default: 'Bearer <token>'
+            default: 'Bearer <token>',
           },
           ProjectId: {
             name: 'project_id',
             in: 'query',
             description: 'The ID of the project to use.',
             required: true,
-            type: 'string'
+            type: 'string',
           },
           XOpenIDToken: {
             name: 'X-OpenID-Connect-ID-Token',
@@ -473,9 +473,9 @@ describe('validation plugin - semantic - operations-shared', function() {
             description: 'UAA token.',
             required: true,
             type: 'string',
-            default: '<token>'
-          }
-        }
+            default: '<token>',
+          },
+        },
       };
 
       const resolvedSpec = await resolver.dereference(spec);
@@ -485,7 +485,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should be able to handle parameters with `.` characters in the name', async function() {
+    it('should be able to handle parameters with `.` characters in the name', async function () {
       const spec = {
         paths: {
           '/fake/{id}': {
@@ -495,21 +495,21 @@ describe('validation plugin - semantic - operations-shared', function() {
               produces: ['application/json'],
               parameters: [
                 {
-                  $ref: '#/parameters/Authorization'
+                  $ref: '#/parameters/Authorization',
                 },
                 {
-                  $ref: '#/parameters/Project.Id'
+                  $ref: '#/parameters/Project.Id',
                 },
                 {
                   name: 'id',
                   in: 'path',
                   type: 'string',
                   required: true,
-                  description: 'something'
-                }
-              ]
-            }
-          }
+                  description: 'something',
+                },
+              ],
+            },
+          },
         },
         parameters: {
           Authorization: {
@@ -518,14 +518,14 @@ describe('validation plugin - semantic - operations-shared', function() {
             description: 'Identity Access Management (IAM) bearer token.',
             required: true,
             type: 'string',
-            default: 'Bearer <token>'
+            default: 'Bearer <token>',
           },
           'Project.Id': {
             name: 'project_id',
             in: 'query',
             description: 'The ID of the project to use.',
             required: true,
-            type: 'string'
+            type: 'string',
           },
           XOpenIDToken: {
             name: 'X-OpenID-Connect-ID-Token',
@@ -533,9 +533,9 @@ describe('validation plugin - semantic - operations-shared', function() {
             description: 'UAA token.',
             required: true,
             type: 'string',
-            default: '<token>'
-          }
-        }
+            default: '<token>',
+          },
+        },
       };
 
       const resolvedSpec = await resolver.dereference(spec);
@@ -545,7 +545,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should complain about an operationId with the wrong case', function() {
+    it('should complain about an operationId with the wrong case', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -561,15 +561,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -581,7 +581,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should not complain about a valid operationId', function() {
+    it('should not complain about a valid operationId', function () {
       const spec = {
         paths: {
           '/CoolPath': {
@@ -597,15 +597,15 @@ describe('validation plugin - semantic - operations-shared', function() {
                     required: ['Property'],
                     properties: [
                       {
-                        name: 'Property'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
+                        name: 'Property',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -614,8 +614,8 @@ describe('validation plugin - semantic - operations-shared', function() {
     });
   });
 
-  describe('OpenAPI 3', function() {
-    it('should complain about a top-level array response', function() {
+  describe('OpenAPI 3', function () {
+    it('should complain about a top-level array response', function () {
       const spec = {
         paths: {
           '/': {
@@ -627,33 +627,33 @@ describe('validation plugin - semantic - operations-shared', function() {
                 content: {
                   'application/json': {
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
+                      type: 'string',
+                    },
+                  },
+                },
               },
               responses: {
-                '200': {
+                200: {
                   content: {
                     'text/plain': {
                       schema: {
-                        type: 'string'
-                      }
+                        type: 'string',
+                      },
                     },
                     'application/json': {
                       schema: {
                         type: 'array',
                         items: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -667,7 +667,7 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should complain about a top-level array response without a type but with an `items` field', function() {
+    it('should complain about a top-level array response without a type but with an `items` field', function () {
       const spec = {
         paths: {
           '/': {
@@ -679,32 +679,32 @@ describe('validation plugin - semantic - operations-shared', function() {
                 content: {
                   'application/json': {
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
+                      type: 'string',
+                    },
+                  },
+                },
               },
               responses: {
-                '200': {
+                200: {
                   content: {
                     'text/plain': {
                       schema: {
-                        type: 'string'
-                      }
+                        type: 'string',
+                      },
                     },
                     'application/json': {
                       schema: {
                         items: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -718,15 +718,15 @@ describe('validation plugin - semantic - operations-shared', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should complain about an unused tag', function() {
+    it('should complain about an unused tag', function () {
       const spec = {
         tags: [
           {
-            name: 'some tag'
+            name: 'some tag',
           },
           {
-            name: 'some unused tag'
-          }
+            name: 'some unused tag',
+          },
         ],
         paths: {
           '/': {
@@ -735,19 +735,19 @@ describe('validation plugin - semantic - operations-shared', function() {
               tags: ['some tag'],
               summary: 'get everything as a string',
               responses: {
-                '200': {
+                200: {
                   content: {
                     'text/plain': {
                       schema: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -760,12 +760,12 @@ describe('validation plugin - semantic - operations-shared', function() {
       );
     });
 
-    it('should complain about an undefined tag', function() {
+    it('should complain about an undefined tag', function () {
       const spec = {
         tags: [
           {
-            name: 'some tag'
-          }
+            name: 'some tag',
+          },
         ],
         paths: {
           '/': {
@@ -774,35 +774,35 @@ describe('validation plugin - semantic - operations-shared', function() {
               tags: ['not a tag'],
               summary: 'get everything as a string',
               responses: {
-                '200': {
+                200: {
                   content: {
                     'text/plain': {
                       schema: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
             },
             post: {
               operationId: 'post_everything',
               tags: ['some tag'],
               summary: 'post everything as a string',
               responses: {
-                '200': {
+                200: {
                   content: {
                     'text/plain': {
                       schema: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -815,15 +815,15 @@ describe('validation plugin - semantic - operations-shared', function() {
       );
     });
 
-    it('should complain about a $ref in an operation', function() {
+    it('should complain about a $ref in an operation', function () {
       const jsSpec = {
         paths: {
           '/resource': {
             post: {
-              $ref: 'external.yaml#/some-post'
-            }
-          }
-        }
+              $ref: 'external.yaml#/some-post',
+            },
+          },
+        },
       };
 
       const resolvedSpec = {
@@ -832,10 +832,10 @@ describe('validation plugin - semantic - operations-shared', function() {
             post: {
               description: 'illegally referenced operation',
               operationId: 'create_resource',
-              summary: 'simple operation'
-            }
-          }
-        }
+              summary: 'simple operation',
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec, resolvedSpec, isOAS3: true }, config);

--- a/test/plugins/validation/2and3/parameters-ibm.test.js
+++ b/test/plugins/validation/2and3/parameters-ibm.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/parameters-ibm');
 
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
@@ -16,12 +16,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                 {
                   name: 'name',
                   in: 'query',
-                  type: 'string'
-                }
-              ]
-            }
-          }
-        }
+                  type: 'string',
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -32,7 +32,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '0'
+        '0',
       ]);
       expect(res.errors[0].message).toEqual(
         'Parameter objects must have a `description` field.'
@@ -49,12 +49,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   name: 'camelCase',
                   in: 'query',
                   description: 'description',
-                  type: 'string'
-                }
-              ]
-            }
-          }
-        }
+                  type: 'string',
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -65,7 +65,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '0'
+        '0',
       ]);
       expect(res.errors[0].message).toEqual(
         'Parameter names must follow case convention: lower_snake_case'
@@ -82,12 +82,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   name: 'camelCase',
                   in: 'header',
                   description: 'description',
-                  type: 'string'
-                }
-              ]
-            }
-          }
-        }
+                  type: 'string',
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -106,12 +106,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   in: 'query',
                   description: 'description',
                   type: 'string',
-                  deprecated: true
-                }
-              ]
-            }
-          }
-        }
+                  deprecated: true,
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -132,14 +132,14 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                       description: '     ',
                       in: 'query',
                       type: 'number',
-                      format: 'int32'
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
+                      format: 'int32',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -157,7 +157,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   name: 'name',
                   in: 'query',
                   type: 'string',
-                  description: 'good description'
+                  description: 'good description',
                 },
                 {
                   name: 'Accept',
@@ -166,19 +166,19 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                     'bad parameter because it specifies an accept type',
                   required: false,
                   type: 'string',
-                  enum: ['application/json', 'application/octet-stream']
+                  enum: ['application/json', 'application/octet-stream'],
                 },
                 {
                   name: 'content-Type',
                   in: 'header',
                   required: false,
                   type: 'string',
-                  description: 'another bad parameter'
-                }
-              ]
-            }
-          }
-        }
+                  description: 'another bad parameter',
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -189,7 +189,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '1'
+        '1',
       ]);
       expect(res.errors[0].message).toEqual(
         'Parameters must not explicitly define `Accept`. Rely on the `produces` field to specify accept-type.'
@@ -199,7 +199,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '2'
+        '2',
       ]);
       expect(res.errors[1].message).toEqual(
         'Parameters must not explicitly define `Content-Type`. Rely on the `consumes` field to specify content-type.'
@@ -218,12 +218,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   required: true,
                   description: 'tags to filter by',
                   type: 'string',
-                  default: 'reptile'
-                }
-              ]
-            }
-          }
-        }
+                  default: 'reptile',
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -233,7 +233,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '0'
+        '0',
       ]);
       expect(res.warnings[0].message).toEqual(
         'Required parameters should not specify default values.'
@@ -253,12 +253,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   required: false,
                   description: 'tags to filter by',
                   type: 'string',
-                  default: 'reptile'
-                }
-              ]
-            }
-          }
-        }
+                  default: 'reptile',
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -277,12 +277,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   in: 'formData',
                   type: 'file',
                   required: true,
-                  description: 'A file passed in formData'
-                }
-              ]
-            }
-          }
-        }
+                  description: 'A file passed in formData',
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: false }, config);
@@ -297,9 +297,9 @@ describe('validation plugin - semantic - parameters-ibm', () => {
             name: 'someparam',
             in: 'header',
             type: 'string',
-            required: true
-          }
-        ]
+            required: true,
+          },
+        ],
       };
 
       const res = validate({ jsSpec: spec, isOAS3: false }, config);
@@ -326,15 +326,15 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                       parameters: {
                         type: 'string',
                         description: 'this is a description',
-                        additionalProperties: {}
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                        additionalProperties: {},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
       expect(res.warnings.length).toEqual(0);
@@ -351,9 +351,9 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   name: 'name',
                   in: 'query',
                   schema: {
-                    type: 'string'
+                    type: 'string',
                   },
-                  description: 'good description'
+                  description: 'good description',
                 },
                 {
                   name: 'ACCEPT',
@@ -362,17 +362,17 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                     'bad parameter because it specifies an accept type',
                   required: false,
                   schema: {
-                    type: 'string'
-                  }
+                    type: 'string',
+                  },
                 },
                 {
                   name: 'content-type',
                   in: 'header',
                   required: false,
                   schema: {
-                    type: 'string'
+                    type: 'string',
                   },
-                  description: 'another bad parameter'
+                  description: 'another bad parameter',
                 },
                 {
                   name: 'Authorization',
@@ -380,13 +380,13 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   description: 'Identity Access Management (IAM) bearer token.',
                   required: false,
                   schema: {
-                    type: 'string'
-                  }
-                }
-              ]
-            }
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -397,7 +397,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '1'
+        '1',
       ]);
       expect(res.errors[0].message).toEqual(
         'Parameters must not explicitly define `Accept`. Rely on the `content` field of a response object to specify accept-type.'
@@ -407,7 +407,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '2'
+        '2',
       ]);
       expect(res.errors[1].message).toEqual(
         'Parameters must not explicitly define `Content-Type`. Rely on the `content` field of a request body or response object to specify content-type.'
@@ -417,7 +417,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '3'
+        '3',
       ]);
       expect(res.warnings[0].message).toEqual(
         'Parameters must not explicitly define `Authorization`. Rely on the `securitySchemes` and `security` fields to specify authorization methods. This check will be converted to an `error` in an upcoming release.'
@@ -432,11 +432,11 @@ describe('validation plugin - semantic - parameters-ibm', () => {
               in: 'query',
               name: 'bad_query_param',
               schema: {
-                type: 'string'
-              }
-            }
-          }
-        }
+                type: 'string',
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -445,7 +445,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
       expect(res.errors[0].path).toEqual([
         'components',
         'parameters',
-        'BadParam'
+        'BadParam',
       ]);
       expect(res.errors[0].message).toEqual(
         'Parameter objects must have a `description` field.'
@@ -465,13 +465,13 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   description: 'tags to filter by',
                   schema: {
                     type: 'string',
-                    default: 'reptile'
-                  }
-                }
-              ]
-            }
-          }
-        }
+                    default: 'reptile',
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -481,7 +481,7 @@ describe('validation plugin - semantic - parameters-ibm', () => {
         '/pets',
         'get',
         'parameters',
-        '0'
+        '0',
       ]);
       expect(res.warnings[0].message).toEqual(
         'Required parameters should not specify default values.'
@@ -500,13 +500,13 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                   in: 'query',
                   description: 'tags to filter by',
                   schema: {
-                    type: 'string'
-                  }
-                }
-              ]
-            }
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -524,12 +524,12 @@ describe('validation plugin - semantic - parameters-ibm', () => {
                 in: 'query',
                 schema: {
                   type: 'string',
-                  format: 'byte'
-                }
-              }
-            ]
-          }
-        }
+                  format: 'byte',
+                },
+              },
+            ],
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);

--- a/test/plugins/validation/2and3/paths-ibm.test.js
+++ b/test/plugins/validation/2and3/paths-ibm.test.js
@@ -1,14 +1,14 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/paths-ibm');
 
-describe('validation plugin - semantic - paths-ibm', function() {
-  it('should return an error when a path parameter is not correctly defined in an operation', function() {
+describe('validation plugin - semantic - paths-ibm', function () {
+  it('should return an error when a path parameter is not correctly defined in an operation', function () {
     const config = {
       paths: {
-        missing_path_parameter: 'error'
-      }
+        missing_path_parameter: 'error',
+      },
     };
 
     const spec = {
@@ -22,9 +22,9 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'good parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
+                format: 'int64',
+              },
+            ],
           },
           post: {
             parameters: [
@@ -34,10 +34,10 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'bad parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
-          }
+                format: 'int64',
+              },
+            ],
+          },
         },
         '/bogus/{id}/foo/{foo}/bar': {
           post: {
@@ -45,12 +45,12 @@ describe('validation plugin - semantic - paths-ibm', function() {
               {
                 name: 'baz',
                 in: 'query',
-                type: 'string'
-              }
-            ]
-          }
-        }
-      }
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -60,7 +60,7 @@ describe('validation plugin - semantic - paths-ibm', function() {
       'paths',
       '/cool_path/{id}',
       'post',
-      'parameters'
+      'parameters',
     ]);
     expect(res.errors[0].message).toEqual(
       'Operation must include a path parameter with name: id.'
@@ -69,7 +69,7 @@ describe('validation plugin - semantic - paths-ibm', function() {
       'paths',
       '/bogus/{id}/foo/{foo}/bar',
       'post',
-      'parameters'
+      'parameters',
     ]);
     expect(res.errors[1].message).toEqual(
       'Operation must include a path parameter with name: id.'
@@ -78,18 +78,18 @@ describe('validation plugin - semantic - paths-ibm', function() {
       'paths',
       '/bogus/{id}/foo/{foo}/bar',
       'post',
-      'parameters'
+      'parameters',
     ]);
     expect(res.errors[2].message).toEqual(
       'Operation must include a path parameter with name: foo.'
     );
   });
 
-  it('should not return an error for a missing path parameter when a path defines a global parameter', function() {
+  it('should not return an error for a missing path parameter when a path defines a global parameter', function () {
     const config = {
       paths: {
-        missing_path_parameter: 'error'
-      }
+        missing_path_parameter: 'error',
+      },
     };
 
     const spec = {
@@ -102,8 +102,8 @@ describe('validation plugin - semantic - paths-ibm', function() {
               description: 'good global parameter',
               required: true,
               type: 'integer',
-              format: 'int64'
-            }
+              format: 'int64',
+            },
           ],
           get: {
             parameters: [
@@ -113,9 +113,9 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'good overriding parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
+                format: 'int64',
+              },
+            ],
           },
           post: {
             parameters: [
@@ -125,12 +125,12 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'bad parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
-          }
-        }
-      }
+                format: 'int64',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -138,11 +138,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not return an error when incorrect path parameter is in an excluded operation', function() {
+  it('should not return an error when incorrect path parameter is in an excluded operation', function () {
     const config = {
       paths: {
-        missing_path_parameter: 'error'
-      }
+        missing_path_parameter: 'error',
+      },
     };
 
     const spec = {
@@ -156,9 +156,9 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'good parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
+                format: 'int64',
+              },
+            ],
           },
           post: {
             'x-sdk-exclude': true,
@@ -169,12 +169,12 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'bad parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
-          }
-        }
-      }
+                format: 'int64',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -182,11 +182,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not return an error when incorrect path parameter is in a vendor extension', function() {
+  it('should not return an error when incorrect path parameter is in a vendor extension', function () {
     const config = {
       paths: {
-        missing_path_parameter: 'error'
-      }
+        missing_path_parameter: 'error',
+      },
     };
 
     const spec = {
@@ -200,9 +200,9 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'good parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
+                format: 'int64',
+              },
+            ],
           },
           'x-vendor-post': {
             parameters: [
@@ -212,12 +212,12 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 description: 'bad parameter',
                 required: true,
                 type: 'integer',
-                format: 'int64'
-              }
-            ]
-          }
-        }
-      }
+                format: 'int64',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -225,17 +225,17 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should return one problem for an undefined declared path parameter', function() {
+  it('should return one problem for an undefined declared path parameter', function () {
     const config = {
       paths: {
-        missing_path_parameter: 'error'
-      }
+        missing_path_parameter: 'error',
+      },
     };
 
     const spec = {
       paths: {
-        '/cool_path/{id}': {}
-      }
+        '/cool_path/{id}': {},
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -246,11 +246,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.errors[0].path).toEqual(['paths', '/cool_path/{id}']);
   });
 
-  it('should return one problem for an undefined declared path parameter', function() {
+  it('should return one problem for an undefined declared path parameter', function () {
     const config = {
       paths: {
-        missing_path_parameter: 'error'
-      }
+        missing_path_parameter: 'error',
+      },
     };
 
     const spec = {
@@ -261,11 +261,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
               in: 'path',
               name: 'other_param',
               description: 'another parameter',
-              type: 'string'
-            }
-          ]
-        }
-      }
+              type: 'string',
+            },
+          ],
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -275,15 +275,15 @@ describe('validation plugin - semantic - paths-ibm', function() {
     );
     expect(res.errors[0].path).toEqual([
       'paths',
-      '/cool_path/{id}/more_path/{other_param}'
+      '/cool_path/{id}/more_path/{other_param}',
     ]);
   });
 
-  it('should flag a path segment that is not snake_case but should ignore path parameter', function() {
+  it('should flag a path segment that is not snake_case but should ignore path parameter', function () {
     const config = {
       paths: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -295,11 +295,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
               name: 'shouldntMatter',
               description:
                 'bad parameter but should be caught by another validator, not here',
-              type: 'string'
-            }
-          ]
-        }
-      }
+              type: 'string',
+            },
+          ],
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -307,19 +307,19 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(1);
     expect(res.warnings[0].path).toEqual([
       'paths',
-      '/v1/api/NotGoodSegment/{shouldntMatter}/resource'
+      '/v1/api/NotGoodSegment/{shouldntMatter}/resource',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Path segments must be lower snake case.'
     );
   });
 
-  it('should flag a path segment with a period in the name', function() {
+  it('should flag a path segment with a period in the name', function () {
     const config = {
       paths: {
         snake_case_only: 'off',
-        paths_case_convention: ['warning', 'lower_snake_case']
-      }
+        paths_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -330,11 +330,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
               in: 'path',
               name: 'id',
               description: 'id param',
-              type: 'string'
-            }
-          ]
-        }
-      }
+              type: 'string',
+            },
+          ],
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -342,19 +342,19 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(1);
     expect(res.warnings[0].path).toEqual([
       'paths',
-      '/v1/api/not.good_.segment/{id}/resource'
+      '/v1/api/not.good_.segment/{id}/resource',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Path segments must follow case convention: lower_snake_case'
     );
   });
 
-  it('should flag a path segment that does not follow paths_case_convention but should ignore path parameter', function() {
+  it('should flag a path segment that does not follow paths_case_convention but should ignore path parameter', function () {
     const config = {
       paths: {
         snake_case_only: 'off',
-        paths_case_convention: ['warning', 'lower_camel_case']
-      }
+        paths_case_convention: ['warning', 'lower_camel_case'],
+      },
     };
 
     const badSpec = {
@@ -366,11 +366,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
               name: 'shouldntMatter',
               description:
                 'bad parameter but should be caught by another validator, not here',
-              type: 'string'
-            }
-          ]
-        }
-      }
+              type: 'string',
+            },
+          ],
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: badSpec }, config);
@@ -378,19 +378,19 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(1);
     expect(res.warnings[0].path).toEqual([
       'paths',
-      '/v1/api/NotGoodSegment/{shouldntMatter}/resource'
+      '/v1/api/NotGoodSegment/{shouldntMatter}/resource',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Path segments must follow case convention: lower_camel_case'
     );
   });
 
-  it('should not flag a path segment that follows paths_case_convention and should ignore path parameter', function() {
+  it('should not flag a path segment that follows paths_case_convention and should ignore path parameter', function () {
     const config = {
       paths: {
         snake_case_only: 'off',
-        paths_case_convention: ['warning', 'lower_dash_case']
-      }
+        paths_case_convention: ['warning', 'lower_dash_case'],
+      },
     };
 
     const goodSpec = {
@@ -402,11 +402,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
               name: 'shouldntMatter',
               description:
                 'bad parameter but should be caught by another validator, not here',
-              type: 'string'
-            }
-          ]
-        }
-      }
+              type: 'string',
+            },
+          ],
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: goodSpec }, config);
@@ -414,11 +414,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should flag a common path parameter defined at the operation level', function() {
+  it('should flag a common path parameter defined at the operation level', function () {
     const config = {
       paths: {
-        duplicate_path_parameter: 'warning'
-      }
+        duplicate_path_parameter: 'warning',
+      },
     };
 
     const badSpec = {
@@ -432,9 +432,9 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 in: 'path',
                 required: true,
                 type: 'string',
-                description: 'id of the resource'
-              }
-            ]
+                description: 'id of the resource',
+              },
+            ],
           },
           post: {
             operationId: 'update_resource',
@@ -444,12 +444,12 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 in: 'path',
                 required: true,
                 type: 'string',
-                description: 'id of the resource'
-              }
-            ]
-          }
-        }
-      }
+                description: 'id of the resource',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: badSpec }, config);
@@ -460,7 +460,7 @@ describe('validation plugin - semantic - paths-ibm', function() {
       '/v1/api/resources/{id}',
       'get',
       'parameters',
-      '0'
+      '0',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Common path parameters should be defined on path object'
@@ -470,18 +470,18 @@ describe('validation plugin - semantic - paths-ibm', function() {
       '/v1/api/resources/{id}',
       'post',
       'parameters',
-      '0'
+      '0',
     ]);
     expect(res.warnings[1].message).toEqual(
       'Common path parameters should be defined on path object'
     );
   });
 
-  it('should not flag a common path parameter defined at the operation level if descriptions are different', function() {
+  it('should not flag a common path parameter defined at the operation level if descriptions are different', function () {
     const config = {
       paths: {
-        duplicate_path_parameter: 'warning'
-      }
+        duplicate_path_parameter: 'warning',
+      },
     };
 
     const goodSpec = {
@@ -495,9 +495,9 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 in: 'path',
                 required: true,
                 type: 'string',
-                description: 'id of the resource to retrieve'
-              }
-            ]
+                description: 'id of the resource to retrieve',
+              },
+            ],
           },
           post: {
             operationId: 'update_resource',
@@ -507,12 +507,12 @@ describe('validation plugin - semantic - paths-ibm', function() {
                 in: 'path',
                 required: true,
                 type: 'string',
-                description: 'id of the resource to update'
-              }
-            ]
-          }
-        }
-      }
+                description: 'id of the resource to update',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: goodSpec }, config);
@@ -520,11 +520,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not flag a common path parameter defined at the path level', function() {
+  it('should not flag a common path parameter defined at the path level', function () {
     const config = {
       paths: {
-        duplicate_path_parameter: 'warning'
-      }
+        duplicate_path_parameter: 'warning',
+      },
     };
 
     const goodSpec = {
@@ -536,17 +536,17 @@ describe('validation plugin - semantic - paths-ibm', function() {
               in: 'path',
               required: true,
               type: 'string',
-              description: 'id of the resource to retrieve'
-            }
+              description: 'id of the resource to retrieve',
+            },
           ],
           get: {
-            operationId: 'get_resource'
+            operationId: 'get_resource',
           },
           post: {
-            operationId: 'update_resource'
-          }
-        }
-      }
+            operationId: 'update_resource',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: goodSpec }, config);
@@ -554,11 +554,11 @@ describe('validation plugin - semantic - paths-ibm', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should catch redundant path parameter that exists in one operation but not the other', function() {
+  it('should catch redundant path parameter that exists in one operation but not the other', function () {
     const config = {
       paths: {
-        duplicate_path_parameter: 'warning'
-      }
+        duplicate_path_parameter: 'warning',
+      },
     };
 
     const goodSpec = {
@@ -570,23 +570,23 @@ describe('validation plugin - semantic - paths-ibm', function() {
               in: 'path',
               required: true,
               type: 'string',
-              description: 'id of the resource to retrieve'
-            }
+              description: 'id of the resource to retrieve',
+            },
           ],
           get: {
             operationId: 'get_resource',
             parameters: [
               {
                 name: 'id',
-                in: 'path'
-              }
-            ]
+                in: 'path',
+              },
+            ],
           },
           post: {
-            operationId: 'update_resource'
-          }
-        }
-      }
+            operationId: 'update_resource',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: goodSpec }, config);
@@ -596,7 +596,7 @@ describe('validation plugin - semantic - paths-ibm', function() {
       '/v1/api/resources/{id}',
       'get',
       'parameters',
-      '0'
+      '0',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Common path parameters should be defined on path object'

--- a/test/plugins/validation/2and3/paths.test.js
+++ b/test/plugins/validation/2and3/paths.test.js
@@ -1,11 +1,11 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/paths');
 
-describe('validation plugin - semantic - paths', function() {
-  describe('Path parameter definitions need matching paramater declarations', function() {
-    it('should not return problems for a valid definiton/declaration pair', function() {
+describe('validation plugin - semantic - paths', function () {
+  describe('Path parameter definitions need matching paramater declarations', function () {
+    it('should not return problems for a valid definiton/declaration pair', function () {
       const spec = {
         paths: {
           '/CoolPath/{id}': {
@@ -13,11 +13,11 @@ describe('validation plugin - semantic - paths', function() {
               {
                 name: 'id',
                 in: 'path',
-                description: 'An id'
-              }
-            ]
-          }
-        }
+                description: 'An id',
+              },
+            ],
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec });
@@ -27,11 +27,11 @@ describe('validation plugin - semantic - paths', function() {
   });
 
   describe('Empty path templates are not allowed', () => {
-    it('should return one problem for an empty path template', function() {
+    it('should return one problem for an empty path template', function () {
       const spec = {
         paths: {
-          '/CoolPath/{}': {}
-        }
+          '/CoolPath/{}': {},
+        },
       };
 
       const res = validate({ resolvedSpec: spec });
@@ -43,26 +43,26 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Path strings must be equivalently different', () => {
-      it('should return one problem for an equivalent templated path strings', function() {
+      it('should return one problem for an equivalent templated path strings', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
                   name: 'id',
-                  in: 'path'
-                }
-              ]
+                  in: 'path',
+                },
+              ],
             },
             '/CoolPath/{count}': {
               parameters: [
                 {
                   name: 'count',
-                  in: 'path'
-                }
-              ]
-            }
-          }
+                  in: 'path',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -72,7 +72,7 @@ describe('validation plugin - semantic - paths', function() {
         expect(res.errors[0].path).toEqual('paths./CoolPath/{count}');
       });
 
-      it('should return no problems for a templated and untemplated pair of path strings', function() {
+      it('should return no problems for a templated and untemplated pair of path strings', function () {
         const spec = {
           paths: {
             '/CoolPath/': {},
@@ -80,11 +80,11 @@ describe('validation plugin - semantic - paths', function() {
               parameters: [
                 {
                   name: 'count',
-                  in: 'path'
-                }
-              ]
-            }
-          }
+                  in: 'path',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -92,30 +92,30 @@ describe('validation plugin - semantic - paths', function() {
         expect(res.warnings.length).toEqual(0);
       });
 
-      it('should return no problems for a templated and double-templated set of path strings', function() {
+      it('should return no problems for a templated and double-templated set of path strings', function () {
         const spec = {
           paths: {
             '/CoolPath/{group_id}/all': {
               parameters: [
                 {
                   name: 'group_id',
-                  in: 'path'
-                }
-              ]
+                  in: 'path',
+                },
+              ],
             },
             '/CoolPath/{group_id}/{user_id}': {
               parameters: [
                 {
                   name: 'group_id',
-                  in: 'path'
+                  in: 'path',
                 },
                 {
                   name: 'user_id',
-                  in: 'path'
-                }
-              ]
-            }
-          }
+                  in: 'path',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -125,26 +125,26 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Paths must have unique name + in parameters', () => {
-      it('should return one problem for an name + in collision', function() {
+      it('should return one problem for an name + in collision', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
                   name: 'id',
-                  in: 'path'
-                }
-              ]
+                  in: 'path',
+                },
+              ],
             },
             '/CoolPath/{count}': {
               parameters: [
                 {
                   name: 'count',
-                  in: 'path'
-                }
-              ]
-            }
-          }
+                  in: 'path',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -155,22 +155,22 @@ describe('validation plugin - semantic - paths', function() {
         expect(res.errors[0].path).toEqual('paths./CoolPath/{count}');
       });
 
-      it('should return no problems for an name collision only', function() {
+      it('should return no problems for an name collision only', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
                   name: 'id',
-                  in: 'path'
+                  in: 'path',
                 },
                 {
                   name: 'id',
-                  in: 'query'
-                }
-              ]
-            }
-          }
+                  in: 'query',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -178,22 +178,22 @@ describe('validation plugin - semantic - paths', function() {
         expect(res.warnings.length).toEqual(0);
       });
 
-      it("should return no problems when 'in' is not defined", function() {
+      it("should return no problems when 'in' is not defined", function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
                   name: 'id',
-                  in: 'path'
+                  in: 'path',
                 },
                 {
-                  name: 'id'
+                  name: 'id',
                   // in: "path"
-                }
-              ]
-            }
-          }
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -203,18 +203,18 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Paths cannot have partial templates', () => {
-      it('should return no problems for a correct path template', function() {
+      it('should return no problems for a correct path template', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
                   name: 'id',
-                  in: 'path'
-                }
-              ]
-            }
-          }
+                  in: 'path',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -224,18 +224,18 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Paths cannot have query strings in them', () => {
-      it('should return no problems for a correct path template', function() {
+      it('should return no problems for a correct path template', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
                   name: 'id',
-                  in: 'path'
-                }
-              ]
-            }
-          }
+                  in: 'path',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -245,19 +245,19 @@ describe('validation plugin - semantic - paths', function() {
     });
 
     describe('Integrations', () => {
-      it.skip('should return two problems for an equivalent path string missing a parameter definition', function() {
+      it.skip('should return two problems for an equivalent path string missing a parameter definition', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
                   name: 'id',
-                  in: 'path'
-                }
-              ]
+                  in: 'path',
+                },
+              ],
             },
-            '/CoolPath/{count}': {}
-          }
+            '/CoolPath/{count}': {},
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -273,7 +273,7 @@ describe('validation plugin - semantic - paths', function() {
       });
     });
 
-    it('should not crash when `parameters` is not an array', function() {
+    it('should not crash when `parameters` is not an array', function () {
       const spec = {
         paths: {
           '/resource': {
@@ -285,22 +285,22 @@ describe('validation plugin - semantic - paths', function() {
                 allOf: [
                   {
                     name: 'one',
-                    type: 'string'
+                    type: 'string',
                   },
                   {
                     name: 'two',
-                    type: 'string'
-                  }
-                ]
+                    type: 'string',
+                  },
+                ],
               },
               responses: {
-                '200': {
-                  description: 'response'
-                }
-              }
-            }
-          }
-        }
+                200: {
+                  description: 'response',
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec });

--- a/test/plugins/validation/2and3/refs.test.js
+++ b/test/plugins/validation/2and3/refs.test.js
@@ -1,11 +1,11 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/refs');
 
-describe('validation plugin - semantic - refs', function() {
-  describe('Definitions should be referenced at least once in the document', function() {
-    it('should warn about an unused definition - Swagger 2', function() {
+describe('validation plugin - semantic - refs', function () {
+  describe('Definitions should be referenced at least once in the document', function () {
+    it('should warn about an unused definition - Swagger 2', function () {
       const jsSpec = {
         paths: {
           '/CoolPath/{id}': {
@@ -13,10 +13,10 @@ describe('validation plugin - semantic - refs', function() {
               {
                 name: 'id',
                 in: 'path',
-                description: 'An id'
-              }
-            ]
-          }
+                description: 'An id',
+              },
+            ],
+          },
         },
         definitions: {
           SchemaObject: {
@@ -24,11 +24,11 @@ describe('validation plugin - semantic - refs', function() {
             required: ['id'],
             properties: {
               id: {
-                type: 'string'
-              }
-            }
-          }
-        }
+                type: 'string',
+              },
+            },
+          },
+        },
       };
 
       const specStr = JSON.stringify(jsSpec, null, 2);
@@ -43,7 +43,7 @@ describe('validation plugin - semantic - refs', function() {
       );
     });
 
-    it('should warn about an unused schema definition - OpenAPI 3', function() {
+    it('should warn about an unused schema definition - OpenAPI 3', function () {
       const jsSpec = {
         paths: {
           '/CoolPath/{id}': {
@@ -51,10 +51,10 @@ describe('validation plugin - semantic - refs', function() {
               {
                 name: 'id',
                 in: 'path',
-                description: 'An id'
-              }
-            ]
-          }
+                description: 'An id',
+              },
+            ],
+          },
         },
         components: {
           schemas: {
@@ -63,12 +63,12 @@ describe('validation plugin - semantic - refs', function() {
               required: ['id'],
               properties: {
                 id: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
       };
 
       const specStr = JSON.stringify(jsSpec, null, 2);
@@ -83,7 +83,7 @@ describe('validation plugin - semantic - refs', function() {
       );
     });
 
-    it('should not warn about a used schema definition - OpenAPI 3', function() {
+    it('should not warn about a used schema definition - OpenAPI 3', function () {
       const jsSpec = {
         paths: {
           '/CoolPath/{id}': {
@@ -93,13 +93,13 @@ describe('validation plugin - semantic - refs', function() {
                 content: {
                   'application/json': {
                     schema: {
-                      $ref: '#/components/schemas/SchemaObject'
-                    }
-                  }
-                }
-              }
-            }
-          }
+                      $ref: '#/components/schemas/SchemaObject',
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
         components: {
           schemas: {
@@ -108,12 +108,12 @@ describe('validation plugin - semantic - refs', function() {
               required: ['id'],
               properties: {
                 id: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
       };
 
       const specStr = JSON.stringify(jsSpec, null, 2);
@@ -125,31 +125,31 @@ describe('validation plugin - semantic - refs', function() {
     });
   });
 
-  it('should warn about an unused parameter definition - OpenAPI 3', function() {
+  it('should warn about an unused parameter definition - OpenAPI 3', function () {
     const jsSpec = {
       paths: {
         '/CoolPath/{id}': {
           parameters: [
             {
-              $ref: '#/components/parameters/one_parameter_definition'
-            }
-          ]
-        }
+              $ref: '#/components/parameters/one_parameter_definition',
+            },
+          ],
+        },
       },
       components: {
         parameters: {
           one_parameter_definition: {
             name: 'id',
             in: 'path',
-            description: 'An id'
+            description: 'An id',
           },
           other_parameter_definition: {
             name: 'other',
             in: 'query',
-            description: 'another param'
-          }
-        }
-      }
+            description: 'another param',
+          },
+        },
+      },
     };
 
     const specStr = JSON.stringify(jsSpec, null, 2);
@@ -165,34 +165,34 @@ describe('validation plugin - semantic - refs', function() {
     expect(res.warnings.length).toEqual(1);
   });
 
-  it('should not warn about used parameter definitions - OpenAPI 3', function() {
+  it('should not warn about used parameter definitions - OpenAPI 3', function () {
     const jsSpec = {
       paths: {
         '/CoolPath/{id}': {
           parameters: [
             {
-              $ref: '#/components/parameters/one_parameter_definition'
+              $ref: '#/components/parameters/one_parameter_definition',
             },
             {
-              $ref: '#/components/parameters/other_parameter_definition'
-            }
-          ]
-        }
+              $ref: '#/components/parameters/other_parameter_definition',
+            },
+          ],
+        },
       },
       components: {
         parameters: {
           one_parameter_definition: {
             name: 'id',
             in: 'path',
-            description: 'An id'
+            description: 'An id',
           },
           other_parameter_definition: {
             name: 'other',
             in: 'query',
-            description: 'another param'
-          }
-        }
-      }
+            description: 'another param',
+          },
+        },
+      },
     };
 
     const specStr = JSON.stringify(jsSpec, null, 2);
@@ -202,23 +202,23 @@ describe('validation plugin - semantic - refs', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should warn about an unused response definition - OpenAPI 3', function() {
+  it('should warn about an unused response definition - OpenAPI 3', function () {
     const jsSpec = {
       paths: {
         '/CoolPath/{id}': {
           responses: {
-            '200': {
+            200: {
               description: '200 response',
               content: {
                 'application/json': {
                   schema: {
-                    type: 'string'
-                  }
-                }
-              }
-            }
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -227,13 +227,13 @@ describe('validation plugin - semantic - refs', function() {
             content: {
               'application/json': {
                 schema: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
-      }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const specStr = JSON.stringify(jsSpec, null, 2);
@@ -247,26 +247,26 @@ describe('validation plugin - semantic - refs', function() {
     expect(res.warnings.length).toEqual(1);
   });
 
-  it('should not warn about a used response definition - OpenAPI 3', function() {
+  it('should not warn about a used response definition - OpenAPI 3', function () {
     const jsSpec = {
       paths: {
         '/CoolPath/{id}': {
           responses: {
-            '200': {
+            200: {
               description: '200 response',
               content: {
                 'application/json': {
                   schema: {
-                    type: 'string'
-                  }
-                }
-              }
+                    type: 'string',
+                  },
+                },
+              },
             },
-            '400': {
-              $ref: '#/components/responses/response400'
-            }
-          }
-        }
+            400: {
+              $ref: '#/components/responses/response400',
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -275,13 +275,13 @@ describe('validation plugin - semantic - refs', function() {
             content: {
               'application/json': {
                 schema: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
-      }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const specStr = JSON.stringify(jsSpec, null, 2);

--- a/test/plugins/validation/2and3/responses.test.js
+++ b/test/plugins/validation/2and3/responses.test.js
@@ -1,14 +1,14 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/responses');
 
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
-describe('validation plugin - semantic - responses', function() {
-  describe('inline response schemas', function() {
-    describe('Swagger 2', function() {
-      it('should not complain for a valid response', function() {
+describe('validation plugin - semantic - responses', function () {
+  describe('inline response schemas', function () {
+    describe('Swagger 2', function () {
+      it('should not complain for a valid response', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -20,13 +20,13 @@ describe('validation plugin - semantic - responses', function() {
                   200: {
                     description: 'successful operation',
                     schema: {
-                      $ref: '#/definitions/ListStuffResponseModel'
-                    }
-                  }
-                }
-              }
-            }
-          }
+                      $ref: '#/definitions/ListStuffResponseModel',
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -34,7 +34,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should complain about an inline schema', function() {
+      it('should complain about an inline schema', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -49,15 +49,15 @@ describe('validation plugin - semantic - responses', function() {
                       type: 'object',
                       properties: {
                         stuff: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -68,7 +68,7 @@ describe('validation plugin - semantic - responses', function() {
           'get',
           'responses',
           '200',
-          'schema'
+          'schema',
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'
@@ -76,7 +76,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain about inline array schema with items defined as ref', function() {
+      it('should not complain about inline array schema with items defined as ref', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -90,14 +90,14 @@ describe('validation plugin - semantic - responses', function() {
                     schema: {
                       type: 'array',
                       items: {
-                        $ref: '#/components/schemas/ListStuffResponseModel'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                        $ref: '#/components/schemas/ListStuffResponseModel',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -105,7 +105,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain about inline array schema with primitive type items', function() {
+      it('should not complain about inline array schema with primitive type items', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -119,14 +119,14 @@ describe('validation plugin - semantic - responses', function() {
                     schema: {
                       type: 'array',
                       items: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -134,7 +134,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a response with no schema', function() {
+      it('should not complain for a response with no schema', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -144,12 +144,12 @@ describe('validation plugin - semantic - responses', function() {
                 produces: ['application/json'],
                 responses: {
                   200: {
-                    description: 'successful operation'
-                  }
-                }
-              }
-            }
-          }
+                    description: 'successful operation',
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -157,7 +157,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain about a bad pattern within an extension', function() {
+      it('should not complain about a bad pattern within an extension', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -172,15 +172,15 @@ describe('validation plugin - semantic - responses', function() {
                       type: 'object',
                       properties: {
                         stuff: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -189,8 +189,8 @@ describe('validation plugin - semantic - responses', function() {
       });
     });
 
-    describe('OpenAPI 3', function() {
-      it('should not complain for a valid response', function() {
+    describe('OpenAPI 3', function () {
+      it('should not complain for a valid response', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -203,15 +203,15 @@ describe('validation plugin - semantic - responses', function() {
                     content: {
                       'application/json': {
                         schema: {
-                          $ref: '#/components/schemas/ListStuffResponseModel'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                          $ref: '#/components/schemas/ListStuffResponseModel',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -219,7 +219,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a valid response in oneOf', function() {
+      it('should not complain for a valid response in oneOf', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -235,20 +235,20 @@ describe('validation plugin - semantic - responses', function() {
                           oneOf: [
                             {
                               $ref:
-                                '#/components/schemas/ListStuffResponseModel'
+                                '#/components/schemas/ListStuffResponseModel',
                             },
                             {
-                              $ref: '#/components/schemas/ListStuffSecondModel'
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                              $ref: '#/components/schemas/ListStuffSecondModel',
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -256,7 +256,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a valid response in allOf', function() {
+      it('should not complain for a valid response in allOf', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -272,20 +272,20 @@ describe('validation plugin - semantic - responses', function() {
                           allOf: [
                             {
                               $ref:
-                                '#/components/schemas/ListStuffResponseModel'
+                                '#/components/schemas/ListStuffResponseModel',
                             },
                             {
-                              $ref: '#/components/schemas/ListStuffSecondModel'
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                              $ref: '#/components/schemas/ListStuffSecondModel',
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -293,7 +293,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a valid response in anyOf', function() {
+      it('should not complain for a valid response in anyOf', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -309,20 +309,20 @@ describe('validation plugin - semantic - responses', function() {
                           anyOf: [
                             {
                               $ref:
-                                '#/components/schemas/ListStuffResponseModel'
+                                '#/components/schemas/ListStuffResponseModel',
                             },
                             {
-                              $ref: '#/components/schemas/ListStuffSecondModel'
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                              $ref: '#/components/schemas/ListStuffSecondModel',
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -330,7 +330,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a valid combined schema where one schema is an array with items defined as ref', function() {
+      it('should not complain for a valid combined schema where one schema is an array with items defined as ref', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -346,24 +346,24 @@ describe('validation plugin - semantic - responses', function() {
                           anyOf: [
                             {
                               $ref:
-                                '#/components/schemas/ListStuffResponseModel'
+                                '#/components/schemas/ListStuffResponseModel',
                             },
                             {
                               type: 'array',
                               items: {
                                 $ref:
-                                  '#/components/schemas/ListStuffSecondModel'
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                                  '#/components/schemas/ListStuffSecondModel',
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -371,7 +371,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a valid combined schema where one schema is an array with items defined as ref', function() {
+      it('should not complain for a valid combined schema where one schema is an array with items defined as ref', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -386,16 +386,16 @@ describe('validation plugin - semantic - responses', function() {
                         schema: {
                           type: 'array',
                           items: {
-                            $ref: '#/components/schemas/ListStuffResponseModel'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                            $ref: '#/components/schemas/ListStuffResponseModel',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -403,7 +403,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should complain about an inline schema', function() {
+      it('should complain about an inline schema', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -419,17 +419,17 @@ describe('validation plugin - semantic - responses', function() {
                           type: 'object',
                           properties: {
                             stuff: {
-                              type: 'string'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -442,7 +442,7 @@ describe('validation plugin - semantic - responses', function() {
           '200',
           'content',
           'application/json',
-          'schema'
+          'schema',
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'
@@ -450,7 +450,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should complain about an inline schema when using oneOf', function() {
+      it('should complain about an inline schema when using oneOf', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -465,20 +465,20 @@ describe('validation plugin - semantic - responses', function() {
                         schema: {
                           oneOf: [
                             {
-                              type: 'object'
+                              type: 'object',
                             },
                             {
-                              $ref: 'ref1'
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                              $ref: 'ref1',
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -493,7 +493,7 @@ describe('validation plugin - semantic - responses', function() {
           'application/json',
           'schema',
           'oneOf',
-          0
+          0,
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'
@@ -501,7 +501,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should complain about an inline schema when using allOf', function() {
+      it('should complain about an inline schema when using allOf', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -516,20 +516,20 @@ describe('validation plugin - semantic - responses', function() {
                         schema: {
                           allOf: [
                             {
-                              type: 'object'
+                              type: 'object',
                             },
                             {
-                              $ref: 'ref1'
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                              $ref: 'ref1',
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -544,7 +544,7 @@ describe('validation plugin - semantic - responses', function() {
           'application/json',
           'schema',
           'allOf',
-          0
+          0,
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'
@@ -552,7 +552,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should complain about an inline schema when using anyOf', function() {
+      it('should complain about an inline schema when using anyOf', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -567,20 +567,20 @@ describe('validation plugin - semantic - responses', function() {
                         schema: {
                           anyOf: [
                             {
-                              type: 'object'
+                              type: 'object',
                             },
                             {
-                              $ref: 'ref1'
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                              $ref: 'ref1',
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -595,7 +595,7 @@ describe('validation plugin - semantic - responses', function() {
           'application/json',
           'schema',
           'anyOf',
-          0
+          0,
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'
@@ -603,7 +603,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain for a response with no schema', function() {
+      it('should not complain for a response with no schema', function () {
         const spec = {
           paths: {
             '/stuff': {
@@ -612,12 +612,12 @@ describe('validation plugin - semantic - responses', function() {
                 operationId: 'listStuff',
                 responses: {
                   200: {
-                    description: 'successful operation'
-                  }
-                }
-              }
-            }
-          }
+                    description: 'successful operation',
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -625,7 +625,7 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should complain when a response component has an inline schema', function() {
+      it('should complain when a response component has an inline schema', function () {
         const spec = {
           components: {
             responses: {
@@ -637,15 +637,15 @@ describe('validation plugin - semantic - responses', function() {
                       type: 'object',
                       properties: {
                         stuff: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -656,7 +656,7 @@ describe('validation plugin - semantic - responses', function() {
           'ListStuffResponse',
           'content',
           'application/json',
-          'schema'
+          'schema',
         ]);
         expect(res.warnings[0].message).toEqual(
           'Response schemas should be defined with a named ref.'
@@ -664,12 +664,12 @@ describe('validation plugin - semantic - responses', function() {
         expect(res.errors.length).toEqual(0);
       });
 
-      it('should not complain about non-json response that defines an inline schema', function() {
+      it('should not complain about non-json response that defines an inline schema', function () {
         const config = {
           responses: {
             no_response_codes: 'error',
-            no_success_response_codes: 'warning'
-          }
+            no_success_response_codes: 'warning',
+          },
         };
 
         const spec = {
@@ -679,21 +679,21 @@ describe('validation plugin - semantic - responses', function() {
                 summary: 'this is a summary',
                 operationId: 'operationId',
                 responses: {
-                  '400': {
+                  400: {
                     description: 'bad request',
                     content: {
                       'plain/text': {
                         schema: {
                           type: 'string',
-                          format: 'binary'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);

--- a/test/plugins/validation/2and3/schema-ibm.test.js
+++ b/test/plugins/validation/2and3/schema-ibm.test.js
@@ -2,7 +2,7 @@ const expect = require('expect');
 const yaml = require('js-yaml');
 const fs = require('fs');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/schema-ibm');
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
@@ -17,11 +17,11 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
             level: {
               type: 'number',
               format: 'integer',
-              description: 'Good to have a description'
-            }
-          }
-        }
-      }
+              description: 'Good to have a description',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -31,7 +31,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'WordStyle',
       'properties',
       'level',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'Schema of type number should use one of the following formats: float, double.'
@@ -45,9 +45,9 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
         WordStyle: {
           type: 'number',
           format: 'integer',
-          description: 'word style'
-        }
-      }
+          description: 'word style',
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -71,12 +71,12 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
               description: 'has some items',
               items: {
                 type: 'number',
-                format: 'integer'
-              }
-            }
-          }
-        }
-      }
+                format: 'integer',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -87,7 +87,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'properties',
       'level',
       'items',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'Schema of type number should use one of the following formats: float, double.'
@@ -106,16 +106,16 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
               type: 'array',
               description: 'has one item, its a ref',
               items: {
-                $ref: '#/definitions/levelItem'
-              }
-            }
-          }
+                $ref: '#/definitions/levelItem',
+              },
+            },
+          },
         },
         levelItem: {
           type: 'string',
-          description: 'level item'
-        }
-      }
+          description: 'level item',
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -132,12 +132,12 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
               level: {
                 type: 'number',
                 format: 'integer',
-                description: 'i need better types'
-              }
-            }
-          }
-        }
-      }
+                description: 'i need better types',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -148,7 +148,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'schema',
       'properties',
       'level',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'Schema of type number should use one of the following formats: float, double.'
@@ -162,16 +162,16 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
         '/pets': {
           get: {
             responses: {
-              '200': {
+              200: {
                 description: 'legal response',
                 schema: {
-                  type: 'file'
-                }
-              }
-            }
-          }
-        }
-      }
+                  type: 'file',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -189,12 +189,12 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                 name: 'file_param',
                 in: 'query',
                 description: 'a file param',
-                type: 'file'
-              }
-            ]
-          }
-        }
-      }
+                type: 'file',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: false }, config);
@@ -215,12 +215,12 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                 in: 'query',
                 description: 'a file param',
                 type: 'file',
-                format: 'file_should_not_have_a_format'
-              }
-            ]
-          }
-        }
-      }
+                format: 'file_should_not_have_a_format',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: false }, config);
@@ -243,12 +243,12 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                 name: 'file_param',
                 in: 'formData',
                 description: 'a file param',
-                type: 'file'
-              }
-            ]
-          }
-        }
-      }
+                type: 'file',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: false }, config);
@@ -260,9 +260,9 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       definitions: {
         SomeSchema: {
           type: 'file',
-          description: 'file schema, used for parameter or response'
-        }
-      }
+          description: 'file schema, used for parameter or response',
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -274,9 +274,9 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     const spec = {
       definitions: {
         SomeSchema: {
-          type: 'invalid_type'
-        }
-      }
+          type: 'invalid_type',
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -292,21 +292,21 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
         '/pets': {
           get: {
             responses: {
-              '200': {
+              200: {
                 description: 'legal response',
                 schema: {
                   properties: {
                     this_is_bad: {
                       type: 'file',
-                      description: 'non-root type of file is bad'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      description: 'non-root type of file is bad',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -320,7 +320,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'schema',
       'properties',
       'this_is_bad',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'File type only valid for swagger2 and must be used as root schema.'
@@ -332,8 +332,8 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
   it('should return a warning when a property name is not snake case', () => {
     const customConfig = {
       schemas: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -344,11 +344,11 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
           properties: {
             thingString: {
               type: 'string',
-              description: 'thing string'
-            }
-          }
-        }
-      }
+              description: 'thing string',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, customConfig);
@@ -358,7 +358,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'definitions',
       'Thing',
       'properties',
-      'thingString'
+      'thingString',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Property names must be lower snake case.'
@@ -368,8 +368,8 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
   it('should return a warning when an items property name is not snake case', () => {
     const customConfig = {
       schemas: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -386,14 +386,14 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                 properties: {
                   thingString: {
                     type: 'string',
-                    description: 'thing string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    description: 'thing string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, customConfig);
@@ -406,7 +406,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'thing',
       'items',
       'properties',
-      'thingString'
+      'thingString',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Property names must be lower snake case.'
@@ -418,8 +418,8 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        property_case_convention: ['warning', 'lower_snake_case']
-      }
+        property_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -430,11 +430,11 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
           properties: {
             thingString: {
               type: 'string',
-              description: 'thing string'
-            }
-          }
-        }
-      }
+              description: 'thing string',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, customConfig);
@@ -444,7 +444,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'definitions',
       'Thing',
       'properties',
-      'thingString'
+      'thingString',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Property names must follow case convention: lower_snake_case'
@@ -455,8 +455,8 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        property_case_convention: ['warning', 'lower_snake_case']
-      }
+        property_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -473,14 +473,14 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                 properties: {
                   thingString: {
                     type: 'string',
-                    description: 'thing string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    description: 'thing string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, customConfig);
@@ -493,7 +493,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'thing',
       'items',
       'properties',
-      'thingString'
+      'thingString',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Property names must follow case convention: lower_snake_case'
@@ -504,8 +504,8 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        property_case_convention: ['warning', 'lower_snake_case']
-      }
+        property_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -522,14 +522,14 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                 properties: {
                   thing_string: {
                     type: 'string',
-                    description: 'thing string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    description: 'thing string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, customConfig);
@@ -542,8 +542,8 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        property_case_collision: 'warning'
-      }
+        property_case_collision: 'warning',
+      },
     };
 
     const spec = {
@@ -554,15 +554,15 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
           properties: {
             thingString: {
               type: 'string',
-              description: 'thing string'
+              description: 'thing string',
             },
             thing_string: {
               type: 'string',
-              description: 'thing string'
-            }
-          }
-        }
-      }
+              description: 'thing string',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, customConfig);
@@ -572,7 +572,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'definitions',
       'Thing',
       'properties',
-      'thing_string'
+      'thing_string',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Property name is identical to another property except for the naming convention: thing_string'
@@ -589,11 +589,11 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
             thingName: {
               type: 'string',
               description: 'thing name',
-              deprecated: true
-            }
-          }
-        }
-      }
+              deprecated: true,
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -610,19 +610,19 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
             id: {
               type: 'integer',
               format: 'int64',
-              description: 'string'
+              description: 'string',
             },
             name: {
               type: 'string',
-              description: 'string'
+              description: 'string',
             },
             tag: {
               type: 'string',
-              description: 'string'
-            }
-          }
-        }
-      }
+              description: 'string',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -648,15 +648,15 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                   type: 'object',
                   properties: {
                     bad_property: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -671,7 +671,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'schema',
       'properties',
       'bad_property',
-      'description'
+      'description',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Schema properties must have a description with content in it.'
@@ -693,15 +693,15 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                   properties: {
                     any_object: {
                       type: 'object',
-                      description: 'it is not always a JSON object'
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                      description: 'it is not always a JSON object',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -716,7 +716,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'schema',
       'properties',
       'any_object',
-      'description'
+      'description',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Not all languages use JSON, so descriptions should not state that the model is a JSON object.'
@@ -734,16 +734,16 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
               type: 'string',
               readOnly: true,
               description:
-                'Identifies the notice. Many notices may have the same ID. This field exists so that user applications can programmatically identify a notice and take automatic corrective action.'
+                'Identifies the notice. Many notices may have the same ID. This field exists so that user applications can programmatically identify a notice and take automatic corrective action.',
             },
             description: {
               type: 'string',
               readOnly: true,
-              description: 'The description of the notice'
-            }
-          }
-        }
-      }
+              description: 'The description of the notice',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -766,15 +766,15 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
                   properties: {
                     'x-vendor-anyObject': {
                       type: 'object',
-                      description: 'it is not always a JSON object'
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
+                      description: 'it is not always a JSON object',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -794,12 +794,12 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
               description: 'has some items',
               items: {
                 type: 'array',
-                description: 'array nested in an array'
-              }
-            }
-          }
-        }
-      }
+                description: 'array nested in an array',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -811,7 +811,7 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
       'properties',
       'level',
       'items',
-      'type'
+      'type',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Array properties should avoid having items of type array.'
@@ -830,20 +830,20 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
               id: {
                 type: 'integer',
                 format: 'int64',
-                description: 'string'
+                description: 'string',
               },
               name: {
                 type: 'string',
-                description: 'string'
+                description: 'string',
               },
               tag: {
                 type: 'string',
-                description: 'string'
-              }
-            }
-          }
-        }
-      }
+                description: 'string',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -870,15 +870,15 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                     bad_prop: {
                       description: 'property with bad format',
                       type: 'integer',
-                      format: 'wrong'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      format: 'wrong',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -892,7 +892,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'schema',
       'properties',
       'bad_prop',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'Schema of type integer should use one of the following formats: int32, int64.'
@@ -914,13 +914,13 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                 items: {
                   description: 'invalid items',
                   type: 'object',
-                  format: 'objects_should_not_have_formats'
-                }
-              }
-            }
-          }
-        }
-      }
+                  format: 'objects_should_not_have_formats',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -932,7 +932,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'thing',
       'items',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'Schema of type object should not have a format.'
@@ -950,20 +950,20 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
               prop1: {
                 description: 'an object property',
                 type: 'string',
-                format: 'byte'
-              }
-            }
+                format: 'byte',
+              },
+            },
           },
           Thing2: {
             type: 'array',
             description: 'an array',
             items: {
               type: 'number',
-              format: 'float'
-            }
-          }
-        }
-      }
+              format: 'float',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -987,15 +987,15 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                     type: 'array',
                     format: 'arrays_should_not_have_formats',
                     items: {
-                      type: 'invalid_type'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'invalid_type',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -1008,7 +1008,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'thing',
       'properties',
       'prop1',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'Schema of type array should not have a format.'
@@ -1022,7 +1022,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'prop1',
       'items',
-      'type'
+      'type',
     ]);
     expect(res.errors[1].message).toEqual(
       'Invalid type. Valid types are: integer, number, string, boolean, object, array.'
@@ -1039,12 +1039,12 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             properties: {
               thing: {
                 description: 'should not have format without type',
-                format: 'byte'
-              }
-            }
-          }
-        }
-      }
+                format: 'byte',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -1058,19 +1058,19 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
         '/pets': {
           get: {
             responses: {
-              '200': {
+              200: {
                 content: {
                   'application/json': {
                     schema: {
-                      type: 'file'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'file',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -1084,7 +1084,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'content',
       'application/json',
       'schema',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'File type only valid for swagger2 and must be used as root schema.'
@@ -1098,7 +1098,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
         '/pets': {
           get: {
             responses: {
-              '200': {
+              200: {
                 content: {
                   'application/json': {
                     schema: {
@@ -1107,9 +1107,9 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                         prop: {
                           description: 'boolean types should not have formats',
                           type: 'boolean',
-                          format: 'boolean'
-                        }
-                      }
+                          format: 'boolean',
+                        },
+                      },
                     },
                     example: {
                       schema: {
@@ -1117,18 +1117,18 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                         properties: {
                           prop: {
                             type: 'boolean',
-                            format: 'boolean'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                            format: 'boolean',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -1144,7 +1144,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'schema',
       'properties',
       'prop',
-      'type'
+      'type',
     ]);
     expect(res.errors[0].message).toEqual(
       'Schema of type boolean should not have a format.'
@@ -1181,21 +1181,21 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'components',
       'schemas',
       'oneOfError',
-      'oneOf'
+      'oneOf',
     ]);
     expect(res.errors[1].message).toEqual('allOf value should be an array');
     expect(res.errors[1].path).toEqual([
       'components',
       'schemas',
       'allOfError',
-      'allOf'
+      'allOf',
     ]);
     expect(res.errors[2].message).toEqual('anyOf value should be an array');
     expect(res.errors[2].path).toEqual([
       'components',
       'schemas',
       'anyOfError',
-      'anyOf'
+      'anyOf',
     ]);
   });
 
@@ -1215,7 +1215,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'complexOneOfError',
       'oneOf',
       0,
-      'oneOf'
+      'oneOf',
     ]);
     expect(res.errors[1].message).toEqual('allOf value should be an array');
     expect(res.errors[1].path).toEqual([
@@ -1224,7 +1224,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'complexAllOfError',
       'oneOf',
       0,
-      'allOf'
+      'allOf',
     ]);
     expect(res.errors[2].message).toEqual('anyOf value should be an array');
     expect(res.errors[2].path).toEqual([
@@ -1233,7 +1233,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'complexAnyOfError',
       'oneOf',
       0,
-      'anyOf'
+      'anyOf',
     ]);
   });
 
@@ -1254,7 +1254,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'one_of_error_prop',
       'schema',
-      'oneOf'
+      'oneOf',
     ]);
     expect(res.errors[1].message).toEqual('allOf value should be an array');
     expect(res.errors[1].path).toEqual([
@@ -1264,7 +1264,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'all_of_error_prop',
       'schema',
-      'allOf'
+      'allOf',
     ]);
     expect(res.errors[2].message).toEqual('anyOf value should be an array');
     expect(res.errors[2].path).toEqual([
@@ -1274,7 +1274,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'any_of_error_prop',
       'schema',
-      'anyOf'
+      'anyOf',
     ]);
   });
 
@@ -1293,7 +1293,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'schemas',
       'one_of_array',
       'items',
-      'oneOf'
+      'oneOf',
     ]);
     expect(res.errors[1].message).toEqual('allOf value should be an array');
     expect(res.errors[1].path).toEqual([
@@ -1301,7 +1301,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'schemas',
       'all_of_array',
       'items',
-      'allOf'
+      'allOf',
     ]);
     expect(res.errors[2].message).toEqual('anyOf value should be an array');
     expect(res.errors[2].path).toEqual([
@@ -1309,7 +1309,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'schemas',
       'any_of_array',
       'items',
-      'anyOf'
+      'anyOf',
     ]);
   });
 
@@ -1327,8 +1327,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
   it('should return a warning when an enum value is not snake case', () => {
     const customConfig = {
       schemas: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -1340,11 +1340,11 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             color: {
               type: 'string',
               description: 'some color',
-              enum: ['blue', 'light_blue', 'darkBlue']
-            }
-          }
-        }
-      }
+              enum: ['blue', 'light_blue', 'darkBlue'],
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1356,7 +1356,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'color',
       'enum',
-      '2'
+      '2',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must be lower snake case.'
@@ -1366,8 +1366,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
   it('should return a warning when an enum value is not snake case', () => {
     const customConfig = {
       schemas: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -1384,13 +1384,13 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                 items: {
                   type: 'string',
                   description: 'the values',
-                  enum: ['all', 'enumValues', 'possible']
-                }
-              }
-            ]
-          }
-        }
-      }
+                  enum: ['all', 'enumValues', 'possible'],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1404,7 +1404,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '0',
       'items',
       'enum',
-      '1'
+      '1',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must be lower snake case.'
@@ -1414,8 +1414,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
   it('should return a warning when an enum value is not snake case', () => {
     const customConfig = {
       schemas: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -1427,11 +1427,11 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             color: {
               type: 'string',
               description: 'some color',
-              enum: ['blue', 'light_blue', 'darkBlue']
-            }
-          }
-        }
-      }
+              enum: ['blue', 'light_blue', 'darkBlue'],
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1443,7 +1443,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'color',
       'enum',
-      '2'
+      '2',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must be lower snake case.'
@@ -1453,8 +1453,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
   it('should return a warning when an enum value is not snake case', () => {
     const customConfig = {
       schemas: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -1471,13 +1471,13 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                 items: {
                   type: 'string',
                   description: 'the values',
-                  enum: ['all', 'enumValues', 'possible']
-                }
-              }
-            ]
-          }
-        }
-      }
+                  enum: ['all', 'enumValues', 'possible'],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1491,7 +1491,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '0',
       'items',
       'enum',
-      '1'
+      '1',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must be lower snake case.'
@@ -1503,8 +1503,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        enum_case_convention: ['warning', 'lower_snake_case']
-      }
+        enum_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -1516,11 +1516,11 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             color: {
               type: 'string',
               description: 'some color',
-              enum: ['blue', 'light_blue', 'darkBlue']
-            }
-          }
-        }
-      }
+              enum: ['blue', 'light_blue', 'darkBlue'],
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1532,7 +1532,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'color',
       'enum',
-      '2'
+      '2',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must follow case convention: lower_snake_case'
@@ -1543,8 +1543,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        enum_case_convention: ['warning', 'lower_snake_case']
-      }
+        enum_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -1561,13 +1561,13 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                 items: {
                   type: 'string',
                   description: 'the values',
-                  enum: ['all', 'enumValues', 'possible']
-                }
-              }
-            ]
-          }
-        }
-      }
+                  enum: ['all', 'enumValues', 'possible'],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1581,7 +1581,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '0',
       'items',
       'enum',
-      '1'
+      '1',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must follow case convention: lower_snake_case'
@@ -1592,8 +1592,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        enum_case_convention: ['warning', 'lower_snake_case']
-      }
+        enum_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -1605,11 +1605,11 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             color: {
               type: 'string',
               description: 'some color',
-              enum: ['blue', 'light_blue', 'darkBlue']
-            }
-          }
-        }
-      }
+              enum: ['blue', 'light_blue', 'darkBlue'],
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1621,7 +1621,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'properties',
       'color',
       'enum',
-      '2'
+      '2',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must follow case convention: lower_snake_case'
@@ -1632,8 +1632,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
     const customConfig = {
       schemas: {
         snake_case_only: 'off',
-        enum_case_convention: ['warning', 'lower_snake_case']
-      }
+        enum_case_convention: ['warning', 'lower_snake_case'],
+      },
     };
 
     const spec = {
@@ -1650,13 +1650,13 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
                 items: {
                   type: 'string',
                   description: 'the values',
-                  enum: ['all', 'enumValues', 'possible']
-                }
-              }
-            ]
-          }
-        }
-      }
+                  enum: ['all', 'enumValues', 'possible'],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1670,7 +1670,7 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       '0',
       'items',
       'enum',
-      '1'
+      '1',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Enum values must follow case convention: lower_snake_case'
@@ -1680,8 +1680,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
   it('should skip validation for non string values', () => {
     const customConfig = {
       schemas: {
-        snake_case_only: 'warning'
-      }
+        snake_case_only: 'warning',
+      },
     };
 
     const spec = {
@@ -1693,11 +1693,11 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             integer: {
               type: 'integer',
               description: 'an integer',
-              enum: [1, 2, 3]
-            }
-          }
-        }
-      }
+              enum: [1, 2, 3],
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec, isOAS3: true }, customConfig);
@@ -1714,30 +1714,30 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             properties: {
               name: {
                 description: 'type integer',
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           adult: {
             description: 'Causes first warnings',
             properties: {
               name: {
                 description: 'different type',
-                type: 'number'
-              }
-            }
+                type: 'number',
+              },
+            },
           },
           kid: {
             description: 'Causes second warning',
             properties: {
               name: {
                 type: 'string',
-                description: 'differnt type'
-              }
-            }
-          }
-        }
-      }
+                description: 'differnt type',
+              },
+            },
+          },
+        },
+      },
     };
 
     const message = 'Property has inconsistent type: name.';
@@ -1769,30 +1769,30 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             properties: {
               name: {
                 description: 'type integer',
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           adult: {
             description: 'Causes first warnings',
             properties: {
               code: {
                 description: 'different type',
-                type: 'number'
-              }
-            }
+                type: 'number',
+              },
+            },
           },
           kid: {
             description: 'Causes second warning',
             properties: {
               code: {
                 type: 'string',
-                description: 'differnt type'
-              }
-            }
-          }
-        }
-      }
+                description: 'differnt type',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -1804,8 +1804,8 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
   it('should not produce a warning for properties with duplicate custom names', () => {
     const customConfig = {
       schemas: {
-        inconsistent_property_type: ['warning', ['year']]
-      }
+        inconsistent_property_type: ['warning', ['year']],
+      },
     };
 
     const spec = {
@@ -1816,30 +1816,30 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
             properties: {
               year: {
                 description: 'type integer',
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           adult: {
             description: 'Causes first warnings',
             properties: {
               year: {
                 description: 'different type',
-                type: 'number'
-              }
-            }
+                type: 'number',
+              },
+            },
           },
           kid: {
             description: 'Causes second warning',
             properties: {
               year: {
                 type: 'string',
-                description: 'differnt type'
-              }
-            }
-          }
-        }
-      }
+                description: 'differnt type',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, customConfig);

--- a/test/plugins/validation/2and3/security-definitions-ibm.test.js
+++ b/test/plugins/validation/2and3/security-definitions-ibm.test.js
@@ -1,40 +1,40 @@
 const expect = require('expect');
 const resolver = require('json-schema-ref-parser');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/security-definitions-ibm');
 
 const config = {
   security_definitions: {
     unused_security_schemes: 'warning',
-    unused_security_scopes: 'warning'
-  }
+    unused_security_scopes: 'warning',
+  },
 };
 
-describe('validation plugin - semantic - security-definitions-ibm', function() {
-  describe('Swagger 2', function() {
-    it('should warn about an unused security definition', function() {
+describe('validation plugin - semantic - security-definitions-ibm', function () {
+  describe('Swagger 2', function () {
+    it('should warn about an unused security definition', function () {
       const spec = {
         securityDefinitions: {
           basicAuth: {
-            type: 'basic'
+            type: 'basic',
           },
           coolApiAuth: {
             type: 'oauth2',
             scopes: {
-              'read:coolData': 'read some cool data'
-            }
+              'read:coolData': 'read some cool data',
+            },
           },
           api_key: {
             type: 'apiKey',
             name: 'api_key',
-            in: 'header'
-          }
+            in: 'header',
+          },
         },
         security: [
           {
-            basicAuth: []
-          }
+            basicAuth: [],
+          },
         ],
         paths: {
           'CoolPath/secured': {
@@ -43,12 +43,12 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
               summary: 'secure get operation',
               security: [
                 {
-                  coolApiAuth: ['read:coolData']
-                }
-              ]
-            }
-          }
-        }
+                  coolApiAuth: ['read:coolData'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -60,7 +60,7 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
       expect(res.warnings[0].path).toEqual('securityDefinitions.api_key');
     });
 
-    it('should warn about an unused security scope', function() {
+    it('should warn about an unused security scope', function () {
       const spec = {
         securityDefinitions: {
           coolApiAuth: {
@@ -68,14 +68,14 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
             scopes: {
               'read:coolData': 'read some cool data',
               'write:otherCoolData': 'write lots of cool data',
-              'read:unusedScope': 'this scope will not be used'
-            }
-          }
+              'read:unusedScope': 'this scope will not be used',
+            },
+          },
         },
         security: [
           {
-            coolApiAuth: ['write:otherCoolData']
-          }
+            coolApiAuth: ['write:otherCoolData'],
+          },
         ],
         paths: {
           'CoolPath/secured': {
@@ -84,12 +84,12 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
               summary: 'secure get operation',
               security: [
                 {
-                  coolApiAuth: ['read:coolData']
-                }
-              ]
-            }
-          }
-        }
+                  coolApiAuth: ['read:coolData'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -103,16 +103,16 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
       );
     });
 
-    it('should not complain if there are no security definitions', function() {
+    it('should not complain if there are no security definitions', function () {
       const spec = {
         paths: {
           'CoolPath/secured': {
             get: {
               operationId: 'secureGet',
-              summary: 'secure get operation'
-            }
-          }
-        }
+              summary: 'secure get operation',
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -120,28 +120,28 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should gracefully handle Oauth security definition with no scopes', function() {
+    it('should gracefully handle Oauth security definition with no scopes', function () {
       const spec = {
         securityDefinitions: {
           OauthSecurity: {
             type: 'oauth2',
             flow: 'implicit',
-            authorizationUrl: '/auth/v1/login'
-          }
+            authorizationUrl: '/auth/v1/login',
+          },
         },
         security: [
           {
-            OauthSecurity: []
-          }
+            OauthSecurity: [],
+          },
         ],
         paths: {
           '/pcloud/v1/images': {
             get: {
               operationId: 'pcloud.images.getall',
-              summary: 'List all available stock images'
-            }
-          }
-        }
+              summary: 'List all available stock images',
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec }, config);
@@ -150,23 +150,23 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
     });
   });
 
-  describe('OpenAPI 3', function() {
-    it('should follow references to security schemes', async function() {
+  describe('OpenAPI 3', function () {
+    it('should follow references to security schemes', async function () {
       const spec = {
         components: {
           schemas: {
             SecuritySchemeModel: {
               type: 'http',
               scheme: 'basic',
-              descriptions: 'example text for def with unused security def'
-            }
+              descriptions: 'example text for def with unused security def',
+            },
           },
           securitySchemes: {
             scheme1: {
-              $ref: '#/components/schemas/SecuritySchemeModel'
-            }
-          }
-        }
+              $ref: '#/components/schemas/SecuritySchemeModel',
+            },
+          },
+        },
       };
 
       const resolvedSpec = await resolver.dereference(spec);
@@ -178,21 +178,21 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
         'A security scheme is defined but never used: scheme1'
       );
     });
-    it('should warn about an unused security definition', function() {
+    it('should warn about an unused security definition', function () {
       const spec = {
         components: {
           securitySchemes: {
             UnusedAuth: {
               type: 'http',
               scheme: 'basic',
-              descriptions: 'basic auth for OpenAPI 3, not used'
+              descriptions: 'basic auth for OpenAPI 3, not used',
             },
             UsedAuth: {
               type: 'http',
               scheme: 'basic',
-              descriptions: 'basic auth for OpenAPI 3, used'
-            }
-          }
+              descriptions: 'basic auth for OpenAPI 3, used',
+            },
+          },
         },
         paths: {
           '/': {
@@ -201,17 +201,17 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
               summary: 'list everything',
               security: [
                 {
-                  UsedAuth: []
-                }
+                  UsedAuth: [],
+                },
               ],
               responses: {
                 default: {
-                  description: 'default response'
-                }
-              }
-            }
-          }
-        }
+                  description: 'default response',
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -225,7 +225,7 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
       );
     });
 
-    it('should warn about an unused security scope', function() {
+    it('should warn about an unused security scope', function () {
       const spec = {
         components: {
           securitySchemes: {
@@ -237,12 +237,12 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
                   authorizationUrl: 'https://example.com/api/oauth/dialog',
                   scopes: {
                     'write:pets': 'modify pets in your account',
-                    'read:pets': 'read your pets'
-                  }
-                }
-              }
-            }
-          }
+                    'read:pets': 'read your pets',
+                  },
+                },
+              },
+            },
+          },
         },
         paths: {
           '/': {
@@ -251,17 +251,17 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
               summary: 'list everything',
               security: [
                 {
-                  ScopedAuth: ['read:pets']
-                }
+                  ScopedAuth: ['read:pets'],
+                },
               ],
               responses: {
                 default: {
-                  description: 'default response'
-                }
-              }
-            }
-          }
-        }
+                  description: 'default response',
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -275,7 +275,7 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
       );
     });
 
-    it('should not complain if all definitions/scopes are used', function() {
+    it('should not complain if all definitions/scopes are used', function () {
       const spec = {
         components: {
           securitySchemes: {
@@ -287,12 +287,12 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
                   authorizationUrl: 'https://example.com/api/oauth/dialog',
                   scopes: {
                     'write:pets': 'modify pets in your account',
-                    'read:pets': 'read your pets'
-                  }
-                }
-              }
-            }
-          }
+                    'read:pets': 'read your pets',
+                  },
+                },
+              },
+            },
+          },
         },
         paths: {
           '/': {
@@ -301,17 +301,17 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
               summary: 'list everything',
               security: [
                 {
-                  ScopedAuth: ['read:pets', 'write:pets']
-                }
+                  ScopedAuth: ['read:pets', 'write:pets'],
+                },
               ],
               responses: {
                 default: {
-                  description: 'default response'
-                }
-              }
-            }
-          }
-        }
+                  description: 'default response',
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -319,21 +319,21 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should not complain if all definitions are used with multiple auth schemes', function() {
+    it('should not complain if all definitions are used with multiple auth schemes', function () {
       const spec = {
         components: {
           securitySchemes: {
             api_key: {
               type: 'apiKey',
               name: 'api_key',
-              in: 'header'
+              in: 'header',
             },
             api_secret: {
               type: 'apiKey',
               name: 'api_secret',
-              in: 'header'
-            }
-          }
+              in: 'header',
+            },
+          },
         },
         paths: {
           '/': {
@@ -343,17 +343,17 @@ describe('validation plugin - semantic - security-definitions-ibm', function() {
               security: [
                 {
                   api_key: [],
-                  api_secret: []
-                }
+                  api_secret: [],
+                },
               ],
               responses: {
                 default: {
-                  description: 'default response'
-                }
-              }
-            }
-          }
-        }
+                  description: 'default response',
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);

--- a/test/plugins/validation/2and3/security-ibm.test.js
+++ b/test/plugins/validation/2and3/security-ibm.test.js
@@ -1,12 +1,12 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/security-ibm');
 
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
-describe('validation plugin - semantic - security-ibm', function() {
-  describe('Swagger 2', function() {
+describe('validation plugin - semantic - security-ibm', function () {
+  describe('Swagger 2', function () {
     it('should return an error when an operation references a non-existing security scope', () => {
       const spec = {
         securityDefinitions: {
@@ -15,9 +15,9 @@ describe('validation plugin - semantic - security-ibm', function() {
             name: 'apikey',
             in: 'query',
             scopes: {
-              asdf: 'blah blah'
-            }
-          }
+              asdf: 'blah blah',
+            },
+          },
         },
         paths: {
           '/': {
@@ -25,12 +25,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               description: 'asdf',
               security: [
                 {
-                  api_key: ['write:pets']
-                }
-              ]
-            }
-          }
-        }
+                  api_key: ['write:pets'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -48,8 +48,8 @@ describe('validation plugin - semantic - security-ibm', function() {
           api_key: {
             type: 'apiKey',
             name: 'apikey',
-            in: 'query'
-          }
+            in: 'query',
+          },
         },
         paths: {
           '/': {
@@ -57,12 +57,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               description: 'asdf',
               security: [
                 {
-                  fictional_security_definition: ['write:pets']
-                }
-              ]
-            }
-          }
-        }
+                  fictional_security_definition: ['write:pets'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -84,9 +84,9 @@ describe('validation plugin - semantic - security-ibm', function() {
             name: 'apikey',
             in: 'query',
             scopes: {
-              'write:pets': 'write to pets'
-            }
-          }
+              'write:pets': 'write to pets',
+            },
+          },
         },
         paths: {
           '/': {
@@ -94,12 +94,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               description: 'asdf',
               security: [
                 {
-                  api_key: ['write:pets']
-                }
-              ]
-            }
-          }
-        }
+                  api_key: ['write:pets'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -107,23 +107,23 @@ describe('validation plugin - semantic - security-ibm', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should error on a non-empty array for security object that is not of type oauth2', function() {
+    it('should error on a non-empty array for security object that is not of type oauth2', function () {
       const spec = {
         securityDefinitions: {
           basicAuth: {
-            type: 'basic'
+            type: 'basic',
           },
           coolApiAuth: {
             type: 'oauth2',
             scopes: {
-              'read:coolData': 'read some cool data'
-            }
-          }
+              'read:coolData': 'read some cool data',
+            },
+          },
         },
         security: [
           {
-            basicAuth: ['not a good place for a scope']
-          }
+            basicAuth: ['not a good place for a scope'],
+          },
         ],
         paths: {
           'CoolPath/secured': {
@@ -132,12 +132,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               summary: 'secure get operation',
               security: [
                 {
-                  coolApiAuth: ['read:coolData']
-                }
-              ]
-            }
-          }
-        }
+                  coolApiAuth: ['read:coolData'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -149,23 +149,23 @@ describe('validation plugin - semantic - security-ibm', function() {
       expect(res.errors[0].path).toEqual('security.basicAuth');
     });
 
-    it('should not error on a non-empty array for security object of type oauth2', function() {
+    it('should not error on a non-empty array for security object of type oauth2', function () {
       const spec = {
         securityDefinitions: {
           basicAuth: {
-            type: 'basic'
+            type: 'basic',
           },
           coolApiAuth: {
             type: 'oauth2',
             scopes: {
-              'read:coolData': 'read some cool data'
-            }
-          }
+              'read:coolData': 'read some cool data',
+            },
+          },
         },
         security: [
           {
-            basicAuth: []
-          }
+            basicAuth: [],
+          },
         ],
         paths: {
           'CoolPath/secured': {
@@ -174,12 +174,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               summary: 'secure get operation',
               security: [
                 {
-                  coolApiAuth: ['read:coolData']
-                }
-              ]
-            }
-          }
-        }
+                  coolApiAuth: ['read:coolData'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -187,7 +187,7 @@ describe('validation plugin - semantic - security-ibm', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should not validate an object property with the name "security"', function() {
+    it('should not validate an object property with the name "security"', function () {
       const spec = {
         paths: {
           'CoolPath/secured': {
@@ -202,15 +202,15 @@ describe('validation plugin - semantic - security-ibm', function() {
                     properties: {
                       security: {
                         type: 'string',
-                        description: 'just an innocent string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                        description: 'just an innocent string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -219,7 +219,7 @@ describe('validation plugin - semantic - security-ibm', function() {
     });
   });
 
-  describe('OpenAPI 3', function() {
+  describe('OpenAPI 3', function () {
     it('should return an error when an operation references a non-existing security scope', () => {
       const spec = {
         components: {
@@ -231,12 +231,12 @@ describe('validation plugin - semantic - security-ibm', function() {
                 implicit: {
                   authorizationUrl: 'https://example.com/api/oauth',
                   scopes: {
-                    'read:pets': "you can read but you can't write"
-                  }
-                }
-              }
-            }
-          }
+                    'read:pets': "you can read but you can't write",
+                  },
+                },
+              },
+            },
+          },
         },
         paths: {
           '/': {
@@ -244,12 +244,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               description: 'asdf',
               security: [
                 {
-                  TestAuth: ['write:pets']
-                }
-              ]
-            }
-          }
-        }
+                  TestAuth: ['write:pets'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -274,12 +274,12 @@ describe('validation plugin - semantic - security-ibm', function() {
                   scopes: {
                     'read:pets': "you can read but you can't write",
                     'read:houses': "you can read but you can't write",
-                    'write:houses': "you can write but you can't read"
-                  }
-                }
-              }
-            }
-          }
+                    'write:houses': "you can write but you can't read",
+                  },
+                },
+              },
+            },
+          },
         },
         paths: {
           '/': {
@@ -291,13 +291,13 @@ describe('validation plugin - semantic - security-ibm', function() {
                     'write:houses',
                     'read:houses',
                     'write:pets',
-                    'read:pets'
-                  ]
-                }
-              ]
-            }
-          }
-        }
+                    'read:pets',
+                  ],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -320,12 +320,12 @@ describe('validation plugin - semantic - security-ibm', function() {
                 implicit: {
                   authorizationUrl: 'https://example.com/api/oauth',
                   scopes: {
-                    'read:pets': "you can read but you can't write"
-                  }
-                }
-              }
-            }
-          }
+                    'read:pets': "you can read but you can't write",
+                  },
+                },
+              },
+            },
+          },
         },
         paths: {
           '/': {
@@ -333,12 +333,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               description: 'asdf',
               security: [
                 {
-                  UndefinedAuth: ['read:pets']
-                }
-              ]
-            }
-          }
-        }
+                  UndefinedAuth: ['read:pets'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -361,18 +361,18 @@ describe('validation plugin - semantic - security-ibm', function() {
                 implicit: {
                   authorizationUrl: 'https://example.com/api/oauth',
                   scopes: {
-                    'read:pets': "you can read but you can't write"
-                  }
-                }
-              }
-            }
-          }
+                    'read:pets': "you can read but you can't write",
+                  },
+                },
+              },
+            },
+          },
         },
         security: [
           {
-            TestAuth: ['read:pets']
-          }
-        ]
+            TestAuth: ['read:pets'],
+          },
+        ],
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -387,9 +387,9 @@ describe('validation plugin - semantic - security-ibm', function() {
             TestAuth: {
               type: 'openIdConnect',
               description: 'just a test',
-              openIdConnectUrl: 'https://auth.com/openId'
-            }
-          }
+              openIdConnectUrl: 'https://auth.com/openId',
+            },
+          },
         },
         paths: {
           '/': {
@@ -397,12 +397,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               description: 'asdf',
               security: [
                 {
-                  TestAuth: ['write:pets']
-                }
-              ]
-            }
-          }
-        }
+                  TestAuth: ['write:pets'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -410,14 +410,14 @@ describe('validation plugin - semantic - security-ibm', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should error on a non-empty array for security req that is not oauth2 or openIdConnect', function() {
+    it('should error on a non-empty array for security req that is not oauth2 or openIdConnect', function () {
       const spec = {
         components: {
           securitySchemes: {
             TestAuth: {
-              type: 'apikey'
-            }
-          }
+              type: 'apikey',
+            },
+          },
         },
         paths: {
           '/': {
@@ -426,12 +426,12 @@ describe('validation plugin - semantic - security-ibm', function() {
               summary: 'secure get operation',
               security: [
                 {
-                  TestAuth: ['read:coolData']
-                }
-              ]
-            }
-          }
-        }
+                  TestAuth: ['read:coolData'],
+                },
+              ],
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -443,7 +443,7 @@ describe('validation plugin - semantic - security-ibm', function() {
       expect(res.errors[0].path).toEqual('paths./.get.security.TestAuth');
     });
 
-    it('should not error on a non-empty array for security req that is of type oauth2', function() {
+    it('should not error on a non-empty array for security req that is of type oauth2', function () {
       const spec = {
         components: {
           securitySchemes: {
@@ -453,24 +453,24 @@ describe('validation plugin - semantic - security-ibm', function() {
                 implicit: {
                   authorizationUrl: 'https://auth.com',
                   scopes: {
-                    'write:pets': 'write access'
-                  }
+                    'write:pets': 'write access',
+                  },
                 },
                 password: {
                   tokenUrl: 'https://auth.com/token',
                   scopes: {
-                    'read:pets': 'read access'
-                  }
-                }
-              }
-            }
-          }
+                    'read:pets': 'read access',
+                  },
+                },
+              },
+            },
+          },
         },
         security: [
           {
-            TestAuth: ['read:pets']
-          }
-        ]
+            TestAuth: ['read:pets'],
+          },
+        ],
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -478,21 +478,21 @@ describe('validation plugin - semantic - security-ibm', function() {
       expect(res.warnings.length).toEqual(0);
     });
 
-    it('should not error on a non-empty array for security object that is of type openIdConnect', function() {
+    it('should not error on a non-empty array for security object that is of type openIdConnect', function () {
       const spec = {
         components: {
           securitySchemes: {
             TestAuth: {
               type: 'openIdConnect',
-              openIdConnectUrl: 'https://auth.com/openId'
-            }
-          }
+              openIdConnectUrl: 'https://auth.com/openId',
+            },
+          },
         },
         security: [
           {
-            TestAuth: ['read:pets']
-          }
-        ]
+            TestAuth: ['read:pets'],
+          },
+        ],
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -507,21 +507,21 @@ describe('validation plugin - semantic - security-ibm', function() {
             api_key: {
               type: 'apiKey',
               name: 'api_key',
-              in: 'header'
+              in: 'header',
             },
             api_secret: {
               type: 'apiKey',
               name: 'api_secret',
-              in: 'header'
-            }
-          }
+              in: 'header',
+            },
+          },
         },
         security: [
           {
             api_key: [],
-            api_secret: []
-          }
-        ]
+            api_secret: [],
+          },
+        ],
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);

--- a/test/plugins/validation/2and3/walker-ibm.test.js
+++ b/test/plugins/validation/2and3/walker-ibm.test.js
@@ -1,7 +1,7 @@
 const expect = require('expect');
 const resolver = require('json-schema-ref-parser');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/walker-ibm');
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
@@ -16,12 +16,12 @@ describe('validation plugin - semantic - walker-ibm', () => {
                 name: 'tags',
                 in: 'query',
                 description: '',
-                type: 'string'
-              }
-            ]
-          }
-        }
-      }
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -32,7 +32,7 @@ describe('validation plugin - semantic - walker-ibm', () => {
       'get',
       'parameters',
       '0',
-      'description'
+      'description',
     ]);
     expect(res.errors[0].message).toEqual(
       'Items with a description must have content in it.'
@@ -50,12 +50,12 @@ describe('validation plugin - semantic - walker-ibm', () => {
                 name: 'tags',
                 in: 'query',
                 description: '   ',
-                type: 'string'
-              }
-            ]
-          }
-        }
-      }
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -66,7 +66,7 @@ describe('validation plugin - semantic - walker-ibm', () => {
       'get',
       'parameters',
       '0',
-      'description'
+      'description',
     ]);
     expect(res.errors[0].message).toEqual(
       'Items with a description must have content in it.'
@@ -84,12 +84,12 @@ describe('validation plugin - semantic - walker-ibm', () => {
                 name: 'tags',
                 in: 'query',
                 description: '   ',
-                type: 'string'
-              }
-            ]
-          }
-        }
-      }
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -107,12 +107,12 @@ describe('validation plugin - semantic - walker-ibm', () => {
                 name: 'tags',
                 in: 'query',
                 description: null,
-                type: 'string'
-              }
-            ]
-          }
-        }
-      }
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -123,7 +123,7 @@ describe('validation plugin - semantic - walker-ibm', () => {
       'get',
       'parameters',
       '0',
-      'description'
+      'description',
     ]);
     expect(res.errors[0].message).toEqual(
       'Null values are not allowed for any property.'
@@ -141,12 +141,12 @@ describe('validation plugin - semantic - walker-ibm', () => {
                 name: 'tags',
                 in: 'query',
                 default: null,
-                type: 'string'
-              }
-            ]
-          }
-        }
-      }
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -167,19 +167,19 @@ describe('validation plugin - semantic - walker-ibm', () => {
                 description: 'successful operation',
                 schema: {
                   $ref: '#/responses/Success',
-                  description: 'simple success response'
-                }
-              }
-            }
-          }
-        }
+                  description: 'simple success response',
+                },
+              },
+            },
+          },
+        },
       },
       responses: {
         Success: {
           type: 'string',
-          description: 'simple success response'
-        }
-      }
+          description: 'simple success response',
+        },
+      },
     };
 
     // clone spec, otherwise 'dereference' will change the spec by reference
@@ -196,7 +196,7 @@ describe('validation plugin - semantic - walker-ibm', () => {
       'responses',
       '200',
       'schema',
-      'description'
+      'description',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Description sibling to $ref matches that of the referenced schema. This is redundant and should be removed.'
@@ -216,19 +216,19 @@ describe('validation plugin - semantic - walker-ibm', () => {
                 description: 'successful operation',
                 schema: {
                   $ref: '#/responses/Success',
-                  description: 'simple success response'
-                }
-              }
-            }
-          }
-        }
+                  description: 'simple success response',
+                },
+              },
+            },
+          },
+        },
       },
       responses: {
         Success: {
           type: 'string',
-          description: 'simple success response'
-        }
-      }
+          description: 'simple success response',
+        },
+      },
     };
 
     // clone spec, otherwise 'dereference' will change the spec by reference
@@ -245,7 +245,7 @@ describe('validation plugin - semantic - walker-ibm', () => {
       'responses',
       '200',
       'schema',
-      'description'
+      'description',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Description sibling to $ref matches that of the referenced schema. This is redundant and should be removed.'

--- a/test/plugins/validation/2and3/walker.test.js
+++ b/test/plugins/validation/2and3/walker.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/2and3/semantic-validators/walker');
 
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
@@ -12,14 +12,14 @@ describe('validation plugin - semantic - spec walker', () => {
         paths: {
           '/CoolPath/{id}': {
             responses: {
-              '200': {
+              200: {
                 schema: {
-                  type: 4
-                }
-              }
-            }
-          }
-        }
+                  type: 4,
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -30,7 +30,7 @@ describe('validation plugin - semantic - spec walker', () => {
         'responses',
         '200',
         'schema',
-        'type'
+        'type',
       ]);
       expect(res.errors[0].message).toEqual('"type" should be a string');
       expect(res.warnings.length).toEqual(0);
@@ -41,14 +41,14 @@ describe('validation plugin - semantic - spec walker', () => {
         paths: {
           '/CoolPath/{id}': {
             responses: {
-              '200': {
+              200: {
                 schema: {
-                  type: ['number', 'string']
-                }
-              }
-            }
-          }
-        }
+                  type: ['number', 'string'],
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -59,7 +59,7 @@ describe('validation plugin - semantic - spec walker', () => {
         'responses',
         '200',
         'schema',
-        'type'
+        'type',
       ]);
       expect(res.errors[0].message).toEqual('"type" should be a string');
       expect(res.warnings.length).toEqual(0);
@@ -73,17 +73,17 @@ describe('validation plugin - semantic - spec walker', () => {
             properties: {
               code: {
                 type: 'integer',
-                format: 'int32'
+                format: 'int32',
               },
               type: {
-                type: 'string'
+                type: 'string',
               },
               message: {
-                type: 'string'
-              }
-            }
-          }
-        }
+                type: 'string',
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -99,14 +99,14 @@ describe('validation plugin - semantic - spec walker', () => {
             properties: {
               code: {
                 type: 'integer',
-                format: 'int32'
+                format: 'int32',
               },
               message: {
-                type: 'string'
-              }
-            }
-          }
-        }
+                type: 'string',
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -122,10 +122,10 @@ describe('validation plugin - semantic - spec walker', () => {
           securitySchemes: {
             type: {
               type: 'http',
-              scheme: 'basic'
-            }
-          }
-        }
+              scheme: 'basic',
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -135,26 +135,26 @@ describe('validation plugin - semantic - spec walker', () => {
   });
 
   describe('$ref as property name', () => {
-    it('should gracefully handle a property named $ref', function() {
+    it('should gracefully handle a property named $ref', function () {
       const spec = {
         definitions: {
           JSONSchemaProps: {
             description: 'A JSON-Schema following Specification Draft 4.',
             properties: {
               $ref: {
-                type: 'string'
+                type: 'string',
               },
               maximum: {
                 type: 'integer',
-                format: 'int64'
+                format: 'int64',
               },
               minimum: {
                 type: 'integer',
-                format: 'int64'
-              }
-            }
-          }
-        }
+                format: 'int64',
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -169,9 +169,9 @@ describe('validation plugin - semantic - spec walker', () => {
         definitions: {
           MyNumber: {
             minimum: '5',
-            maximum: '2'
-          }
-        }
+            maximum: '2',
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -179,7 +179,7 @@ describe('validation plugin - semantic - spec walker', () => {
       expect(res.errors[0].path).toEqual([
         'definitions',
         'MyNumber',
-        'minimum'
+        'minimum',
       ]);
       expect(res.errors[0].message).toEqual(
         'Minimum cannot be more than maximum'
@@ -192,9 +192,9 @@ describe('validation plugin - semantic - spec walker', () => {
         definitions: {
           MyNumber: {
             minimum: '1',
-            maximum: '2'
-          }
-        }
+            maximum: '2',
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -207,9 +207,9 @@ describe('validation plugin - semantic - spec walker', () => {
         definitions: {
           MyNumber: {
             minProperties: '5',
-            maxProperties: '2'
-          }
-        }
+            maxProperties: '2',
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -217,7 +217,7 @@ describe('validation plugin - semantic - spec walker', () => {
       expect(res.errors[0].path).toEqual([
         'definitions',
         'MyNumber',
-        'minProperties'
+        'minProperties',
       ]);
       expect(res.errors[0].message).toEqual(
         'minProperties cannot be more than maxProperties'
@@ -230,9 +230,9 @@ describe('validation plugin - semantic - spec walker', () => {
         definitions: {
           MyNumber: {
             minProperties: '1',
-            maxProperties: '2'
-          }
-        }
+            maxProperties: '2',
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -245,9 +245,9 @@ describe('validation plugin - semantic - spec walker', () => {
         definitions: {
           MyNumber: {
             minLength: '5',
-            maxLength: '2'
-          }
-        }
+            maxLength: '2',
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -255,7 +255,7 @@ describe('validation plugin - semantic - spec walker', () => {
       expect(res.errors[0].path).toEqual([
         'definitions',
         'MyNumber',
-        'minLength'
+        'minLength',
       ]);
       expect(res.errors[0].message).toEqual(
         'minLength cannot be more than maxLength'
@@ -268,9 +268,9 @@ describe('validation plugin - semantic - spec walker', () => {
         definitions: {
           MyNumber: {
             minLength: '1',
-            maxLength: '2'
-          }
-        }
+            maxLength: '2',
+          },
+        },
       };
 
       const res = validate({ jsSpec: spec }, config);
@@ -281,17 +281,17 @@ describe('validation plugin - semantic - spec walker', () => {
 
   describe('Refs are restricted in specific areas of a spec', () => {
     describe('Response $refs', () => {
-      it('should return a problem for a parameters $ref in a response position', function() {
+      it('should return a problem for a parameters $ref in a response position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               responses: {
-                '200': {
-                  $ref: '#/parameters/abc'
-                }
-              }
-            }
-          }
+                200: {
+                  $ref: '#/parameters/abc',
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -302,22 +302,22 @@ describe('validation plugin - semantic - spec walker', () => {
           '/CoolPath/{id}',
           'responses',
           '200',
-          '$ref'
+          '$ref',
         ]);
         expect(res.warnings[0].message).toEqual(
           'responses $refs must follow this format: *#/responses*'
         );
       });
 
-      it('should return a problem for a definitions $ref in a response position', function() {
+      it('should return a problem for a definitions $ref in a response position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               schema: {
-                $ref: '#/responses/abc'
-              }
-            }
-          }
+                $ref: '#/responses/abc',
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -327,24 +327,24 @@ describe('validation plugin - semantic - spec walker', () => {
           'paths',
           '/CoolPath/{id}',
           'schema',
-          '$ref'
+          '$ref',
         ]);
         expect(res.warnings[0].message).toEqual(
           'schema $refs must follow this format: *#/definitions*'
         );
       });
 
-      it('should not return a problem for a responses $ref in a response position', function() {
+      it('should not return a problem for a responses $ref in a response position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               responses: {
-                '200': {
-                  $ref: '#/responses/abc'
-                }
-              }
-            }
-          }
+                200: {
+                  $ref: '#/responses/abc',
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -354,15 +354,15 @@ describe('validation plugin - semantic - spec walker', () => {
     });
 
     describe('Schema $refs', () => {
-      it('should return a problem for a parameters $ref in a schema position', function() {
+      it('should return a problem for a parameters $ref in a schema position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               schema: {
-                $ref: '#/parameters/abc'
-              }
-            }
-          }
+                $ref: '#/parameters/abc',
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -372,19 +372,19 @@ describe('validation plugin - semantic - spec walker', () => {
           'paths',
           '/CoolPath/{id}',
           'schema',
-          '$ref'
+          '$ref',
         ]);
       });
 
-      it('should return a problem for a responses $ref in a schema position', function() {
+      it('should return a problem for a responses $ref in a schema position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               schema: {
-                $ref: '#/responses/abc'
-              }
-            }
-          }
+                $ref: '#/responses/abc',
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -394,19 +394,19 @@ describe('validation plugin - semantic - spec walker', () => {
           'paths',
           '/CoolPath/{id}',
           'schema',
-          '$ref'
+          '$ref',
         ]);
       });
 
-      it('should not return a problem for a definition $ref in a schema position', function() {
+      it('should not return a problem for a definition $ref in a schema position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               schema: {
-                $ref: '#/definitions/abc'
-              }
-            }
-          }
+                $ref: '#/definitions/abc',
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -414,7 +414,7 @@ describe('validation plugin - semantic - spec walker', () => {
         expect(res.warnings.length).toEqual(0);
       });
 
-      it("should not return a problem for a schema property named 'properties'", function() {
+      it("should not return a problem for a schema property named 'properties'", function () {
         // #492 regression
         const spec = {
           definitions: {
@@ -423,17 +423,17 @@ describe('validation plugin - semantic - spec walker', () => {
               properties: {
                 plan_id: {
                   type: 'string',
-                  description: 'ID of the new plan from the catalog.'
+                  description: 'ID of the new plan from the catalog.',
                 },
                 parameters: {
-                  $ref: '#/definitions/Parameter'
+                  $ref: '#/definitions/Parameter',
                 },
                 previous_values: {
-                  $ref: '#/definitions/PreviousValues'
-                }
-              }
-            }
-          }
+                  $ref: '#/definitions/PreviousValues',
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -443,17 +443,17 @@ describe('validation plugin - semantic - spec walker', () => {
     });
 
     describe('Parameter $refs', () => {
-      it('should return a problem for a definition $ref in a parameter position', function() {
+      it('should return a problem for a definition $ref in a parameter position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
-                  $ref: '#/definitions/abc'
-                }
-              ]
-            }
-          }
+                  $ref: '#/definitions/abc',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -464,24 +464,24 @@ describe('validation plugin - semantic - spec walker', () => {
           '/CoolPath/{id}',
           'parameters',
           '0',
-          '$ref'
+          '$ref',
         ]);
         expect(res.warnings[0].message).toEqual(
           'parameters $refs must follow this format: *#/parameters*'
         );
       });
 
-      it('should return a problem for a responses $ref in a parameter position', function() {
+      it('should return a problem for a responses $ref in a parameter position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
-                  $ref: '#/responses/abc'
-                }
-              ]
-            }
-          }
+                  $ref: '#/responses/abc',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -492,21 +492,21 @@ describe('validation plugin - semantic - spec walker', () => {
           '/CoolPath/{id}',
           'parameters',
           '0',
-          '$ref'
+          '$ref',
         ]);
       });
 
-      it('should not return a problem for a parameter $ref in a parameter position', function() {
+      it('should not return a problem for a parameter $ref in a parameter position', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               parameters: [
                 {
-                  $ref: '#/parameters/abc'
-                }
-              ]
-            }
-          }
+                  $ref: '#/parameters/abc',
+                },
+              ],
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -516,7 +516,7 @@ describe('validation plugin - semantic - spec walker', () => {
     });
 
     describe('Restricted $refs - OpenAPI 3', () => {
-      it('should return a problem for a schema not defined in schemas', function() {
+      it('should return a problem for a schema not defined in schemas', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
@@ -526,14 +526,14 @@ describe('validation plugin - semantic - spec walker', () => {
                   content: {
                     'application/json': {
                       schema: {
-                        $ref: '#/components/requestBodies/Object'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+                        $ref: '#/components/requestBodies/Object',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -547,14 +547,14 @@ describe('validation plugin - semantic - spec walker', () => {
           'content',
           'application/json',
           'schema',
-          '$ref'
+          '$ref',
         ]);
         expect(res.warnings[0].message).toEqual(
           'schema $refs must follow this format: *#/components/schemas*'
         );
       });
 
-      it('should not return a problem for a header ref within a responses object', function() {
+      it('should not return a problem for a header ref within a responses object', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
@@ -564,19 +564,19 @@ describe('validation plugin - semantic - spec walker', () => {
                   content: {
                     'application/json': {
                       schema: {
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   headers: {
                     'X-Fake-Header': {
-                      $ref: '#/components/headers/FakeHeader'
-                    }
-                  }
-                }
-              }
-            }
-          }
+                      $ref: '#/components/headers/FakeHeader',
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -592,10 +592,10 @@ describe('validation plugin - semantic - spec walker', () => {
             '/CoolPath/{id}': {
               schema: {
                 $ref: '#/definitions/abc',
-                description: 'My very cool schema'
-              }
-            }
-          }
+                description: 'My very cool schema',
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec }, config);
@@ -609,10 +609,10 @@ describe('validation plugin - semantic - spec walker', () => {
             '/CoolPath/{id}': {
               schema: {
                 $ref: '#/definitions/abc',
-                description: 'My very cool schema'
-              }
-            }
-          }
+                description: 'My very cool schema',
+              },
+            },
+          },
         };
 
         // temporarily configure $ref_siblings to be a warning
@@ -630,41 +630,41 @@ describe('validation plugin - semantic - spec walker', () => {
           'paths',
           '/CoolPath/{id}',
           'schema',
-          'description'
+          'description',
         ]);
       });
 
-      it('should return a problem for a links $ref that does not have the correct format', function() {
+      it('should return a problem for a links $ref that does not have the correct format', function () {
         const spec = {
           paths: {
             '/CoolPath/{id}': {
               responses: {
-                '200': {
+                200: {
                   desciption: 'hi',
                   content: {
                     'application/json': {
                       schema: {
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   headers: {
                     Location: {
                       description: 'hi',
                       schema: {
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   links: {
                     link1: {
-                      $ref: '#/parameters/abc'
-                    }
-                  }
-                }
-              }
-            }
-          }
+                      $ref: '#/parameters/abc',
+                    },
+                  },
+                },
+              },
+            },
+          },
         };
 
         const res = validate({ jsSpec: spec, isOAS3: true }, config);
@@ -677,7 +677,7 @@ describe('validation plugin - semantic - spec walker', () => {
           '200',
           'links',
           'link1',
-          '$ref'
+          '$ref',
         ]);
         expect(res.warnings[0].message).toEqual(
           'links $refs must follow this format: *#/components/links*'

--- a/test/plugins/validation/oas3/discriminator.test.js
+++ b/test/plugins/validation/oas3/discriminator.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/discriminator');
 
 describe('validation plugin - semantic - oas3 discriminator', () => {
@@ -10,16 +10,16 @@ describe('validation plugin - semantic - oas3 discriminator', () => {
         schemas: {
           Pet: {
             discriminator: {
-              propertyName: 'petType'
+              propertyName: 'petType',
             },
             properties: {
               petType: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      }
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(0);
@@ -30,10 +30,10 @@ describe('validation plugin - semantic - oas3 discriminator', () => {
       components: {
         schemas: {
           Pet: {
-            discriminator: ''
-          }
-        }
-      }
+            discriminator: '',
+          },
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(1);
@@ -50,18 +50,18 @@ describe('validation plugin - semantic - oas3 discriminator', () => {
       components: {
         schemas: {
           Pet: {
-            discriminator: []
+            discriminator: [],
           },
           Food: {
-            discriminator: {}
+            discriminator: {},
           },
           Human: {
             discriminator: {
-              notPropertyName: 'not property name'
-            }
-          }
-        }
-      }
+              notPropertyName: 'not property name',
+            },
+          },
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(3);
@@ -92,16 +92,16 @@ describe('validation plugin - semantic - oas3 discriminator', () => {
         schemas: {
           Pet: {
             discriminator: {
-              propertyName: {}
-            }
+              propertyName: {},
+            },
           },
           Food: {
             discriminator: {
-              propertyName: 123
-            }
-          }
-        }
-      }
+              propertyName: 123,
+            },
+          },
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(2);
@@ -130,22 +130,22 @@ describe('validation plugin - semantic - oas3 discriminator', () => {
         schemas: {
           Pet: {
             discriminator: {
-              propertyName: 'petType'
+              propertyName: 'petType',
             },
             properties: {
               name: {
-                type: 'string'
-              }
-            }
+                type: 'string',
+              },
+            },
           },
           Food: {
             discriminator: {
-              propertyName: 'expirationDate'
+              propertyName: 'expirationDate',
             },
-            properties: {}
-          }
-        }
-      }
+            properties: {},
+          },
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(2);

--- a/test/plugins/validation/oas3/openapi.test.js
+++ b/test/plugins/validation/oas3/openapi.test.js
@@ -1,13 +1,13 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/openapi');
 
 describe('validation plugin - semantic - openapi', () => {
   //this is for openapi object
   it('should return an error when an API definition does not have openapi field', () => {
     const spec = {
-      Openapi: '3.0.0'
+      Openapi: '3.0.0',
     };
 
     const res = validate({ jsSpec: spec });
@@ -20,7 +20,7 @@ describe('validation plugin - semantic - openapi', () => {
 
   it('should return an error when an openapi field is not a string', () => {
     const spec = {
-      openapi: 123
+      openapi: 123,
     };
 
     const res = validate({ jsSpec: spec });
@@ -33,7 +33,7 @@ describe('validation plugin - semantic - openapi', () => {
 
   it('should return an error when an openapi does not conform to semantic versioning 2.0.0', () => {
     const spec = {
-      openapi: 'v1.0.10'
+      openapi: 'v1.0.10',
     };
 
     const res = validate({ jsSpec: spec });

--- a/test/plugins/validation/oas3/operations.test.js
+++ b/test/plugins/validation/oas3/operations.test.js
@@ -1,11 +1,11 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/operations');
 const config = require('../../../../src/.defaultsForValidator').defaults.oas3;
 
-describe('validation plugin - semantic - operations - oas3', function() {
-  it('should complain about a request body not having a content field', function() {
+describe('validation plugin - semantic - operations - oas3', function () {
+  it('should complain about a request body not having a content field', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -13,11 +13,11 @@ describe('validation plugin - semantic - operations - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             requestBody: {
-              description: 'body for request'
-            }
-          }
-        }
-      }
+              description: 'body for request',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -29,7 +29,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should warn about an operation with a non-form, array schema request body that does not set a name', function() {
+  it('should warn about an operation with a non-form, array schema request body that does not set a name', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -43,15 +43,15 @@ describe('validation plugin - semantic - operations - oas3', function() {
                   schema: {
                     type: 'array',
                     items: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -63,7 +63,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not warn about an operation with a non-array application/json request body that does not set a name', function() {
+  it('should not warn about an operation with a non-array application/json request body that does not set a name', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -75,14 +75,14 @@ describe('validation plugin - semantic - operations - oas3', function() {
               content: {
                 'application/json': {
                   schema: {
-                    type: 'string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -90,7 +90,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not warn about an operation with a non-array `+json` request body that does not set a name', function() {
+  it('should not warn about an operation with a non-array `+json` request body that does not set a name', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -102,14 +102,14 @@ describe('validation plugin - semantic - operations - oas3', function() {
               content: {
                 'application/merge-patch+json': {
                   schema: {
-                    type: 'string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -117,7 +117,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not warn about an operation with a non-form request body that sets a name', function() {
+  it('should not warn about an operation with a non-form request body that sets a name', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -130,14 +130,14 @@ describe('validation plugin - semantic - operations - oas3', function() {
               content: {
                 'application/json': {
                   schema: {
-                    type: 'string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -145,7 +145,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not warn about an operation with a form request body that does not set a name', function() {
+  it('should not warn about an operation with a form request body that does not set a name', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -160,16 +160,16 @@ describe('validation plugin - semantic - operations - oas3', function() {
                     type: 'object',
                     properties: {
                       name: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -177,7 +177,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not warn about an operation with a referenced request body that does not set a name', function() {
+  it('should not warn about an operation with a referenced request body that does not set a name', function () {
     const resolvedSpec = {
       paths: {
         '/pets': {
@@ -188,14 +188,14 @@ describe('validation plugin - semantic - operations - oas3', function() {
               content: {
                 'application/json': {
                   schema: {
-                    type: 'string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const jsSpec = {
@@ -205,11 +205,11 @@ describe('validation plugin - semantic - operations - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             requestBody: {
-              $ref: '#/components/requestBodies/SomeBody'
-            }
-          }
-        }
-      }
+              $ref: '#/components/requestBodies/SomeBody',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec, jsSpec }, config);
@@ -217,7 +217,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not crash in request body name check when path name contains a period', function() {
+  it('should not crash in request body name check when path name contains a period', function () {
     const spec = {
       paths: {
         '/other.pets': {
@@ -231,15 +231,15 @@ describe('validation plugin - semantic - operations - oas3', function() {
                   schema: {
                     type: 'array',
                     items: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -251,13 +251,13 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not crash when request body is behind a ref', function() {
+  it('should not crash when request body is behind a ref', function () {
     const jsSpec = {
       paths: {
         '/resource': {
-          $ref: 'external.yaml#/some-path'
-        }
-      }
+          $ref: 'external.yaml#/some-path',
+        },
+      },
     };
 
     const resolvedSpec = {
@@ -271,19 +271,19 @@ describe('validation plugin - semantic - operations - oas3', function() {
               content: {
                 'application/json': {
                   schema: {
-                    type: 'string'
-                  }
-                }
-              }
+                    type: 'string',
+                  },
+                },
+              },
             },
             responses: {
-              '200': {
-                description: 'success'
-              }
-            }
-          }
-        }
-      }
+              200: {
+                description: 'success',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec, resolvedSpec, isOAS3: true }, config);
@@ -291,7 +291,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain about valid use of type:string, format: binary', function() {
+  it('should not complain about valid use of type:string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -310,24 +310,24 @@ describe('validation plugin - semantic - operations - oas3', function() {
                       properties: {
                         prop1: {
                           type: 'string',
-                          format: 'binary'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should warn about application/json request body with type:string, format: binary', function() {
+  it('should warn about application/json request body with type:string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -341,14 +341,14 @@ describe('validation plugin - semantic - operations - oas3', function() {
                 'application/json': {
                   schema: {
                     type: 'string',
-                    format: 'binary'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    format: 'binary',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -361,7 +361,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     );
   });
 
-  it('should warn about application/json request body with nested array of type:string, format: binary', function() {
+  it('should warn about application/json request body with nested array of type:string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -381,17 +381,17 @@ describe('validation plugin - semantic - operations - oas3', function() {
                         type: 'array',
                         items: {
                           type: 'string',
-                          format: 'binary'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -404,7 +404,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     );
   });
 
-  it('should warn about application/json request body with nested arrays of Objects with octet sequences', function() {
+  it('should warn about application/json request body with nested arrays of Objects with octet sequences', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -427,23 +427,23 @@ describe('validation plugin - semantic - operations - oas3', function() {
                           properties: {
                             prop1: {
                               type: 'string',
-                              format: 'binary'
+                              format: 'binary',
                             },
                             prop2: {
                               type: 'string',
-                              format: 'binary'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                              format: 'binary',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -462,7 +462,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     );
   });
 
-  it('should warn about json with type: string, format: binary when json is the second mime type', function() {
+  it('should warn about json with type: string, format: binary when json is the second mime type', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -475,20 +475,20 @@ describe('validation plugin - semantic - operations - oas3', function() {
               content: {
                 'text/plain': {
                   schema: {
-                    type: 'string'
-                  }
+                    type: 'string',
+                  },
                 },
                 'application/json': {
                   schema: {
                     type: 'string',
-                    format: 'binary'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    format: 'binary',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -501,7 +501,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     );
   });
 
-  it('should warn about json request body with nested arrays of Objects with prop of nested array type: string, format: binary', function() {
+  it('should warn about json request body with nested arrays of Objects with prop of nested array type: string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -526,20 +526,20 @@ describe('validation plugin - semantic - operations - oas3', function() {
                               type: 'array',
                               items: {
                                 type: 'string',
-                                format: 'binary'
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                                format: 'binary',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -552,7 +552,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     );
   });
 
-  it('should warn about json request body with nested arrays of Objects with props of type Object that have props of type: string, format: binary', function() {
+  it('should warn about json request body with nested arrays of Objects with props of type Object that have props of type: string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -576,33 +576,33 @@ describe('validation plugin - semantic - operations - oas3', function() {
                             properties: {
                               sub_prop1: {
                                 type: 'string',
-                                format: 'binary'
+                                format: 'binary',
                               },
                               sub_prop2: {
                                 type: 'string',
-                                format: 'binary'
-                              }
-                            }
+                                format: 'binary',
+                              },
+                            },
                           },
                           prop2: {
                             type: 'object',
                             properties: {
                               sub_prop3: {
                                 type: 'string',
-                                format: 'binary'
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                                format: 'binary',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
@@ -627,7 +627,7 @@ describe('validation plugin - semantic - operations - oas3', function() {
     );
   });
 
-  it('should warn about json request body with nested arrays of Objects with props of type Object that have props of type: string, format: binary', function() {
+  it('should warn about json request body with nested arrays of Objects with props of type Object that have props of type: string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -651,27 +651,27 @@ describe('validation plugin - semantic - operations - oas3', function() {
                             properties: {
                               sub_prop1: {
                                 type: 'string',
-                                format: 'binary'
-                              }
-                            }
+                                format: 'binary',
+                              },
+                            },
                           },
                           prop2: {
                             type: 'array',
                             items: {
                               type: 'string',
-                              format: 'binary'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                              format: 'binary',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);

--- a/test/plugins/validation/oas3/pagination-ibm.test.js
+++ b/test/plugins/validation/oas3/pagination-ibm.test.js
@@ -1,13 +1,13 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/pagination-ibm');
 
 const config = require('../../../../src/.defaultsForValidator').defaults.shared;
 
-describe('validation plugin - semantic - pagaination - oas3', function() {
-  describe('only check paginated list operations', function() {
-    it('should skip operations that do not return an array', function() {
+describe('validation plugin - semantic - pagaination - oas3', function () {
+  describe('only check paginated list operations', function () {
+    it('should skip operations that do not return an array', function () {
       const spec = {
         paths: {
           '/pets': {
@@ -23,12 +23,12 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
-                }
+                    maximum: 50,
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -38,21 +38,21 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                         properties: {
                           resource: {
                             description: 'resource',
-                            type: 'object'
+                            type: 'object',
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -60,7 +60,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should skip operations that do not have a limit query parameter', function() {
+    it('should skip operations that do not have a limit query parameter', function () {
       const spec = {
         paths: {
           '/pets': {
@@ -69,7 +69,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
               operationId: 'operationId',
               parameters: [],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -81,22 +81,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: 'resource',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -104,7 +104,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
       expect(res.errors.length).toEqual(0);
     });
 
-    it('should skip operations that do not have an application/json response', function() {
+    it('should skip operations that do not have an application/json response', function () {
       const spec = {
         paths: {
           '/pets': {
@@ -120,25 +120,25 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
-                }
+                    maximum: 50,
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/octet-stream': {
                       schema: {
                         description: '',
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -147,8 +147,8 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     });
   });
 
-  describe('limit query parameter', function() {
-    it('should complain when limit parameter is not an integer', function() {
+  describe('limit query parameter', function () {
+    it('should complain when limit parameter is not an integer', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -164,12 +164,12 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'string',
                     default: '10',
-                    maximum: '50'
-                  }
-                }
+                    maximum: '50',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -181,22 +181,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -207,14 +207,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         '/resources',
         'get',
         'parameters',
-        0
+        0,
       ]);
       expect(res.warnings[0].message).toEqual(
         'The limit parameter must be of type integer and optional with default and maximum values.'
       );
     });
 
-    it('should complain when limit parameter is not optional', function() {
+    it('should complain when limit parameter is not optional', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -230,12 +230,12 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
-                }
+                    maximum: 50,
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -247,22 +247,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -273,14 +273,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         '/resources',
         'get',
         'parameters',
-        0
+        0,
       ]);
       expect(res.warnings[0].message).toEqual(
         'The limit parameter must be of type integer and optional with default and maximum values.'
       );
     });
 
-    it('should complain when limit parameter does not specify a default value', function() {
+    it('should complain when limit parameter does not specify a default value', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -294,12 +294,12 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   description: 'limit',
                   schema: {
                     type: 'integer',
-                    maximum: 50
-                  }
-                }
+                    maximum: 50,
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -311,22 +311,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -337,80 +337,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         '/resources',
         'get',
         'parameters',
-        0
+        0,
       ]);
       expect(res.warnings[0].message).toEqual(
         'The limit parameter must be of type integer and optional with default and maximum values.'
       );
     });
 
-    it('should complain when limit parameter does not specify a maximum value', function() {
-      const spec = {
-        paths: {
-          '/resources': {
-            get: {
-              summary: 'this is a summary',
-              operationId: 'operationId',
-              parameters: [
-                {
-                  name: 'limit',
-                  in: 'query',
-                  description: 'limit',
-                  schema: {
-                    type: 'integer',
-                    default: 10
-                  }
-                }
-              ],
-              responses: {
-                '200': {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        description: '',
-                        type: 'object',
-                        required: ['resources', 'limit'],
-                        properties: {
-                          resources: {
-                            description: '',
-                            type: 'array',
-                            items: {
-                              type: 'object'
-                            }
-                          },
-                          limit: {
-                            description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-      expect(res.warnings.length).toEqual(1);
-      expect(res.errors.length).toEqual(0);
-      expect(res.warnings[0].path).toEqual([
-        'paths',
-        '/resources',
-        'get',
-        'parameters',
-        0
-      ]);
-      expect(res.warnings[0].message).toEqual(
-        'The limit parameter must be of type integer and optional with default and maximum values.'
-      );
-    });
-  });
-
-  describe('offset query parameter', function() {
-    it('should complain when the offset parameter is not an integer', function() {
+    it('should complain when limit parameter does not specify a maximum value', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -425,20 +359,86 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                  },
+                },
+              ],
+              responses: {
+                200: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                            },
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/resources',
+        'get',
+        'parameters',
+        0,
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The limit parameter must be of type integer and optional with default and maximum values.'
+      );
+    });
+  });
+
+  describe('offset query parameter', function () {
+    it('should complain when the offset parameter is not an integer', function () {
+      const spec = {
+        paths: {
+          '/resources': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'offset',
                   in: 'query',
                   description: 'offset',
                   schema: {
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -450,26 +450,26 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
+                            type: 'integer',
                           },
                           offset: {
                             description: 'offset',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -480,14 +480,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         '/resources',
         'get',
         'parameters',
-        1
+        1,
       ]);
       expect(res.warnings[0].message).toEqual(
         'The offset parameter must be of type integer and optional.'
       );
     });
 
-    it('should complain when the offset parameter is not optional', function() {
+    it('should complain when the offset parameter is not optional', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -502,8 +502,8 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'offset',
@@ -511,12 +511,12 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   description: 'offset',
                   required: true,
                   schema: {
-                    type: 'integer'
-                  }
-                }
+                    type: 'integer',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -528,26 +528,26 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
+                            type: 'integer',
                           },
                           offset: {
                             description: 'offset',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -558,7 +558,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         '/resources',
         'get',
         'parameters',
-        1
+        1,
       ]);
       expect(res.warnings[0].message).toEqual(
         'The offset parameter must be of type integer and optional.'
@@ -566,8 +566,8 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     });
   });
 
-  describe('start|cursor|page_token query parameter', function() {
-    it('should complain when the start parameter is not a string or optional', function() {
+  describe('start|cursor|page_token query parameter', function () {
+    it('should complain when the start parameter is not a string or optional', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -582,20 +582,20 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'start',
                   in: 'query',
                   description: 'start',
                   schema: {
-                    type: 'integer'
-                  }
-                }
+                    type: 'integer',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -607,22 +607,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -633,14 +633,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         '/resources',
         'get',
         'parameters',
-        1
+        1,
       ]);
       expect(res.warnings[0].message).toEqual(
         'The start parameter must be of type string and optional.'
       );
     });
 
-    it('should complain when the cursor parameter is not a string or optional', function() {
+    it('should complain when the cursor parameter is not a string or optional', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -655,8 +655,8 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'cursor',
@@ -664,12 +664,12 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   description: 'cursor',
                   required: true,
                   schema: {
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -681,22 +681,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -707,7 +707,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         '/resources',
         'get',
         'parameters',
-        1
+        1,
       ]);
       expect(res.warnings[0].message).toEqual(
         'The cursor parameter must be of type string and optional.'
@@ -715,8 +715,8 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     });
   });
 
-  describe('limit property in response body', function() {
-    it('should complain when limit property is not defined in response body', function() {
+  describe('limit property in response body', function () {
+    it('should complain when limit property is not defined in response body', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -732,12 +732,12 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
-                }
+                    maximum: 50,
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -749,88 +749,18 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      };
-
-      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
-      expect(res.warnings.length).toEqual(1);
-      expect(res.errors.length).toEqual(0);
-      expect(res.warnings[0].path).toEqual([
-        'paths',
-        '/resources',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'properties'
-      ]);
-      expect(res.warnings[0].message).toEqual(
-        'A paginated list operation must include a "limit" property in the response body schema.'
-      );
-    });
-
-    it('should complain when limit property in response body is not an integer', function() {
-      const spec = {
-        paths: {
-          '/resources': {
-            get: {
-              summary: 'this is a summary',
-              operationId: 'operationId',
-              parameters: [
-                {
-                  name: 'limit',
-                  in: 'query',
-                  description: 'limit',
-                  required: false,
-                  schema: {
-                    type: 'integer',
-                    default: 10,
-                    maximum: 50
-                  }
-                }
-              ],
-              responses: {
-                '200': {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        description: '',
-                        type: 'object',
-                        required: ['resources', 'limit'],
-                        properties: {
-                          resources: {
-                            description: '',
-                            type: 'array',
-                            items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
-                          limit: {
-                            description: 'limit',
-                            type: 'string'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -846,14 +776,13 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'application/json',
         'schema',
         'properties',
-        'limit'
       ]);
       expect(res.warnings[0].message).toEqual(
-        'The "limit" property in the response body of a paginated list operation must be of type integer and required.'
+        'A paginated list operation must include a "limit" property in the response body schema.'
       );
     });
 
-    it('should complain when limit property in response body is not required', function() {
+    it('should complain when limit property in response body is not an integer', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -869,12 +798,83 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
-                }
+                    maximum: 50,
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        description: '',
+                        type: 'object',
+                        required: ['resources', 'limit'],
+                        properties: {
+                          resources: {
+                            description: '',
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                            },
+                          },
+                          limit: {
+                            description: 'limit',
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+      expect(res.warnings.length).toEqual(1);
+      expect(res.errors.length).toEqual(0);
+      expect(res.warnings[0].path).toEqual([
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'limit',
+      ]);
+      expect(res.warnings[0].message).toEqual(
+        'The "limit" property in the response body of a paginated list operation must be of type integer and required.'
+      );
+    });
+
+    it('should complain when limit property in response body is not required', function () {
+      const spec = {
+        paths: {
+          '/resources': {
+            get: {
+              summary: 'this is a summary',
+              operationId: 'operationId',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  description: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                    default: 10,
+                    maximum: 50,
+                  },
+                },
+              ],
+              responses: {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -886,22 +886,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -917,7 +917,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'application/json',
         'schema',
         'properties',
-        'limit'
+        'limit',
       ]);
       expect(res.warnings[0].message).toEqual(
         'The "limit" property in the response body of a paginated list operation must be of type integer and required.'
@@ -925,8 +925,8 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     });
   });
 
-  describe('offset property in response body', function() {
-    it('should complain when offset property is not defined in response body', function() {
+  describe('offset property in response body', function () {
+    it('should complain when offset property is not defined in response body', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -942,20 +942,20 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'offset',
                   in: 'query',
                   description: 'offset',
                   schema: {
-                    type: 'integer'
-                  }
-                }
+                    type: 'integer',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -967,22 +967,22 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -997,14 +997,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'content',
         'application/json',
         'schema',
-        'properties'
+        'properties',
       ]);
       expect(res.warnings[0].message).toEqual(
         'A paginated list operation with an "offset" parameter must include an "offset" property in the response body schema.'
       );
     });
 
-    it('should complain when offset property in response body is not an integer', function() {
+    it('should complain when offset property in response body is not an integer', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -1020,20 +1020,20 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'offset',
                   in: 'query',
                   description: 'offset',
                   schema: {
-                    type: 'integer'
-                  }
-                }
+                    type: 'integer',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -1045,26 +1045,26 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
+                            type: 'integer',
                           },
                           offset: {
                             description: 'offset',
-                            type: 'string'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -1080,14 +1080,14 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'application/json',
         'schema',
         'properties',
-        'offset'
+        'offset',
       ]);
       expect(res.warnings[0].message).toEqual(
         'The "offset" property in the response body of a paginated list operation must be of type integer and required.'
       );
     });
 
-    it('should complain when offset property in response body is not required', function() {
+    it('should complain when offset property in response body is not required', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -1103,20 +1103,20 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'offset',
                   in: 'query',
                   description: 'offset',
                   schema: {
-                    type: 'integer'
-                  }
-                }
+                    type: 'integer',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -1128,26 +1128,26 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
+                            type: 'integer',
                           },
                           offset: {
                             description: 'offset',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -1163,7 +1163,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'application/json',
         'schema',
         'properties',
-        'offset'
+        'offset',
       ]);
       expect(res.warnings[0].message).toEqual(
         'The "offset" property in the response body of a paginated list operation must be of type integer and required.'
@@ -1171,8 +1171,8 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     });
   });
 
-  describe('collection property in response body', function() {
-    it('should complain when response body does not include an array property whose name matches the final segment of the path', function() {
+  describe('collection property in response body', function () {
+    it('should complain when response body does not include an array property whose name matches the final segment of the path', function () {
       const spec = {
         paths: {
           '/resources': {
@@ -1188,20 +1188,20 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                   schema: {
                     type: 'integer',
                     default: 10,
-                    maximum: 50
-                  }
+                    maximum: 50,
+                  },
                 },
                 {
                   name: 'offset',
                   in: 'query',
                   description: 'offset',
                   schema: {
-                    type: 'integer'
-                  }
-                }
+                    type: 'integer',
+                  },
+                },
               ],
               responses: {
-                '200': {
+                200: {
                   content: {
                     'application/json': {
                       schema: {
@@ -1213,26 +1213,26 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
                             description: '',
                             type: 'array',
                             items: {
-                              type: 'object'
-                            }
+                              type: 'object',
+                            },
                           },
                           limit: {
                             description: 'limit',
-                            type: 'integer'
+                            type: 'integer',
                           },
                           offset: {
                             description: 'offset',
-                            type: 'integer'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                            type: 'integer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
@@ -1247,7 +1247,7 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
         'content',
         'application/json',
         'schema',
-        'properties'
+        'properties',
       ]);
       expect(res.warnings[0].message).toEqual(
         'A paginated list operation must include an array property whose name matches the final segment of the path.'

--- a/test/plugins/validation/oas3/parameters.test.js
+++ b/test/plugins/validation/oas3/parameters.test.js
@@ -1,11 +1,11 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/parameters');
 const config = require('../../../../src/.defaultsForValidator').defaults.oas3;
 
-describe('validation plugin - semantic - parameters - oas3', function() {
-  it('should not complain when parameter is valid', function() {
+describe('validation plugin - semantic - parameters - oas3', function () {
+  it('should not complain when parameter is valid', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -17,26 +17,26 @@ describe('validation plugin - semantic - parameters - oas3', function() {
                 in: 'query',
                 name: 'query_param',
                 schema: {
-                  type: 'string'
+                  type: 'string',
                 },
-                description: 'a parameter'
-              }
+                description: 'a parameter',
+              },
             ],
             responses: {
-              '200': {
+              200: {
                 description: 'success',
                 content: {
                   'text/plain': {
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -44,7 +44,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when `in` is missing', function() {
+  it('should complain when `in` is missing', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -55,26 +55,26 @@ describe('validation plugin - semantic - parameters - oas3', function() {
               {
                 name: 'query_param',
                 schema: {
-                  type: 'string'
+                  type: 'string',
                 },
-                description: 'a parameter'
-              }
+                description: 'a parameter',
+              },
             ],
             responses: {
-              '200': {
+              200: {
                 description: 'success',
                 content: {
                   'text/plain': {
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -84,7 +84,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
       '/pets',
       'get',
       'parameters',
-      '0'
+      '0',
     ]);
     expect(res.errors[0].message).toEqual(
       'Parameters MUST have an `in` property.'
@@ -92,7 +92,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when `in` is an invalid value', function() {
+  it('should complain when `in` is an invalid value', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -104,26 +104,26 @@ describe('validation plugin - semantic - parameters - oas3', function() {
                 in: 'body',
                 name: 'query_param',
                 schema: {
-                  type: 'string'
+                  type: 'string',
                 },
-                description: 'a parameter'
-              }
+                description: 'a parameter',
+              },
             ],
             responses: {
-              '200': {
+              200: {
                 description: 'success',
                 content: {
                   'text/plain': {
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -134,7 +134,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
       'get',
       'parameters',
       '0',
-      'in'
+      'in',
     ]);
     expect(res.errors[0].message).toEqual(
       "Unsupported value for `in`: 'body'. Allowed values are query, header, path, cookie"
@@ -142,7 +142,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when the parameter has an undescribed data type', function() {
+  it('should complain when the parameter has an undescribed data type', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -153,24 +153,24 @@ describe('validation plugin - semantic - parameters - oas3', function() {
               {
                 in: 'cookie',
                 name: 'query_param',
-                description: 'a parameter'
-              }
+                description: 'a parameter',
+              },
             ],
             responses: {
-              '200': {
+              200: {
                 description: 'success',
                 content: {
                   'text/plain': {
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -180,7 +180,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
       '/pets',
       'get',
       'parameters',
-      '0'
+      '0',
     ]);
     expect(res.errors[0].message).toEqual(
       'Parameters MUST have their data described by either `schema` or `content`.'
@@ -188,7 +188,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when a parameter describes data type with both `schema` and `content`', function() {
+  it('should complain when a parameter describes data type with both `schema` and `content`', function () {
     const spec = {
       components: {
         parameters: {
@@ -199,16 +199,16 @@ describe('validation plugin - semantic - parameters - oas3', function() {
             content: {
               'text/plain': {
                 schema: {
-                  type: 'string'
-                }
-              }
+                  type: 'string',
+                },
+              },
             },
             schema: {
-              type: 'string'
-            }
-          }
-        }
-      }
+              type: 'string',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -216,7 +216,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
     expect(res.errors[0].path).toEqual([
       'components',
       'parameters',
-      'BadParam'
+      'BadParam',
     ]);
     expect(res.errors[0].message).toEqual(
       'Parameters MUST NOT have both a `schema` and `content` property.'
@@ -224,7 +224,7 @@ describe('validation plugin - semantic - parameters - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when a parameter uses json content with schema type: string, format: binary', function() {
+  it('should complain when a parameter uses json content with schema type: string, format: binary', function () {
     const spec = {
       components: {
         parameters: {
@@ -249,21 +249,21 @@ describe('validation plugin - semantic - parameters - oas3', function() {
                               properties: {
                                 sub_sub_prop1: {
                                   type: 'string',
-                                  format: 'binary'
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                                  format: 'binary',
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -282,14 +282,14 @@ describe('validation plugin - semantic - parameters - oas3', function() {
       'properties',
       'sub_prop1',
       'properties',
-      'sub_sub_prop1'
+      'sub_sub_prop1',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Parameters should not contain binary (type: string, format: binary) values.'
     );
   });
 
-  it('should complain when a parameter uses json as second mime type with schema type: string, format: binary', function() {
+  it('should complain when a parameter uses json as second mime type with schema type: string, format: binary', function () {
     const spec = {
       components: {
         parameters: {
@@ -299,18 +299,18 @@ describe('validation plugin - semantic - parameters - oas3', function() {
             description: 'a parameter',
             content: {
               'text/plain': {
-                type: 'string'
+                type: 'string',
               },
               'application/json': {
                 schema: {
                   type: 'string',
-                  format: 'binary'
-                }
-              }
-            }
-          }
-        }
-      }
+                  format: 'binary',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -321,31 +321,31 @@ describe('validation plugin - semantic - parameters - oas3', function() {
       'BadParam',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Parameters should not contain binary (type: string, format: binary) values.'
     );
   });
 
-  it('should complain multiple times when multiple parameters use schema type: string, format: binary', function() {
+  it('should complain multiple times when multiple parameters use schema type: string, format: binary', function () {
     const spec = {
       components: {
         parameters: {
           BadParam1: {
             schema: {
               type: 'string',
-              format: 'binary'
-            }
+              format: 'binary',
+            },
           },
           BadParam2: {
             schema: {
               type: 'string',
-              format: 'binary'
-            }
-          }
-        }
-      }
+              format: 'binary',
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -354,73 +354,27 @@ describe('validation plugin - semantic - parameters - oas3', function() {
       'components',
       'parameters',
       'BadParam1',
-      'schema'
+      'schema',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Parameters should not contain binary (type: string, format: binary) values.'
     );
   });
 
-  it('should not complain when the schema field is empty', function() {
+  it('should not complain when the schema field is empty', function () {
     const spec = {
       components: {
         parameters: {
-          GoodParam: {}
-        }
-      }
-    };
-
-    const res = validate({ jsSpec: spec }, config);
-    expect(res.warnings.length).toEqual(0);
-  });
-
-  it('should not complain when parameter is a ref', async function() {
-    const spec = {
-      paths: {
-        '/pets': {
-          get: {
-            summary: 'this is a summary',
-            operationId: 'operationId',
-            parameters: [
-              {
-                $ref: '#/components/parameters/QueryParam'
-              }
-            ],
-            responses: {
-              '200': {
-                description: 'success',
-                content: {
-                  'text/plain': {
-                    schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+          GoodParam: {},
+        },
       },
-      components: {
-        parameters: {
-          QueryParam: {
-            in: 'query',
-            name: 'query_param',
-            schema: {
-              type: 'string'
-            },
-            description: 'a parameter'
-          }
-        }
-      }
     };
 
     const res = validate({ jsSpec: spec }, config);
-    expect(res.errors.length).toEqual(0);
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain twice when parameter is a ref', async function() {
+  it('should not complain when parameter is a ref', async function () {
     const spec = {
       paths: {
         '/pets': {
@@ -429,23 +383,23 @@ describe('validation plugin - semantic - parameters - oas3', function() {
             operationId: 'operationId',
             parameters: [
               {
-                $ref: '#/components/parameters/QueryParam'
-              }
+                $ref: '#/components/parameters/QueryParam',
+              },
             ],
             responses: {
-              '200': {
+              200: {
                 description: 'success',
                 content: {
                   'text/plain': {
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       components: {
         parameters: {
@@ -454,19 +408,65 @@ describe('validation plugin - semantic - parameters - oas3', function() {
             name: 'query_param',
             schema: {
               type: 'string',
-              format: 'binary'
             },
-            description: 'a parameter'
-          }
-        }
-      }
+            description: 'a parameter',
+          },
+        },
+      },
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(0);
+  });
+
+  it('should not complain twice when parameter is a ref', async function () {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            parameters: [
+              {
+                $ref: '#/components/parameters/QueryParam',
+              },
+            ],
+            responses: {
+              200: {
+                description: 'success',
+                content: {
+                  'text/plain': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        parameters: {
+          QueryParam: {
+            in: 'query',
+            name: 'query_param',
+            schema: {
+              type: 'string',
+              format: 'binary',
+            },
+            description: 'a parameter',
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
     expect(res.warnings.length).toEqual(1);
   });
 
-  it('should not complain about a schema property named `parameters`', function() {
+  it('should not complain about a schema property named `parameters`', function () {
     const spec = {
       components: {
         schemas: {
@@ -476,13 +476,13 @@ describe('validation plugin - semantic - parameters - oas3', function() {
                 type: 'object',
                 description: 'A map of key/value pairs',
                 additionalProperties: {
-                  description: 'A parameter. But not an OpenAPI parameter ;)'
-                }
-              }
-            }
-          }
-        }
-      }
+                  description: 'A parameter. But not an OpenAPI parameter ;)',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);

--- a/test/plugins/validation/oas3/responses.test.js
+++ b/test/plugins/validation/oas3/responses.test.js
@@ -2,13 +2,13 @@ const expect = require('expect');
 const resolver = require('json-schema-ref-parser');
 
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/responses');
 
 const config = require('../../../../src/.defaultsForValidator').defaults.oas3;
 
-describe('validation plugin - semantic - responses - oas3', function() {
-  it('should not complain for valid use of type:string, format: binary', function() {
+describe('validation plugin - semantic - responses - oas3', function () {
+  it('should not complain for valid use of type:string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -16,28 +16,28 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
+              200: {
                 description: '200 response',
                 content: {
                   'multipart/form-data': {
                     schema: {
                       type: 'string',
-                      format: 'binary'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      format: 'binary',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when response body uses json and schema type: string, format: binary', function() {
+  it('should complain when response body uses json and schema type: string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -45,7 +45,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
+              200: {
                 description: '200 response',
                 content: {
                   'application/json': {
@@ -53,16 +53,16 @@ describe('validation plugin - semantic - responses - oas3', function() {
                       type: 'array',
                       items: {
                         type: 'string',
-                        format: 'binary'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                        format: 'binary',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -76,14 +76,14 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'content',
       'application/json',
       'schema',
-      'items'
+      'items',
     ]);
     expect(res.warnings[0].message).toEqual(
       'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
     );
   });
 
-  it('should complain when a response is missing a description', function() {
+  it('should complain when a response is missing a description', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -91,20 +91,20 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
+              200: {
                 content: {
                   'multipart/form-data': {
                     schema: {
                       type: 'string',
-                      format: 'binary'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      format: 'binary',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -115,14 +115,14 @@ describe('validation plugin - semantic - responses - oas3', function() {
       '/pets',
       'get',
       'responses',
-      '200'
+      '200',
     ]);
     expect(res.errors[0].message).toEqual(
       'All responses must include a description.'
     );
   });
 
-  it('should complain when 422 response code used', function() {
+  it('should complain when 422 response code used', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -130,24 +130,24 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
+              200: {
                 description: '200 response',
                 content: {
                   'multipart/form-data': {
                     schema: {
                       type: 'string',
-                      format: 'binary'
-                    }
-                  }
-                }
+                      format: 'binary',
+                    },
+                  },
+                },
               },
-              '422': {
-                description: '422 response discouraged'
-              }
-            }
-          }
-        }
-      }
+              422: {
+                description: '422 response discouraged',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -157,7 +157,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     );
   });
 
-  it('should complain when 302 response code used', function() {
+  it('should complain when 302 response code used', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -165,24 +165,24 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
+              200: {
                 description: '200 response',
                 content: {
                   'multipart/form-data': {
                     schema: {
                       type: 'string',
-                      format: 'binary'
-                    }
-                  }
-                }
+                      format: 'binary',
+                    },
+                  },
+                },
               },
-              '302': {
-                description: '302 response discouraged'
-              }
-            }
-          }
-        }
-      }
+              302: {
+                description: '302 response discouraged',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -192,7 +192,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     );
   });
 
-  it('should complain when default response body uses json as second mime type and uses schema type: string, format: binary', function() {
+  it('should complain when default response body uses json as second mime type and uses schema type: string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -205,8 +205,8 @@ describe('validation plugin - semantic - responses - oas3', function() {
                 content: {
                   'text/plain': {
                     schema: {
-                      type: 'string'
-                    }
+                      type: 'string',
+                    },
                   },
                   'application/json': {
                     schema: {
@@ -214,17 +214,17 @@ describe('validation plugin - semantic - responses - oas3', function() {
                       properties: {
                         prop1: {
                           type: 'string',
-                          format: 'binary'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -239,14 +239,14 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'application/json',
       'schema',
       'properties',
-      'prop1'
+      'prop1',
     ]);
     expect(res.warnings[0].message).toEqual(
       'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
     );
   });
 
-  it('should complain multiple times when multiple json response bodies use type: string, format: binary', function() {
+  it('should complain multiple times when multiple json response bodies use type: string, format: binary', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -254,7 +254,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
+              200: {
                 description: '200 response',
                 content: {
                   'application/json': {
@@ -262,13 +262,13 @@ describe('validation plugin - semantic - responses - oas3', function() {
                       type: 'array',
                       items: {
                         type: 'string',
-                        format: 'binary'
-                      }
-                    }
-                  }
-                }
+                        format: 'binary',
+                      },
+                    },
+                  },
+                },
               },
-              '201': {
+              201: {
                 description: '201 response',
                 content: {
                   'application/json': {
@@ -277,22 +277,22 @@ describe('validation plugin - semantic - responses - oas3', function() {
                       properties: {
                         prop1: {
                           type: 'string',
-                          format: 'binary'
+                          format: 'binary',
                         },
                         prop2: {
                           type: 'array',
                           items: {
                             type: 'string',
-                            format: 'binary'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
+                            format: 'binary',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
               },
-              '204': {
-                description: '204 response'
+              204: {
+                description: '204 response',
               },
               default: {
                 description: 'the default response',
@@ -303,17 +303,17 @@ describe('validation plugin - semantic - responses - oas3', function() {
                       properties: {
                         prop1: {
                           type: 'string',
-                          format: 'binary'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -327,7 +327,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'content',
       'application/json',
       'schema',
-      'items'
+      'items',
     ]);
     expect(res.warnings[0].message).toEqual(
       'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
@@ -342,7 +342,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'application/json',
       'schema',
       'properties',
-      'prop1'
+      'prop1',
     ]);
     expect(res.warnings[1].message).toEqual(
       'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
@@ -358,7 +358,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'schema',
       'properties',
       'prop2',
-      'items'
+      'items',
     ]);
     expect(res.warnings[2].message).toEqual(
       'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
@@ -373,14 +373,14 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'application/json',
       'schema',
       'properties',
-      'prop1'
+      'prop1',
     ]);
     expect(res.warnings[3].message).toEqual(
       'JSON request/response bodies should not contain binary (type: string, format: binary) values.'
     );
   });
 
-  it('should complain when response object only has a default', function() {
+  it('should complain when response object only has a default', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -389,12 +389,12 @@ describe('validation plugin - semantic - responses - oas3', function() {
             operationId: 'operationId',
             responses: {
               default: {
-                description: 'the default response'
-              }
-            }
-          }
-        }
-      }
+                description: 'the default response',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -406,7 +406,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when no response codes are valid', function() {
+  it('should complain when no response codes are valid', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -414,13 +414,13 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '2007': {
-                description: 'an invalid response'
-              }
-            }
-          }
-        }
-      }
+              2007: {
+                description: 'an invalid response',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -432,7 +432,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain when there are no problems', function() {
+  it('should not complain when there are no problems', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -440,13 +440,13 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '204': {
-                description: 'successful operation call with no response body'
-              }
-            }
-          }
-        }
-      }
+              204: {
+                description: 'successful operation call with no response body',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -454,7 +454,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain when a non-204 success does not have response body', function() {
+  it('should complain when a non-204 success does not have response body', function () {
     const spec = {
       paths: {
         '/example': {
@@ -462,13 +462,13 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '200': {
-                description: 'successful operation call with no response body'
-              }
-            }
-          }
-        }
-      }
+              200: {
+                description: 'successful operation call with no response body',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -478,14 +478,14 @@ describe('validation plugin - semantic - responses - oas3', function() {
       '/example',
       'get',
       'responses',
-      '200'
+      '200',
     ]);
     expect(res.warnings[0].message).toEqual(
       `A 200 response should include a response body. Use 204 for responses without content.`
     );
   });
 
-  it('should issue multiple warnings when multiple non-204 successes do not have response bodies', function() {
+  it('should issue multiple warnings when multiple non-204 successes do not have response bodies', function () {
     const spec = {
       paths: {
         '/example1': {
@@ -493,27 +493,27 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId_1',
             responses: {
-              '200': {
-                description: 'first successful response with no response body'
+              200: {
+                description: 'first successful response with no response body',
               },
-              '202': {
-                description: 'second successful response with no response body'
-              }
-            }
-          }
+              202: {
+                description: 'second successful response with no response body',
+              },
+            },
+          },
         },
         '/example2': {
           get: {
             summary: 'this is a summary',
             operationId: 'operationId_2',
             responses: {
-              '203': {
-                description: 'third successful response with no response body'
-              }
-            }
-          }
-        }
-      }
+              203: {
+                description: 'third successful response with no response body',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -523,7 +523,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
       '/example1',
       'get',
       'responses',
-      '200'
+      '200',
     ]);
     expect(res.warnings[0].message).toEqual(
       `A 200 response should include a response body. Use 204 for responses without content.`
@@ -533,7 +533,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
       '/example1',
       'get',
       'responses',
-      '202'
+      '202',
     ]);
     expect(res.warnings[1].message).toEqual(
       `A 202 response should include a response body. Use 204 for responses without content.`
@@ -543,14 +543,14 @@ describe('validation plugin - semantic - responses - oas3', function() {
       '/example2',
       'get',
       'responses',
-      '203'
+      '203',
     ]);
     expect(res.warnings[2].message).toEqual(
       `A 203 response should include a response body. Use 204 for responses without content.`
     );
   });
 
-  it('should not complain when a non-204 success has a ref to a response with content', async function() {
+  it('should not complain when a non-204 success has a ref to a response with content', async function () {
     const jsSpec = {
       paths: {
         '/comments': {
@@ -558,12 +558,12 @@ describe('validation plugin - semantic - responses - oas3', function() {
             operationId: 'add_comment',
             summary: 'adds a comment',
             responses: {
-              '201': {
-                $ref: '#/components/responses/success'
-              }
-            }
-          }
-        }
+              201: {
+                $ref: '#/components/responses/success',
+              },
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -572,13 +572,13 @@ describe('validation plugin - semantic - responses - oas3', function() {
             content: {
               'application/json': {
                 schema: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
-      }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const spec = await resolver.dereference(jsSpec);
@@ -587,7 +587,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain about having only error responses', function() {
+  it('should complain about having only error responses', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -595,22 +595,22 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '400': {
-                description: 'bad request'
+              400: {
+                description: 'bad request',
               },
-              '401': {
-                description: 'unauthorized'
+              401: {
+                description: 'unauthorized',
               },
-              '404': {
-                description: 'resource not found'
+              404: {
+                description: 'resource not found',
               },
               default: {
-                description: 'any other response'
-              }
-            }
-          }
-        }
-      }
+                description: 'any other response',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -619,7 +619,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'paths',
       '/pets',
       'get',
-      'responses'
+      'responses',
     ]);
     expect(res.warnings[0].message).toEqual(
       'Each `responses` object SHOULD have at least one code for a successful response.'
@@ -627,7 +627,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should not complain about having only a 101 response', function() {
+  it('should not complain about having only a 101 response', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -635,13 +635,13 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '101': {
-                description: 'switching protocols'
-              }
-            }
-          }
-        }
-      }
+              101: {
+                description: 'switching protocols',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -649,7 +649,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should complain about having a 101 along with any 2xx code', function() {
+  it('should complain about having a 101 along with any 2xx code', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -657,16 +657,16 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '101': {
-                description: 'switching protocols'
+              101: {
+                description: 'switching protocols',
               },
-              '204': {
-                description: 'no content'
-              }
-            }
-          }
-        }
-      }
+              204: {
+                description: 'no content',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -678,7 +678,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
     );
   });
 
-  it('should complain about 204 response that defines a response body', function() {
+  it('should complain about 204 response that defines a response body', function () {
     const spec = {
       paths: {
         '/pets': {
@@ -686,24 +686,24 @@ describe('validation plugin - semantic - responses - oas3', function() {
             summary: 'this is a summary',
             operationId: 'operationId',
             responses: {
-              '204': {
+              204: {
                 description: 'bad request',
                 content: {
                   schema: {
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               },
-              '400': {
-                description: 'bad request'
+              400: {
+                description: 'bad request',
               },
               default: {
-                description: 'any other response'
-              }
-            }
-          }
-        }
-      }
+                description: 'any other response',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec }, config);
@@ -715,7 +715,7 @@ describe('validation plugin - semantic - responses - oas3', function() {
       'delete',
       'responses',
       '204',
-      'content'
+      'content',
     ]);
     expect(res.errors[0].message).toEqual(
       'A 204 response MUST NOT include a message-body.'

--- a/test/plugins/validation/oas3/security-definitions-ibm.test.js
+++ b/test/plugins/validation/oas3/security-definitions-ibm.test.js
@@ -1,18 +1,18 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/oas3/semantic-validators/security-definitions-ibm');
 
-describe('it should have a type of `apiKey`,`http`,`oauth2`, `openIdConnect`', function() {
-  it('should have a type', function() {
+describe('it should have a type of `apiKey`,`http`,`oauth2`, `openIdConnect`', function () {
+  it('should have a type', function () {
     const spec = {
       components: {
         securitySchemes: {
           SecuritySchemeModel: {
-            scheme: 'basic'
-          }
-        }
-      }
+            scheme: 'basic',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -23,17 +23,17 @@ describe('it should have a type of `apiKey`,`http`,`oauth2`, `openIdConnect`', f
       'security scheme is missing required field `type`'
     );
   });
-  it('type can only be `apiKey`, `http`, `oauth2`, `openIdConnect`', function() {
+  it('type can only be `apiKey`, `http`, `oauth2`, `openIdConnect`', function () {
     const spec = {
       components: {
         securitySchemes: {
           SecuritySchemeModel: {
             type: 'wrong type',
             scheme: 'basic',
-            description: 'example text'
-          }
-        }
-      }
+            description: 'example text',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -48,8 +48,8 @@ describe('it should have a type of `apiKey`,`http`,`oauth2`, `openIdConnect`', f
   });
 });
 
-describe('if the type is `apiKey` then it should have `query`, `header` or `cookie` as well as `name`', function() {
-  it('if type is `apiKey`, then the `in` property should be defined and can only be `query`, `header` or `cookie`.', function() {
+describe('if the type is `apiKey` then it should have `query`, `header` or `cookie` as well as `name`', function () {
+  it('if type is `apiKey`, then the `in` property should be defined and can only be `query`, `header` or `cookie`.', function () {
     const spec = {
       components: {
         securitySchemes: {
@@ -57,10 +57,10 @@ describe('if the type is `apiKey` then it should have `query`, `header` or `cook
             type: 'apiKey',
             name: 'apiKey',
             scheme: 'basic',
-            descriptions: 'example text'
-          }
-        }
-      }
+            descriptions: 'example text',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -73,7 +73,7 @@ describe('if the type is `apiKey` then it should have `query`, `header` or `cook
       "apiKey authorization must have required 'in' property, valid values are 'query' or 'header' or 'cookie'."
     );
   });
-  it('if type is `apiKey`, then the `name` property should be defined and should be the name of the header or query property', function() {
+  it('if type is `apiKey`, then the `name` property should be defined and should be the name of the header or query property', function () {
     const spec = {
       components: {
         securitySchemes: {
@@ -81,10 +81,10 @@ describe('if the type is `apiKey` then it should have `query`, `header` or `cook
             type: 'apiKey',
             in: 'cookie',
             scheme: 'basic',
-            descriptions: 'example text'
-          }
-        }
-      }
+            descriptions: 'example text',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -97,20 +97,20 @@ describe('if the type is `apiKey` then it should have `query`, `header` or `cook
   });
 });
 
-describe('if the type is `oauth2` then it should have flows and flows should follow the spec requirements', function() {
-  it('should have flows property if type is oauth2', function() {
+describe('if the type is `oauth2` then it should have flows and flows should follow the spec requirements', function () {
+  it('should have flows property if type is oauth2', function () {
     const spec = {
       components: {
         securitySchemes: {
           SecuritySchemeModel: {
-            type: 'oauth2'
+            type: 'oauth2',
           },
           authorizationCode: {
             authorizationUrl: 'https://example.com/api/oauth/dialog',
-            tokenUrl: 'https://example.com/api/oauth/token'
-          }
-        }
-      }
+            tokenUrl: 'https://example.com/api/oauth/token',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -121,7 +121,7 @@ describe('if the type is `oauth2` then it should have flows and flows should fol
       "oauth2 authorization must have required 'flows' property" //////recieved
     );
   });
-  it('should have `authorizationUrl` if flows is `implicit`', function() {
+  it('should have `authorizationUrl` if flows is `implicit`', function () {
     const spec = {
       components: {
         securitySchemes: {
@@ -130,12 +130,12 @@ describe('if the type is `oauth2` then it should have flows and flows should fol
             flows: {
               implicit: {
                 authurl: 'not real url',
-                scopes: {}
-              }
-            }
-          }
-        }
-      }
+                scopes: {},
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -148,7 +148,7 @@ describe('if the type is `oauth2` then it should have flows and flows should fol
       "oauth2 implicit flow must have required 'authorizationUrl' property"
     );
   });
-  it('should have `authorizationUrl` and `tokenUrl` if type is `oauth2` and flow is `authorizationCode`', function() {
+  it('should have `authorizationUrl` and `tokenUrl` if type is `oauth2` and flow is `authorizationCode`', function () {
     const spec = {
       components: {
         securitySchemes: {
@@ -157,12 +157,12 @@ describe('if the type is `oauth2` then it should have flows and flows should fol
             flows: {
               authorizationCode: {
                 authorizationUrl: 'https://example.com/api/oauth/dialog',
-                scopes: {}
-              }
-            }
-          }
-        }
-      }
+                scopes: {},
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -175,7 +175,7 @@ describe('if the type is `oauth2` then it should have flows and flows should fol
       "flow must have required 'tokenUrl' property if type is `authorizationCode`"
     );
   });
-  it('should have `scopes` defined as an object if type is `oauth2`', function() {
+  it('should have `scopes` defined as an object if type is `oauth2`', function () {
     const spec = {
       components: {
         securitySchemes: {
@@ -186,12 +186,12 @@ describe('if the type is `oauth2` then it should have flows and flows should fol
             scheme: 'Basic',
             flows: {
               implicit: {
-                authorizationUrl: 'https://example.com/api/oauth/dialog'
-              }
-            }
-          }
-        }
-      }
+                authorizationUrl: 'https://example.com/api/oauth/dialog',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -206,17 +206,17 @@ describe('if the type is `oauth2` then it should have flows and flows should fol
   });
 });
 
-describe('if `type` is `http`, then scheme property must be defined', function() {
-  it('should have a defined scheme if type is `http`', function() {
+describe('if `type` is `http`, then scheme property must be defined', function () {
+  it('should have a defined scheme if type is `http`', function () {
     const spec = {
       components: {
         securitySchemes: {
           SecuritySchemeModel: {
             type: 'http',
-            descriptions: 'example text'
-          }
-        }
-      }
+            descriptions: 'example text',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -229,8 +229,8 @@ describe('if `type` is `http`, then scheme property must be defined', function()
   });
 });
 
-describe('if `type` is `openIdConnect` then `openIdConnectUrl` must be defined and valid', function() {
-  it('should have `openIdConnectUrl` propery if the type is defined as `openIdConnect`', function() {
+describe('if `type` is `openIdConnect` then `openIdConnectUrl` must be defined and valid', function () {
+  it('should have `openIdConnectUrl` propery if the type is defined as `openIdConnect`', function () {
     const spec = {
       components: {
         securitySchemes: {
@@ -238,10 +238,10 @@ describe('if `type` is `openIdConnect` then `openIdConnectUrl` must be defined a
             type: 'openIdConnect',
             openIdConnectUrl: 2,
             scheme: 'basic',
-            descriptions: 'example text'
-          }
-        }
-      }
+            descriptions: 'example text',
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });

--- a/test/plugins/validation/swagger2/discriminator.test.js
+++ b/test/plugins/validation/swagger2/discriminator.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/swagger2/semantic-validators/discriminator');
 
 describe('validation plugin - semantic - swagger2 discriminator', () => {
@@ -12,12 +12,12 @@ describe('validation plugin - semantic - swagger2 discriminator', () => {
           discriminator: 'petType',
           properties: {
             petType: {
-              type: 'string'
-            }
+              type: 'string',
+            },
           },
-          required: ['petType']
-        }
-      }
+          required: ['petType'],
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(0);
@@ -28,13 +28,13 @@ describe('validation plugin - semantic - swagger2 discriminator', () => {
       definitions: {
         Pet: {
           type: 'object',
-          discriminator: {}
+          discriminator: {},
         },
         Food: {
           type: 'object',
-          discriminator: 123
-        }
-      }
+          discriminator: 123,
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(2);
@@ -61,11 +61,11 @@ describe('validation plugin - semantic - swagger2 discriminator', () => {
           discriminator: 'petType',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
-        }
-      }
+              type: 'string',
+            },
+          },
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(1);
@@ -85,11 +85,11 @@ describe('validation plugin - semantic - swagger2 discriminator', () => {
           discriminator: 'petType',
           properties: {
             petType: {
-              type: 'string'
-            }
-          }
-        }
-      }
+              type: 'string',
+            },
+          },
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(1);
@@ -107,22 +107,22 @@ describe('validation plugin - semantic - swagger2 discriminator', () => {
           discriminator: 'petType',
           properties: {
             petType: {
-              type: 'string'
-            }
+              type: 'string',
+            },
           },
-          required: {}
+          required: {},
         },
         Food: {
           type: 'object',
           discriminator: 'foodType',
           properties: {
             foodType: {
-              type: 'string'
-            }
+              type: 'string',
+            },
           },
-          required: 123
-        }
-      }
+          required: 123,
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(2);
@@ -144,12 +144,12 @@ describe('validation plugin - semantic - swagger2 discriminator', () => {
           discriminator: 'petType',
           properties: {
             petType: {
-              type: 'string'
-            }
+              type: 'string',
+            },
           },
-          required: ['name']
-        }
-      }
+          required: ['name'],
+        },
+      },
     };
     const res = validate({ jsSpec: spec });
     expect(res.errors.length).toEqual(1);

--- a/test/plugins/validation/swagger2/form-data.test.js
+++ b/test/plugins/validation/swagger2/form-data.test.js
@@ -1,17 +1,17 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/swagger2/semantic-validators/form-data');
 
-describe('validation plugin - semantic - form data', function() {
-  describe('/parameters/...', function() {
-    describe('in: formdata + in: body', function() {
+describe('validation plugin - semantic - form data', function () {
+  describe('/parameters/...', function () {
+    describe('in: formdata + in: body', function () {
       // Already covered in validators/operations.js
-      it.skip('should complain about having both in the same parameter', function() {
+      it.skip('should complain about having both in the same parameter', function () {
         const spec = {
           parameters: {
-            CoolParam: [{ in: 'query' }, { in: 'body' }, { in: 'formData' }]
-          }
+            CoolParam: [{ in: 'query' }, { in: 'body' }, { in: 'formData' }],
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -19,18 +19,18 @@ describe('validation plugin - semantic - form data', function() {
           {
             message:
               'Parameters cannot have `in` values of both "body" and "formData", as "formData" _will_ be the body',
-            path: 'parameters.CoolParam.1'
-          }
+            path: 'parameters.CoolParam.1',
+          },
         ]);
       });
     });
 
-    describe('typo in formdata', function() {
-      it('should warn about formdata ( typo )', function() {
+    describe('typo in formdata', function () {
+      it('should warn about formdata ( typo )', function () {
         const spec = {
           parameters: {
-            CoolParam: [{ in: 'formdata' }]
-          }
+            CoolParam: [{ in: 'formdata' }],
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -43,17 +43,17 @@ describe('validation plugin - semantic - form data', function() {
     });
   });
 
-  describe('/paths/...', function() {
-    describe('typo in formdata', function() {
-      it('should warn about formdata ( typo )', function() {
+  describe('/paths/...', function () {
+    describe('typo in formdata', function () {
+      it('should warn about formdata ( typo )', function () {
         const spec = {
           paths: {
             '/some': {
               post: {
-                parameters: [{ in: 'formdata' }]
-              }
-            }
-          }
+                parameters: [{ in: 'formdata' }],
+              },
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -65,8 +65,8 @@ describe('validation plugin - semantic - form data', function() {
       });
     });
     // Already covered in validators/operations.js
-    describe.skip('in: formdata + in: body', function() {
-      it('should complain about having both in the same parameter', function() {
+    describe.skip('in: formdata + in: body', function () {
+      it('should complain about having both in the same parameter', function () {
         const spec = {
           paths: {
             '/some': {
@@ -74,11 +74,11 @@ describe('validation plugin - semantic - form data', function() {
                 parameters: [
                   { in: 'query' },
                   { in: 'body' },
-                  { in: 'formData' }
-                ]
-              }
-            }
-          }
+                  { in: 'formData' },
+                ],
+              },
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -90,8 +90,8 @@ describe('validation plugin - semantic - form data', function() {
       });
     });
 
-    describe('missing consumes', function() {
-      it("should complain if 'type:file` and no 'in: formData", function() {
+    describe('missing consumes', function () {
+      it("should complain if 'type:file` and no 'in: formData", function () {
         const spec = {
           paths: {
             '/some': {
@@ -99,12 +99,12 @@ describe('validation plugin - semantic - form data', function() {
                 consumes: ['multipart/form-data'],
                 parameters: [
                   {
-                    type: 'file'
-                  }
-                ]
-              }
-            }
-          }
+                    type: 'file',
+                  },
+                ],
+              },
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -115,7 +115,7 @@ describe('validation plugin - semantic - form data', function() {
         expect(res.errors[0].path).toEqual('paths./some.post.parameters.0');
       });
 
-      it("should complain if 'type:file` and no consumes - 'multipart/form-data'", function() {
+      it("should complain if 'type:file` and no consumes - 'multipart/form-data'", function () {
         const spec = {
           paths: {
             '/some': {
@@ -123,12 +123,12 @@ describe('validation plugin - semantic - form data', function() {
                 parameters: [
                   {
                     in: 'formData',
-                    type: 'file'
-                  }
-                ]
-              }
-            }
-          }
+                    type: 'file',
+                  },
+                ],
+              },
+            },
+          },
         };
 
         const res = validate({ resolvedSpec: spec });
@@ -141,15 +141,15 @@ describe('validation plugin - semantic - form data', function() {
     });
   });
 
-  describe('/pathitems/...', function() {
+  describe('/pathitems/...', function () {
     // Already covered in validators/operations.js
-    it.skip('should complain about having both in the same parameter', function() {
+    it.skip('should complain about having both in the same parameter', function () {
       const spec = {
         pathitems: {
           CoolPathItem: {
-            parameters: [{ in: 'formData' }, { in: 'body' }]
-          }
-        }
+            parameters: [{ in: 'formData' }, { in: 'body' }],
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec });
@@ -160,18 +160,18 @@ describe('validation plugin - semantic - form data', function() {
       expect(res.errors[0].path).toEqual('pathitems.CoolPathItem.parameters.1');
     });
 
-    it("should complain if 'type:file` and no 'in: formData", function() {
+    it("should complain if 'type:file` and no 'in: formData", function () {
       const spec = {
         pathitems: {
           SomePathItem: {
             consumes: ['multipart/form-data'],
             parameters: [
               {
-                type: 'file'
-              }
-            ]
-          }
-        }
+                type: 'file',
+              },
+            ],
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec });
@@ -182,18 +182,18 @@ describe('validation plugin - semantic - form data', function() {
       expect(res.errors[0].path).toEqual('pathitems.SomePathItem.parameters.0');
     });
 
-    it("should complain if 'type:file` and no consumes - 'multipart/form-data'", function() {
+    it("should complain if 'type:file` and no consumes - 'multipart/form-data'", function () {
       const spec = {
         pathitems: {
           SomePathItem: {
             parameters: [
               {
                 in: 'formData',
-                type: 'file'
-              }
-            ]
-          }
-        }
+                type: 'file',
+              },
+            ],
+          },
+        },
       };
 
       const res = validate({ resolvedSpec: spec });

--- a/test/plugins/validation/swagger2/operations-ibm.test.js
+++ b/test/plugins/validation/swagger2/operations-ibm.test.js
@@ -1,14 +1,14 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/swagger2/semantic-validators/operations-ibm');
 
-describe('validation plugin - semantic - operations-ibm - swagger2', function() {
-  it('should complain about PUT operation with body parameter and a missing consumes', function() {
+describe('validation plugin - semantic - operations-ibm - swagger2', function () {
+  it('should complain about PUT operation with body parameter and a missing consumes', function () {
     const config = {
       operations: {
-        no_consumes_for_put_or_post: 'error'
-      }
+        no_consumes_for_put_or_post: 'error',
+      },
     };
 
     const spec = {
@@ -26,15 +26,15 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -46,11 +46,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain about POST operation with body parameter and a missing consumes', function() {
+  it('should complain about POST operation with body parameter and a missing consumes', function () {
     const config = {
       operations: {
-        no_consumes_for_put_or_post: 'error'
-      }
+        no_consumes_for_put_or_post: 'error',
+      },
     };
 
     const spec = {
@@ -69,15 +69,15 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -89,11 +89,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain about PUT opeartion with body parameter in path and a missing consumes', function() {
+  it('should complain about PUT opeartion with body parameter in path and a missing consumes', function () {
     const config = {
       operations: {
-        no_consumes_for_put_or_post: 'error'
-      }
+        no_consumes_for_put_or_post: 'error',
+      },
     };
 
     const spec = {
@@ -107,20 +107,20 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                 required: ['Property'],
                 properties: [
                   {
-                    name: 'Property'
-                  }
-                ]
-              }
-            }
+                    name: 'Property',
+                  },
+                ],
+              },
+            },
           ],
           put: {
             consumes: [' '],
             produces: ['application/json'],
             summary: 'this is a summary',
-            operationId: 'operationId'
-          }
-        }
-      }
+            operationId: 'operationId',
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -132,11 +132,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain about POST opeartion with body parameter in path and a missing consumes', function() {
+  it('should complain about POST opeartion with body parameter in path and a missing consumes', function () {
     const config = {
       operations: {
-        no_consumes_for_put_or_post: 'error'
-      }
+        no_consumes_for_put_or_post: 'error',
+      },
     };
 
     const spec = {
@@ -150,20 +150,20 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                 required: ['Property'],
                 properties: [
                   {
-                    name: 'Property'
-                  }
-                ]
-              }
-            }
+                    name: 'Property',
+                  },
+                ],
+              },
+            },
           ],
           post: {
             consumes: [' '],
             produces: ['application/json'],
             summary: 'this is a summary',
-            operationId: 'operationId'
-          }
-        }
-      }
+            operationId: 'operationId',
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -175,11 +175,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain about missing consumes when there is no body parameter', function() {
+  it('should not complain about missing consumes when there is no body parameter', function () {
     const config = {
       operations: {
-        no_consumes_for_put_or_post: 'error'
-      }
+        no_consumes_for_put_or_post: 'error',
+      },
     };
 
     const spec = {
@@ -188,10 +188,10 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
           put: {
             produces: ['application/json'],
             summary: 'this is a summary',
-            operationId: 'operationId'
-          }
-        }
-      }
+            operationId: 'operationId',
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -199,11 +199,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain about a missing consumes when there is a global consumes', function() {
+  it('should not complain about a missing consumes when there is a global consumes', function () {
     const config = {
       operations: {
-        no_consumes_for_put_or_post: 'error'
-      }
+        no_consumes_for_put_or_post: 'error',
+      },
     };
 
     const spec = {
@@ -222,15 +222,15 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -238,11 +238,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain about a get operation having consumes', function() {
+  it('should complain about a get operation having consumes', function () {
     const config = {
       operations: {
-        get_op_has_consumes: 'warning'
-      }
+        get_op_has_consumes: 'warning',
+      },
     };
 
     const spec = {
@@ -261,15 +261,15 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -281,11 +281,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.errors.length).toEqual(0);
   });
 
-  it('should complain about a get operation not having produces', function() {
+  it('should complain about a get operation not having produces', function () {
     const config = {
       operations: {
-        no_produces: 'error'
-      }
+        no_produces: 'error',
+      },
     };
 
     const spec = {
@@ -302,15 +302,15 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -322,11 +322,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should complain about a post operation not having produces', function() {
+  it('should complain about a post operation not having produces', function () {
     const config = {
       operations: {
-        no_produces: 'error'
-      }
+        no_produces: 'error',
+      },
     };
 
     const spec = {
@@ -344,29 +344,29 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
             ],
             responses: {
-              '200': {
+              200: {
                 description: 'successful response producing text/plain',
                 schema: {
-                  type: 'string'
-                }
+                  type: 'string',
+                },
               },
-              '204': {
-                description: 'no content is a possibility here'
+              204: {
+                description: 'no content is a possibility here',
               },
-              '500': {
-                description: 'internal error'
-              }
-            }
-          }
-        }
-      }
+              500: {
+                description: 'internal error',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -378,11 +378,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain about a missing produces when there is a global produces', function() {
+  it('should not complain about a missing produces when there is a global produces', function () {
     const config = {
       operations: {
-        no_produces: 'error'
-      }
+        no_produces: 'error',
+      },
     };
 
     const spec = {
@@ -400,15 +400,15 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -416,11 +416,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain about a missing produces for a HEAD operation', function() {
+  it('should not complain about a missing produces for a HEAD operation', function () {
     const config = {
       operations: {
-        no_produces: 'error'
-      }
+        no_produces: 'error',
+      },
     };
 
     const spec = {
@@ -438,15 +438,15 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);
@@ -454,11 +454,11 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should not complain about a missing produces for an op where the only success response is a 204', function() {
+  it('should not complain about a missing produces for an op where the only success response is a 204', function () {
     const config = {
       operations: {
-        no_produces: 'error'
-      }
+        no_produces: 'error',
+      },
     };
 
     const spec = {
@@ -477,26 +477,26 @@ describe('validation plugin - semantic - operations-ibm - swagger2', function() 
                   required: ['Property'],
                   properties: [
                     {
-                      name: 'Property'
-                    }
-                  ]
-                }
-              }
+                      name: 'Property',
+                    },
+                  ],
+                },
+              },
             ],
             responses: {
-              '204': {
-                description: 'no content'
+              204: {
+                description: 'no content',
               },
-              '400': {
-                description: 'bad request'
+              400: {
+                description: 'bad request',
               },
-              '500': {
-                description: 'internal error'
-              }
-            }
-          }
-        }
-      }
+              500: {
+                description: 'internal error',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ jsSpec: spec }, config);

--- a/test/plugins/validation/swagger2/parameters.test.js
+++ b/test/plugins/validation/swagger2/parameters.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/swagger2/semantic-validators/parameters');
 
 describe('validation plugin - semantic - parameters', () => {
@@ -14,12 +14,12 @@ describe('validation plugin - semantic - parameters', () => {
                 name: 'tags',
                 in: 'query',
                 description: 'tags to filter by',
-                type: 'array'
-              }
-            ]
-          }
-        }
-      }
+                type: 'array',
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -29,7 +29,7 @@ describe('validation plugin - semantic - parameters', () => {
       '/pets',
       'get',
       'parameters',
-      '0'
+      '0',
     ]);
     expect(res.errors[0].message).toEqual(
       "Parameters with 'array' type require an 'items' property."

--- a/test/plugins/validation/swagger2/schema.test.js
+++ b/test/plugins/validation/swagger2/schema.test.js
@@ -1,6 +1,6 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/swagger2/semantic-validators/schema');
 
 describe('validation plugin - semantic - schema', () => {
@@ -12,11 +12,11 @@ describe('validation plugin - semantic - schema', () => {
           properties: [
             {
               name: 'BadProperty',
-              readOnly: true
-            }
-          ]
-        }
-      }
+              readOnly: true,
+            },
+          ],
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -25,7 +25,7 @@ describe('validation plugin - semantic - schema', () => {
       'definitions',
       'CoolModel',
       'required',
-      '0'
+      '0',
     ]);
     expect(res.errors[0].message).toEqual(
       'Read only properties cannot marked as required by a schema.'
@@ -40,11 +40,11 @@ describe('validation plugin - semantic - schema', () => {
           required: ['BadProperty'],
           properties: [
             {
-              name: 'BadProperty'
-            }
-          ]
-        }
-      }
+              name: 'BadProperty',
+            },
+          ],
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -64,15 +64,15 @@ describe('validation plugin - semantic - schema', () => {
                   properties: [
                     {
                       name: 'BadProperty',
-                      readOnly: true
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
+                      readOnly: true,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -85,7 +85,7 @@ describe('validation plugin - semantic - schema', () => {
       '200',
       'schema',
       'required',
-      '0'
+      '0',
     ]);
     expect(res.errors[0].message).toEqual(
       'Read only properties cannot marked as required by a schema.'
@@ -104,15 +104,15 @@ describe('validation plugin - semantic - schema', () => {
                   required: ['BadProperty'],
                   properties: [
                     {
-                      name: 'BadProperty'
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
+                      name: 'BadProperty',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -134,15 +134,15 @@ describe('validation plugin - semantic - schema', () => {
                   properties: [
                     {
                       name: 'BadProperty',
-                      readOnly: true
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      readOnly: true,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });
@@ -155,7 +155,7 @@ describe('validation plugin - semantic - schema', () => {
       '0',
       'schema',
       'required',
-      '0'
+      '0',
     ]);
     expect(res.errors[0].message).toEqual(
       'Read only properties cannot marked as required by a schema.'
@@ -176,15 +176,15 @@ describe('validation plugin - semantic - schema', () => {
                   required: ['BadProperty'],
                   properties: [
                     {
-                      name: 'BadProperty'
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
+                      name: 'BadProperty',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
     };
 
     const res = validate({ resolvedSpec: spec });

--- a/test/plugins/validation/swagger2/swagger.test.js
+++ b/test/plugins/validation/swagger2/swagger.test.js
@@ -1,13 +1,13 @@
 const expect = require('expect');
 const {
-  validate
+  validate,
 } = require('../../../../src/plugins/validation/swagger2/semantic-validators/swagger');
 
 describe('validation plugin - semantic - swagger', () => {
   //this is for openapi object
   it('should return an error when an API definition does not have swagger field', () => {
     const spec = {
-      Swagger: '2.0'
+      Swagger: '2.0',
     };
 
     const res = validate({ jsSpec: spec });
@@ -20,7 +20,7 @@ describe('validation plugin - semantic - swagger', () => {
 
   it('should return an error when an swagger field is not a string', () => {
     const spec = {
-      swagger: 123
+      swagger: 123,
     };
 
     const res = validate({ jsSpec: spec });
@@ -33,7 +33,7 @@ describe('validation plugin - semantic - swagger', () => {
 
   it('should return an error when an swagger field does not have value `2.0`', () => {
     const spec = {
-      swagger: '2.0.0'
+      swagger: '2.0.0',
     };
 
     const res = validate({ jsSpec: spec });

--- a/test/spectral/tests/custom-rules/content-entry-contains-schema.test.js
+++ b/test/spectral/tests/custom-rules/content-entry-contains-schema.test.js
@@ -1,6 +1,6 @@
 const inCodeValidator = require('../../../../src/lib');
 
-describe('spectral - test validation that schema provided in content object', function() {
+describe('spectral - test validation that schema provided in content object', function () {
   it('should not error when the content object contains a schema', async () => {
     const spec = {
       openapi: '3.0.0',
@@ -8,12 +8,12 @@ describe('spectral - test validation that schema provided in content object', fu
         path1: {
           get: {
             responses: {
-              '200': {
-                $ref: '#/components/responses/GenericResponse'
-              }
-            }
-          }
-        }
+              200: {
+                $ref: '#/components/responses/GenericResponse',
+              },
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -22,18 +22,18 @@ describe('spectral - test validation that schema provided in content object', fu
               'application/json': {
                 // schema provided
                 schema: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
-      }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Content entries in request and response bodies must specify a schema'
     );
@@ -47,10 +47,10 @@ describe('spectral - test validation that schema provided in content object', fu
         path1: {
           post: {
             requestBody: {
-              $ref: '#/components/requestBodies/GenericRequestBody'
-            }
-          }
-        }
+              $ref: '#/components/requestBodies/GenericRequestBody',
+            },
+          },
+        },
       },
       components: {
         requestBodies: {
@@ -58,16 +58,16 @@ describe('spectral - test validation that schema provided in content object', fu
             content: {
               'application/json': {
                 // schema not provided
-              }
-            }
-          }
-        }
-      }
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Content entries in request and response bodies must specify a schema'
     );
@@ -81,12 +81,12 @@ describe('spectral - test validation that schema provided in content object', fu
         path1: {
           post: {
             responses: {
-              '200': {
-                $ref: '#/components/responses/GenericResponse'
-              }
-            }
-          }
-        }
+              200: {
+                $ref: '#/components/responses/GenericResponse',
+              },
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -94,16 +94,16 @@ describe('spectral - test validation that schema provided in content object', fu
             content: {
               'application/json': {
                 // schema not provided
-              }
-            }
-          }
-        }
-      }
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Content entries in request and response bodies must specify a schema'
     );
@@ -122,25 +122,25 @@ describe('spectral - test validation that schema provided in content object', fu
                 content: {
                   '*/*': {
                     // schema not provided
-                  }
-                }
+                  },
+                },
               },
               default: {
                 content: {
                   'text/html': {
                     // schema not provided
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Content entries in request and response bodies must specify a schema'
     );
@@ -158,17 +158,17 @@ describe('spectral - test validation that schema provided in content object', fu
               content: {
                 'application/json': {
                   // no schema provided
-                }
-              }
-            }
-          }
-        }
-      }
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Content entries in request and response bodies must specify a schema'
     );

--- a/test/spectral/tests/custom-rules/content-entry-provided.test.js
+++ b/test/spectral/tests/custom-rules/content-entry-provided.test.js
@@ -1,12 +1,12 @@
 const inCodeValidator = require('../../../../src/lib');
 
-describe('spectral - test content entry validation does not produce false positives', function() {
+describe('spectral - test content entry validation does not produce false positives', function () {
   it('should not error when content object provided or for 204 response without content', async () => {
     const spec = {
       openapi: '3.0.0',
       info: {
         version: '1.0.0',
-        title: 'ErrorAPI'
+        title: 'ErrorAPI',
       },
       servers: [{ url: 'http://api.errorapi.com/v1' }],
       paths: {
@@ -15,24 +15,24 @@ describe('spectral - test content entry validation does not produce false positi
             requestBody: {
               content: {
                 'application/json': {
-                  $ref: '#/components/schemas/GenericSchema'
-                }
-              }
+                  $ref: '#/components/schemas/GenericSchema',
+                },
+              },
             },
             responses: {
-              '200': {
+              200: {
                 content: {
                   'application/json': {
-                    $ref: '#/components/schemas/GenericSchema'
-                  }
-                }
+                    $ref: '#/components/schemas/GenericSchema',
+                  },
+                },
               },
-              '204': {
-                description: 'Success response with no response body'
-              }
-            }
-          }
-        }
+              204: {
+                description: 'Success response with no response body',
+              },
+            },
+          },
+        },
       },
       components: {
         schemas: {
@@ -40,17 +40,17 @@ describe('spectral - test content entry validation does not produce false positi
             type: 'object',
             properties: {
               prop: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      }
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Request bodies and non-204 responses should define a content object'
     );
@@ -58,13 +58,13 @@ describe('spectral - test content entry validation does not produce false positi
   });
 });
 
-describe('spectral - test content entry validation does not produce false positives', function() {
+describe('spectral - test content entry validation does not produce false positives', function () {
   it('should error when content object not provided', async () => {
     const spec = {
       openapi: '3.0.0',
       info: {
         version: '1.0.0',
-        title: 'ErrorAPI'
+        title: 'ErrorAPI',
       },
       servers: [{ url: 'http://api.errorapi.com/v1' }],
       paths: {
@@ -72,19 +72,19 @@ describe('spectral - test content entry validation does not produce false positi
           post: {
             requestBody: {},
             responses: {
-              '200': {},
-              '300': {},
-              '400': {},
-              '500': {}
-            }
-          }
-        }
-      }
+              200: {},
+              300: {},
+              400: {},
+              500: {},
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Request bodies and non-204 responses should define a content object'
     );

--- a/test/spectral/tests/custom-rules/error-response-schema.test.js
+++ b/test/spectral/tests/custom-rules/error-response-schema.test.js
@@ -1,6 +1,6 @@
 const inCodeValidator = require('../../../../src/lib');
 
-describe('spectral - test error-response validation does not produce false positives', function() {
+describe('spectral - test error-response validation does not produce false positives', function () {
   let res;
 
   beforeAll(async () => {
@@ -8,28 +8,28 @@ describe('spectral - test error-response validation does not produce false posit
       openapi: '3.0.0',
       info: {
         version: '1.0.0',
-        title: 'ErrorAPI'
+        title: 'ErrorAPI',
       },
       servers: [{ url: 'http://api.errorapi.com/v1' }],
       paths: {
         path1: {
           get: {
             responses: {
-              '204': {
-                description: 'Success response with no response body'
+              204: {
+                description: 'Success response with no response body',
               },
-              '400': {
-                $ref: '#/components/responses/ErrorResponse'
+              400: {
+                $ref: '#/components/responses/ErrorResponse',
               },
-              '404': {
-                $ref: '#/components/responses/AcceptableErrorResponse'
+              404: {
+                $ref: '#/components/responses/AcceptableErrorResponse',
               },
-              '500': {
-                $ref: '#/components/responses/ErrorResponse'
-              }
-            }
-          }
-        }
+              500: {
+                $ref: '#/components/responses/ErrorResponse',
+              },
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -37,33 +37,33 @@ describe('spectral - test error-response validation does not produce false posit
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/AcceptableErrorModel'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/AcceptableErrorModel',
+                },
+              },
+            },
           },
           ErrorResponse: {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/ErrorContainerModel'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/ErrorContainerModel',
+                },
+              },
+            },
+          },
         },
         schemas: {
           AcceptableErrorModel: {
             type: 'object',
             properties: {
               error: {
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/ErrorModel',
               },
               trace: {
                 type: 'string',
-                format: 'uuid'
-              }
-            }
+                format: 'uuid',
+              },
+            },
           },
           ErrorContainerModel: {
             type: 'object',
@@ -71,120 +71,124 @@ describe('spectral - test error-response validation does not produce false posit
               errors: {
                 type: 'array',
                 items: {
-                  $ref: '#/components/schemas/ErrorModel'
-                }
+                  $ref: '#/components/schemas/ErrorModel',
+                },
               },
               trace: {
                 type: 'string',
-                format: 'uuid'
+                format: 'uuid',
               },
               status_code: {
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           ErrorModel: {
             type: 'object',
             properties: {
               code: {
                 type: 'string',
-                enum: ['error_1', 'error_2']
+                enum: ['error_1', 'error_2'],
               },
               message: {
-                type: 'string'
+                type: 'string',
               },
               more_info: {
                 type: 'string',
-                description: 'url with link to more information about the error'
+                description:
+                  'url with link to more information about the error',
               },
               target: {
-                $ref: '#/components/schemas/ErrorTargetModel'
-              }
-            }
+                $ref: '#/components/schemas/ErrorTargetModel',
+              },
+            },
           },
           ErrorTargetModel: {
             type: {
               type: 'string',
-              enum: ['field', 'parameter', 'header']
+              enum: ['field', 'parameter', 'header'],
             },
             name: {
               type: 'string',
-              description: 'name of the problematic field that caused the error'
-            }
-          }
-        }
-      }
+              description:
+                'name of the problematic field that caused the error',
+            },
+          },
+        },
+      },
     };
 
     res = await inCodeValidator(spec, true);
   });
 
-  it('should not error when content object provided', function() {
+  it('should not error when content object provided', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Request bodies and non-204 responses should define a content object'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error-response that is an object', function() {
+  it('should not error for error-response that is an object', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === 'Error response should be an object with properties'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error-response that includes trace field', function() {
+  it('should not error for error-response that includes trace field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error response should have a uuid `trace` field'
+      (warn) =>
+        warn.message === 'Error response should have a uuid `trace` field'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error-response with a valid status_code field', function() {
+  it('should not error for error-response with a valid status_code field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === '`status_code` field must be an integer'
+      (warn) => warn.message === '`status_code` field must be an integer'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error-response `errors` field that is an array', function() {
+  it('should not error for error-response `errors` field that is an array', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === '`errors` field should be an array of error models'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error-response that with `errors` field that has object items', function() {
+  it('should not error for error-response that with `errors` field that has object items', function () {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error Model should be an object with properties'
+      (warn) =>
+        warn.message === 'Error Model should be an object with properties'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error model with valid code field', function() {
+  it('should not error for error model with valid code field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Error Model should contain `code` field, a snake-case, string, enum error code'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error model with valid message field', function() {
+  it('should not error for error model with valid message field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === 'Error Model should contain a string, `message`, field'
     );
     expect(expectedWarnings.length).toBe(0);
   });
 
-  it('should not error for error model with valid `more_info` field', function() {
+  it('should not error for error model with valid `more_info` field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Error Model should contain `more_info` field that contains a URL with more info about the error'
     );
@@ -192,7 +196,7 @@ describe('spectral - test error-response validation does not produce false posit
   });
 });
 
-describe('spectral - test error-response validation catches invalid error responses', function() {
+describe('spectral - test error-response validation catches invalid error responses', function () {
   let res;
 
   beforeAll(async () => {
@@ -200,46 +204,47 @@ describe('spectral - test error-response validation catches invalid error respon
       openapi: '3.0.0',
       info: {
         version: '1.0.0',
-        title: 'ErrorAPI'
+        title: 'ErrorAPI',
       },
       servers: [{ url: 'http://api.errorapi.com/v1' }],
       paths: {
         path1: {
           get: {
             responses: {
-              '204': {
-                description: 'Success response with no response body'
+              204: {
+                description: 'Success response with no response body',
               },
-              '400': {
-                $ref: '#/components/responses/NoObjectErrorModelResponse'
+              400: {
+                $ref: '#/components/responses/NoObjectErrorModelResponse',
               },
-              '404': {
-                $ref: '#/components/responses/NoContentErrorResponse'
+              404: {
+                $ref: '#/components/responses/NoContentErrorResponse',
               },
-              '412': {
+              412: {
                 $ref:
-                  '#/components/responses/ErrorContainerModelItemsNotObjectsResponse'
+                  '#/components/responses/ErrorContainerModelItemsNotObjectsResponse',
               },
-              '500': {
-                $ref: '#/components/responses/MissingPropertiesErrorResponse'
+              500: {
+                $ref: '#/components/responses/MissingPropertiesErrorResponse',
               },
-              '501': {
-                $ref: '#/components/responses/IncorrectPropertiesErrorResponse'
+              501: {
+                $ref: '#/components/responses/IncorrectPropertiesErrorResponse',
               },
-              '502': {
+              502: {
                 $ref:
-                  '#/components/responses/ErrorContainerModelIncorrectItemsPropertiesResponse'
+                  '#/components/responses/ErrorContainerModelIncorrectItemsPropertiesResponse',
               },
-              '503': {
+              503: {
                 $ref:
-                  '#/components/responses/SingleErrorModelIncorrectPropertiesResponse'
+                  '#/components/responses/SingleErrorModelIncorrectPropertiesResponse',
               },
-              '504': {
-                $ref: '#/components/responses/SingleErrorModelNotObjectResponse'
-              }
-            }
-          }
-        }
+              504: {
+                $ref:
+                  '#/components/responses/SingleErrorModelNotObjectResponse',
+              },
+            },
+          },
+        },
       },
       components: {
         responses: {
@@ -247,81 +252,81 @@ describe('spectral - test error-response validation catches invalid error respon
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/BadErrorModel'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/BadErrorModel',
+                },
+              },
+            },
           },
           NoContentErrorResponse: {
             schema: {
-              $ref: '#/components/schemas/BadErrorModel'
-            }
+              $ref: '#/components/schemas/BadErrorModel',
+            },
           },
           MissingPropertiesErrorResponse: {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/MissingPropertiesErrorModel'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/MissingPropertiesErrorModel',
+                },
+              },
+            },
           },
           IncorrectPropertiesErrorResponse: {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/IncorrectPropertiesModel'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/IncorrectPropertiesModel',
+                },
+              },
+            },
           },
           ErrorContainerModelItemsNotObjectsResponse: {
             content: {
               'application/json': {
                 schema: {
                   $ref:
-                    '#/components/schemas/ErrorContainerModelItemsNotObjects'
-                }
-              }
-            }
+                    '#/components/schemas/ErrorContainerModelItemsNotObjects',
+                },
+              },
+            },
           },
           ErrorContainerModelIncorrectItemsPropertiesResponse: {
             content: {
               'application/json': {
                 schema: {
                   $ref:
-                    '#/components/schemas/ErrorContainerModelIncorrectItemsProperties'
-                }
-              }
-            }
+                    '#/components/schemas/ErrorContainerModelIncorrectItemsProperties',
+                },
+              },
+            },
           },
           SingleErrorModelIncorrectPropertiesResponse: {
             content: {
               'application/json': {
                 schema: {
                   $ref:
-                    '#/components/schemas/SingleErrorModelIncorrectProperties'
-                }
-              }
-            }
+                    '#/components/schemas/SingleErrorModelIncorrectProperties',
+                },
+              },
+            },
           },
           SingleErrorModelNotObjectResponse: {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/SingleErrorModelNotObject'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/SingleErrorModelNotObject',
+                },
+              },
+            },
+          },
         },
         schemas: {
           BadErrorModel: {
-            type: 'string'
+            type: 'string',
           },
           MissingPropertiesErrorModel: {
             type: 'object',
-            properties: {}
+            properties: {},
           },
           IncorrectPropertiesModel: {
             type: 'object',
@@ -329,28 +334,28 @@ describe('spectral - test error-response validation catches invalid error respon
               errors: {},
               trace: {
                 // should be string, uuid
-                type: 'integer'
+                type: 'integer',
               },
               status_code: {
-                type: 'string'
-              }
-            }
+                type: 'string',
+              },
+            },
           },
           ErrorContainerModelItemsNotObjects: {
             type: 'object',
             properties: {
               errors: {
                 type: 'array',
-                items: {}
+                items: {},
               },
               trace: {
                 type: 'string',
-                format: 'uuid'
+                format: 'uuid',
               },
               status_code: {
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           ErrorContainerModelIncorrectItemsProperties: {
             type: 'object',
@@ -358,136 +363,138 @@ describe('spectral - test error-response validation catches invalid error respon
               errors: {
                 type: 'array',
                 items: {
-                  $ref: '#/components/schemas/IncorrectPropertiesSchema'
-                }
+                  $ref: '#/components/schemas/IncorrectPropertiesSchema',
+                },
               },
               trace: {
                 type: 'string',
-                format: 'uuid'
+                format: 'uuid',
               },
               status_code: {
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           SingleErrorModelNotObject: {
             type: 'object',
             properties: {
               error: {
-                type: 'string'
+                type: 'string',
               },
               trace: {
                 type: 'string',
-                format: 'uuid'
+                format: 'uuid',
               },
               status_code: {
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           SingleErrorModelIncorrectProperties: {
             type: 'object',
             properties: {
               error: {
-                $ref: '#/components/schemas/IncorrectPropertiesSchema'
+                $ref: '#/components/schemas/IncorrectPropertiesSchema',
               },
               trace: {
                 type: 'string',
-                format: 'uuid'
+                format: 'uuid',
               },
               status_code: {
-                type: 'integer'
-              }
-            }
+                type: 'integer',
+              },
+            },
           },
           IncorrectPropertiesSchema: {
             type: 'object',
             properties: {
               code: {
                 // should be string
-                type: 'integer'
+                type: 'integer',
               },
               message: {
-                type: 'integer'
+                type: 'integer',
               },
               more_info: {
-                type: 'integer'
-              }
-            }
-          }
-        }
-      }
+                type: 'integer',
+              },
+            },
+          },
+        },
+      },
     };
 
     res = await inCodeValidator(spec, true);
   });
 
-  it('should error for missing content for failure response with no content', function() {
+  it('should error for missing content for failure response with no content', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Request bodies and non-204 responses should define a content object'
     );
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response that is not an object', function() {
+  it('should error for error-response that is not an object', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === 'Error response should be an object with properties'
     );
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response that does not include trace field', function() {
+  it('should error for error-response that does not include trace field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error response should have a uuid `trace` field'
+      (warn) =>
+        warn.message === 'Error response should have a uuid `trace` field'
     );
     expect(expectedWarnings.length).toBe(2);
   });
 
-  it('should error for error-response that with an invalid status_code field', function() {
+  it('should error for error-response that with an invalid status_code field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === '`status_code` field must be an integer'
+      (warn) => warn.message === '`status_code` field must be an integer'
     );
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response `errors` field that is not an array', function() {
+  it('should error for error-response `errors` field that is not an array', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === '`errors` field should be an array of error models'
     );
     expect(expectedWarnings.length).toBe(1);
   });
 
-  it('should error for error-response that with `errors` field that does not have object items', function() {
+  it('should error for error-response that with `errors` field that does not have object items', function () {
     const expectedWarnings = res.warnings.filter(
-      warn => warn.message === 'Error Model should be an object with properties'
+      (warn) =>
+        warn.message === 'Error Model should be an object with properties'
     );
     expect(expectedWarnings.length).toBe(2);
   });
 
-  it('should error for error model with missing or invalid code field', function() {
+  it('should error for error model with missing or invalid code field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Error Model should contain `code` field, a snake-case, string error code'
     );
     expect(expectedWarnings.length).toBe(3);
   });
 
-  it('should error for error model with missing or invalid message field', function() {
+  it('should error for error model with missing or invalid message field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === 'Error Model should contain a string, `message`, field'
     );
     expect(expectedWarnings.length).toBe(3);
   });
 
-  it('should error for error model with missing or invalid `more_info` field', function() {
+  it('should error for error model with missing or invalid `more_info` field', function () {
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message ===
         'Error Model should contain `more_info` field that contains a URL with more info about the error'
     );

--- a/test/spectral/tests/custom-rules/major-version-in-path.test.js
+++ b/test/spectral/tests/custom-rules/major-version-in-path.test.js
@@ -3,13 +3,13 @@ const inCodeValidator = require('../../../../src/lib');
 const { getCapturedText } = require('../../../test-utils');
 const re = /^Validator: spectral/;
 
-describe('spectral - test major-version-in-path rule', function() {
+describe('spectral - test major-version-in-path rule', function () {
   it('test major-version-in-path using mockFiles/oas3/multiple-major-versions.yml', async () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
     program.args = [
-      './test/spectral/mockFiles/oas3/multiple-major-versions.yml'
+      './test/spectral/mockFiles/oas3/multiple-major-versions.yml',
     ];
     program.default_mode = true;
     program.print_validator_modules = true;
@@ -23,7 +23,7 @@ describe('spectral - test major-version-in-path rule', function() {
 
     expect(validatorsText.length).toBeGreaterThan(0);
 
-    validatorsText.forEach(text => {
+    validatorsText.forEach((text) => {
       const match = re.test(text);
       if (!match) {
         foundOtherValidator = true;
@@ -46,15 +46,15 @@ describe('spectral - test major-version-in-path rule', function() {
       openapi: '3.0.0',
       info: {
         version: '1.0.0',
-        title: 'Multiple versions in server URLs'
+        title: 'Multiple versions in server URLs',
       },
       servers: [
         {
-          url: 'http://petstore.swagger.io/v1'
+          url: 'http://petstore.swagger.io/v1',
         },
         {
-          url: 'http://petstore.swagger.io/v2'
-        }
+          url: 'http://petstore.swagger.io/v2',
+        },
       ],
       paths: {
         '/pets': {
@@ -62,13 +62,13 @@ describe('spectral - test major-version-in-path rule', function() {
             summary: 'Get a list of pets',
             operationId: 'list_pets',
             responses: {
-              '200': {
-                description: 'Success'
-              }
-            }
-          }
-        }
-      }
+              200: {
+                description: 'Success',
+              },
+            },
+          },
+        },
+      },
     };
     const validationResults = await inCodeValidator(apidef, true);
 
@@ -76,7 +76,7 @@ describe('spectral - test major-version-in-path rule', function() {
     expect(validationResults.errors).toBeUndefined();
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
-    const warnings = validationResults.warnings.map(warn => warn.message);
+    const warnings = validationResults.warnings.map((warn) => warn.message);
     expect(warnings.length).toBeGreaterThan(0);
 
     expect(warnings).toContain(

--- a/test/spectral/tests/custom-rules/response-example-provided.test.js
+++ b/test/spectral/tests/custom-rules/response-example-provided.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 const inCodeValidator = require('../../../../src/lib');
 
-describe('spectral - test validation that schema provided in content object', function() {
+describe('spectral - test validation that schema provided in content object', function () {
   it('should not error when a response example provided in the schema or at the response level', async () => {
     const spec = {
       openapi: '3.0.0',
@@ -11,52 +11,52 @@ describe('spectral - test validation that schema provided in content object', fu
         path1: {
           get: {
             responses: {
-              '200': {
+              200: {
                 content: {
                   'application/json': {
                     schema: {
                       type: 'string',
-                      example: 'example string'
-                    }
-                  }
-                }
-              },
-              '400': {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'string'
+                      example: 'example string',
                     },
-                    example: 'example string'
-                  }
-                }
+                  },
+                },
               },
-              '404': {
+              400: {
                 content: {
                   'application/json': {
                     schema: {
-                      type: 'string'
+                      type: 'string',
+                    },
+                    example: 'example string',
+                  },
+                },
+              },
+              404: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
                     },
                     examples: {
                       example1: {
-                        value: 'example string 1'
+                        value: 'example string 1',
                       },
                       example2: {
-                        value: 'example string 2'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                        value: 'example string 2',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === 'Response bodies should include an example response'
     );
     expect(expectedWarnings.length).toBe(0);
@@ -69,45 +69,45 @@ describe('spectral - test validation that schema provided in content object', fu
         path1: {
           get: {
             responses: {
-              '200': {
+              200: {
                 content: {
                   'application/json': {
                     // schema provided
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
+                      type: 'string',
+                    },
+                  },
+                },
               },
-              '300': {
+              300: {
                 content: {
                   'application/json': {
                     // schema provided
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
+                      type: 'string',
+                    },
+                  },
+                },
               },
               default: {
                 content: {
                   'application/json': {
                     // schema provided
                     schema: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const res = await inCodeValidator(spec, true);
     const expectedWarnings = res.warnings.filter(
-      warn =>
+      (warn) =>
         warn.message === 'Response bodies should include an example response'
     );
     expect(expectedWarnings.length).toBe(1);

--- a/test/spectral/tests/disabled-rules.test.js
+++ b/test/spectral/tests/disabled-rules.test.js
@@ -4,7 +4,7 @@ const { getCapturedText } = require('../../test-utils');
 const swaggerInMemory = require('../mockFiles/swagger/disabled-rules-in-memory');
 const oas3InMemory = require('../mockFiles/oas3/disabled-rules-in-memory');
 
-describe('spectral - test disabled rules - Swagger 2', function() {
+describe('spectral - test disabled rules - Swagger 2', function () {
   let allOutput;
 
   beforeAll(async () => {
@@ -25,7 +25,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test contact-properties rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test contact-properties rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -33,7 +33,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test info-contact rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test info-contact rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -41,7 +41,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test info-description rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test info-description rule using mockFiles/swagger/disabled-rules.yml', function () {
     // set up mock user input
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
@@ -50,7 +50,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test info-license rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test info-license rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -58,13 +58,13 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test license-url rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test license-url rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain('License object should include `url`.');
   });
 
-  it('test no-$ref-siblings rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test no-$ref-siblings rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -72,7 +72,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test openapi-tags-alphabetical rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test openapi-tags-alphabetical rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -80,7 +80,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test path-params rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test path-params rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -88,13 +88,13 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test operation-operationId rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test operation-operationId rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain('Operation should have an `operationId`');
   });
 
-  it('test operation-2xx-response rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test operation-2xx-response rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -102,7 +102,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test operation-parameters validator rule mockFiles/swagger/disabled-rules.yml', function() {
+  it('test operation-parameters validator rule mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -110,7 +110,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test operation-operationId-valid-in-url validator rule mockFiles/swagger/disabled-rules.yml', function() {
+  it('test operation-operationId-valid-in-url validator rule mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -118,27 +118,27 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test path-declarations-must-exist rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test path-declarations-must-exist rule using mockFiles/swagger/disabled-rules.yml', function () {
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
       'Path parameter declarations cannot be empty, ex.`/given/{}` is invalid'
     );
   });
 
-  it('test operation-default-response rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test operation-default-response rule using mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain('Operations must have a default response');
   });
 
-  it('test path-not-include-query rule using mockFiles/swagger/disabled-rules.yml', function() {
+  it('test path-not-include-query rule using mockFiles/swagger/disabled-rules.yml', function () {
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
       'given keys should not include a query string'
     );
   });
 
-  it('test oas2-unused-definition validator rule mockFiles/swagger/disabled-rules.yml', function() {
+  it('test oas2-unused-definition validator rule mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -146,7 +146,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test oas2-operation-formData-consume-check validator rule mockFiles/swagger/disabled-rules.yml', function() {
+  it('test oas2-operation-formData-consume-check validator rule mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -154,7 +154,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test oas2-operation-security-defined validator rule mockFiles/swagger/disabled-rules.yml', function() {
+  it('test oas2-operation-security-defined validator rule mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -162,7 +162,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
     );
   });
 
-  it('test oas2-parameter-description validator rule mockFiles/swagger/disabled-rules.yml', function() {
+  it('test oas2-parameter-description validator rule mockFiles/swagger/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -171,7 +171,7 @@ describe('spectral - test disabled rules - Swagger 2', function() {
   });
 });
 
-describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
+describe('spectral - test disabled rules - Swagger 2 In Memory', function () {
   let errors;
   let warnings;
 
@@ -188,13 +188,13 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     expect(validationResults.errors.length).toBeGreaterThan(0);
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
-    errors = validationResults.errors.map(error => error.message);
-    warnings = validationResults.warnings.map(warn => warn.message);
+    errors = validationResults.errors.map((error) => error.message);
+    warnings = validationResults.warnings.map((warn) => warn.message);
     expect(errors.length).toBeGreaterThan(0);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
-  it('test contact-properties rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test contact-properties rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Contact object should have `name`, `url` and `email`.'
     );
@@ -203,14 +203,14 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test info-contact rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test info-contact rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('Info object should contain `contact` object');
     expect(warnings).not.toContain(
       'Info object should contain `contact` object.'
     );
   });
 
-  it('test info-description rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test info-description rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'OpenAPI object info `description` must be present and non-empty string.'
     );
@@ -219,7 +219,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test info-license rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test info-license rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'OpenAPI object `info` should contain a `license` object.'
     );
@@ -228,12 +228,12 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test license-url rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test license-url rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('License object should include `url`.');
     expect(warnings).not.toContain('License object should include `url`.');
   });
 
-  it('test no-$ref-siblings rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test no-$ref-siblings rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       '$ref cannot be placed next to any other properties'
     );
@@ -242,7 +242,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test openapi-tags-alphabetical rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test openapi-tags-alphabetical rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'OpenAPI object should have alphabetical `tags`.'
     );
@@ -251,7 +251,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test path-params rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test path-params rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Path parameter `pet_id` is defined multiple times. Path parameters must be unique.'
     );
@@ -260,12 +260,12 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test operation-operationId rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test operation-operationId rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('Operation should have an `operationId`.');
     expect(warnings).not.toContain('Operation should have an `operationId`.');
   });
 
-  it('test operation-2xx-response rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test operation-2xx-response rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Operation must have at least one `2xx` response.'
     );
@@ -274,7 +274,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test operation-operationId-valid-in-url validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test operation-operationId-valid-in-url validator rule mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'operationId may only use characters that are valid when used in a URL.'
     );
@@ -283,7 +283,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test path-declarations-must-exist rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test path-declarations-must-exist rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Path parameter declarations cannot be empty, ex.`/given/{}` is invalid.'
     );
@@ -292,12 +292,12 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test operation-default-response rule using mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test operation-default-response rule using mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('Operations must have a default response.');
     expect(warnings).not.toContain('Operations must have a default response.');
   });
 
-  it('test oas2-unused-definition validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test oas2-unused-definition validator rule mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Potentially unused definition has been detected.'
     );
@@ -306,7 +306,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test oas2-operation-security-defined validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test oas2-operation-security-defined validator rule mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Operation `security` values must match a scheme defined in the `securityDefinitions` object.'
     );
@@ -315,7 +315,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
     );
   });
 
-  it('test oas2-parameter-description validator rule mockFiles/swagger/disabled-rules-in-memory', function() {
+  it('test oas2-parameter-description validator rule mockFiles/swagger/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Parameter objects should have a `description`.'
     );
@@ -325,7 +325,7 @@ describe('spectral - test disabled rules - Swagger 2 In Memory', function() {
   });
 });
 
-describe(' spectral - test disabled rules - OAS3', function() {
+describe(' spectral - test disabled rules - OAS3', function () {
   let allOutput;
 
   beforeAll(async () => {
@@ -346,7 +346,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test contact-properties rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test contact-properties rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -354,7 +354,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test info-contact rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test info-contact rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -362,7 +362,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test info-description rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test info-description rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -370,7 +370,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test info-license rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test info-license rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -378,13 +378,13 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test license-url rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test license-url rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain('License object should include `url`.');
   });
 
-  it('test no-$ref-siblings rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test no-$ref-siblings rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -392,7 +392,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test openapi-tags-alphabetical rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test openapi-tags-alphabetical rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -400,13 +400,13 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test operation-default-response rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test operation-default-response rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain('Operations must have a default response');
   });
 
-  it('test path-params rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test path-params rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -414,13 +414,13 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test operation-operationId rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test operation-operationId rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain('Operation should have an `operationId`');
   });
 
-  it('test operation-2xx-response rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test operation-2xx-response rule using mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -428,7 +428,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test operation-parameters validator rule mockFiles/oas3/disabled-rules.yml', function() {
+  it('test operation-parameters validator rule mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -436,7 +436,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test operation-operationId-valid-in-url validator rule mockFiles/oas3/disabled-rules.yml', function() {
+  it('test operation-operationId-valid-in-url validator rule mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -444,21 +444,21 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test path-declarations-must-exist rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test path-declarations-must-exist rule using mockFiles/oas3/disabled-rules.yml', function () {
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
       'Path parameter declarations cannot be empty, ex.`/given/{}` is invalid'
     );
   });
 
-  it('test path-not-include-query rule using mockFiles/oas3/disabled-rules.yml', function() {
+  it('test path-not-include-query rule using mockFiles/oas3/disabled-rules.yml', function () {
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
       'given keys should not include a query string'
     );
   });
 
-  it('test oas3-unused-components-schema validator rule mockFiles/oas3/disabled-rules.yml', function() {
+  it('test oas3-unused-components-schema validator rule mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -466,7 +466,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test oas3-parameter-description validator rule mockFiles/oas3/disabled-rules.yml', function() {
+  it('test oas3-parameter-description validator rule mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -474,7 +474,7 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test oas3-operation-security-defined validator rule mockFiles/oas3/disabled-rules.yml', function() {
+  it('test oas3-operation-security-defined validator rule mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain(
@@ -482,14 +482,14 @@ describe(' spectral - test disabled rules - OAS3', function() {
     );
   });
 
-  it('test oas3-schema validator rule mockFiles/oas3/disabled-rules.yml', function() {
+  it('test oas3-schema validator rule mockFiles/oas3/disabled-rules.yml', function () {
     // rule is disabled, so spectral shouldn't produce a warning
     expect(allOutput).not.toContain('Validator: spectral');
     expect(allOutput).not.toContain('`type` property type should be string.');
   });
 });
 
-describe('spectral - test disabled rules - OAS3 In Memory', function() {
+describe('spectral - test disabled rules - OAS3 In Memory', function () {
   let errors;
   let warnings;
 
@@ -503,13 +503,13 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     expect(validationResults.errors.length).toBeGreaterThan(0);
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
-    errors = validationResults.errors.map(error => error.message);
-    warnings = validationResults.warnings.map(warn => warn.message);
+    errors = validationResults.errors.map((error) => error.message);
+    warnings = validationResults.warnings.map((warn) => warn.message);
     expect(errors.length).toBeGreaterThan(0);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
-  it('test contact-properties rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test contact-properties rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Contact object should have `name`, `url` and `email`.'
     );
@@ -518,7 +518,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test info-contact rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test info-contact rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Info object should contain `contact` object.'
     );
@@ -527,7 +527,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test info-description rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test info-description rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'OpenAPI object info `description` must be present and non-empty string.'
     );
@@ -536,7 +536,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test info-license rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test info-license rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'OpenAPI object `info` should contain a `license` object.'
     );
@@ -545,12 +545,12 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test license-url rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test license-url rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('License object should include `url`.');
     expect(warnings).not.toContain('License object should include `url`.');
   });
 
-  it('test no-$ref-siblings rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test no-$ref-siblings rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       '$ref cannot be placed next to any other properties'
     );
@@ -559,7 +559,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test openapi-tags-alphabetical rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test openapi-tags-alphabetical rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'OpenAPI object should have alphabetical `tags`.'
     );
@@ -568,12 +568,12 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test operation-default-response rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test operation-default-response rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('Operations must have a default response.');
     expect(warnings).not.toContain('Operations must have a default response.');
   });
 
-  it('test path-params rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test path-params rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Path parameter `pet_id` is defined multiple times. Path parameters must be unique.'
     );
@@ -582,12 +582,12 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test operation-operationId rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test operation-operationId rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('Operation should have an `operationId`.');
     expect(warnings).not.toContain('Operation should have an `operationId`.');
   });
 
-  it('test operation-2xx-response rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test operation-2xx-response rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Operation must have at least one `2xx` response.'
     );
@@ -596,7 +596,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test operation-operationId-valid-in-url validator rule mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test operation-operationId-valid-in-url validator rule mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'operationId may only use characters that are valid when used in a URL.'
     );
@@ -605,7 +605,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test path-declarations-must-exist rule using mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test path-declarations-must-exist rule using mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Path parameter declarations cannot be empty, ex.`/given/{}` is invalid.'
     );
@@ -614,7 +614,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test oas3-unused-components-schema validator rule mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test oas3-unused-components-schema validator rule mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Potentially unused components schema has been detected'
     );
@@ -623,7 +623,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test oas3-parameter-description validator rule mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test oas3-parameter-description validator rule mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Parameter objects should have a `description`'
     );
@@ -632,7 +632,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test oas3-operation-security-defined validator rule mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test oas3-operation-security-defined validator rule mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Operation `security` values must match a scheme defined in the `components.securitySchemes` object`'
     );
@@ -641,7 +641,7 @@ describe('spectral - test disabled rules - OAS3 In Memory', function() {
     );
   });
 
-  it('test oas3-schema validator rule mockFiles/oas3/disabled-rules-in-memory', function() {
+  it('test oas3-schema validator rule mockFiles/oas3/disabled-rules-in-memory', function () {
     expect(errors).not.toContain('`type` property type should be string');
     expect(warnings).not.toContain('`type` property type should be string');
   });

--- a/test/spectral/tests/enabled-rules.test.js
+++ b/test/spectral/tests/enabled-rules.test.js
@@ -5,7 +5,7 @@ const swaggerInMemory = require('../mockFiles/swagger/enabled-rules-in-memory');
 const oas3InMemory = require('../mockFiles/oas3/enabled-rules-in-memory');
 const re = /^Validator: spectral/;
 
-describe('spectral - test enabled rules - Swagger 2', function() {
+describe('spectral - test enabled rules - Swagger 2', function () {
   let allOutput;
 
   beforeAll(async () => {
@@ -24,7 +24,7 @@ describe('spectral - test enabled rules - Swagger 2', function() {
     let foundOtherValidator = false;
     expect(validatorsText.length).toBeGreaterThan(0);
 
-    validatorsText.forEach(text => {
+    validatorsText.forEach((text) => {
       const match = re.test(text);
       if (!match) {
         foundOtherValidator = true;
@@ -37,88 +37,88 @@ describe('spectral - test enabled rules - Swagger 2', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test no-eval-in-markdown rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test no-eval-in-markdown rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Markdown descriptions should not contain `eval(`'
     );
   });
 
-  it('test no-script-tags-in-markdown rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test no-script-tags-in-markdown rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Markdown descriptions should not contain `<script>` tags'
     );
   });
 
-  it('test openapi-tags rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test openapi-tags rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'OpenAPI object should have non-empty `tags` array'
     );
   });
 
-  it('test operation-description rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test operation-description rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Operation `description` must be present and non-empty string'
     );
   });
 
-  it('test operation-tags rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test operation-tags rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain('Operation should have non-empty `tags` array');
   });
 
-  it('test operation-tag-defined rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test operation-tag-defined rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Operation tags should be defined in global tags'
     );
   });
 
-  it('test path-keys-no-trailing-slash rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test path-keys-no-trailing-slash rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain('paths should not end with a slash');
   });
 
-  it('test typed-enum rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test typed-enum rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Enum value `a_string` does not respect the specified type `integer`'
     );
   });
 
-  it('test oas2-api-host rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test oas2-api-host rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'OpenAPI `host` must be present and non-empty string'
     );
   });
 
-  it('test oas2-api-schemes rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test oas2-api-schemes rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'OpenAPI host `schemes` must be present and non-empty array'
     );
   });
 
-  it('test oas2-valid-example rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test oas2-valid-example rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       '`number_of_coins` property type should be integer'
     );
   });
 
-  it('test oas2-anyOf rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test oas2-anyOf rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'anyOf is not available in OpenAPI v2, it was added in OpenAPI v3'
     );
   });
 
-  it('test oas2-oneOf rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test oas2-oneOf rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'oneOf is not available in OpenAPI v2, it was added in OpenAPI v3'
     );
   });
 
-  it('test major-version-in-path rule using mockFiles/swagger/enabled-rules.yml', function() {
+  it('test major-version-in-path rule using mockFiles/swagger/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Major version segment not present in either basePath or paths'
     );
   });
 });
 
-describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
+describe('spectral - test enabled rules - Swagger 2 In Memory', function () {
   let warnings;
 
   beforeAll(async () => {
@@ -132,98 +132,98 @@ describe('spectral - test enabled rules - Swagger 2 In Memory', function() {
     expect(validationResults.errors).toBeUndefined();
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
-    warnings = validationResults.warnings.map(warn => warn.message);
+    warnings = validationResults.warnings.map((warn) => warn.message);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
-  it('test no-eval-in-markdown rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test no-eval-in-markdown rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Markdown descriptions should not contain `eval(`.'
     );
   });
 
-  it('test no-script-tags-in-markdown rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test no-script-tags-in-markdown rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Markdown descriptions should not contain `<script>` tags.'
     );
   });
 
-  it('test openapi-tags rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test openapi-tags rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'OpenAPI object should have non-empty `tags` array.'
     );
   });
 
-  it('test operation-description rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test operation-description rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Operation `description` must be present and non-empty string.'
     );
   });
 
-  it('test operation-parameters rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test operation-parameters rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'A parameter in this operation already exposes the same combination of `name` and `in` values.'
     );
   });
 
-  it('test operation-tags rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test operation-tags rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain('Operation should have non-empty `tags` array.');
   });
 
-  it('test operation-tag-defined rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test operation-tag-defined rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Operation tags should be defined in global tags.'
     );
   });
 
-  it('test path-keys-no-trailing-slash rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test path-keys-no-trailing-slash rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain('paths should not end with a slash.');
   });
 
-  it('test typed-enum rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test typed-enum rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Enum value `a_string` does not respect the specified type `integer`.'
     );
   });
 
-  it('test oas2-api-host rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test oas2-api-host rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'OpenAPI `host` must be present and non-empty string.'
     );
   });
 
-  it('test oas2-api-schemes rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test oas2-api-schemes rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'OpenAPI host `schemes` must be present and non-empty array.'
     );
   });
 
-  it('test oas2-valid-definition-example rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test oas2-valid-definition-example rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       '`number_of_coins` property type should be integer'
     );
   });
 
-  it('test oas2-anyOf rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test oas2-anyOf rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'anyOf is not available in OpenAPI v2, it was added in OpenAPI v3'
     );
   });
 
-  it('test oas2-oneOf rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test oas2-oneOf rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'oneOf is not available in OpenAPI v2, it was added in OpenAPI v3'
     );
   });
 
-  it('test oas2-operation-formData-consume-check rule using mockFiles/swagger/enabled-rules-in-memory', function() {
+  it('test oas2-operation-formData-consume-check rule using mockFiles/swagger/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Operations with an `in: formData` parameter must include `application/x-www-form-urlencoded` or `multipart/form-data` in their `consumes` property.'
     );
   });
 });
 
-describe('spectral - test enabled rules - OAS3', function() {
+describe('spectral - test enabled rules - OAS3', function () {
   let allOutput;
 
   beforeAll(async () => {
@@ -243,7 +243,7 @@ describe('spectral - test enabled rules - OAS3', function() {
 
     expect(validatorsText.length).toBeGreaterThan(0);
 
-    validatorsText.forEach(text => {
+    validatorsText.forEach((text) => {
       const match = re.test(text);
       if (!match) {
         foundOtherValidator = true;
@@ -256,82 +256,82 @@ describe('spectral - test enabled rules - OAS3', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Markdown descriptions should not contain `eval(`'
     );
   });
 
-  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Markdown descriptions should not contain `<script>` tags'
     );
   });
 
-  it('test openapi-tags rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test openapi-tags rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'OpenAPI object should have non-empty `tags` array'
     );
   });
 
-  it('test operation-description rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test operation-description rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Operation `description` must be present and non-empty string'
     );
   });
 
-  it('test operation-tags rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test operation-tags rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain('Operation should have non-empty `tags` array');
   });
 
-  it('test operation-tag-defined rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test operation-tag-defined rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Operation tags should be defined in global tags'
     );
   });
 
-  it('test path-keys-no-trailing-slash rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test path-keys-no-trailing-slash rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain('paths should not end with a slash');
   });
 
-  it('test typed-enum rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test typed-enum rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Enum value `a_string` does not respect the specified type `integer`'
     );
   });
 
-  it('test oas3-api-servers rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test oas3-api-servers rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'OpenAPI `servers` must be present and non-empty array'
     );
   });
 
-  it('test oas3-examples-value-or-externalValue rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test oas3-examples-value-or-externalValue rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Examples should have either a `value` or `externalValue` field'
     );
   });
 
-  it('test oas3-valid-schema-example rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test oas3-valid-schema-example rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       '`number_of_coins` property type should be integer'
     );
   });
 
-  it('test oas3-valid-oas-content-example rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test oas3-valid-oas-content-example rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       '`number_of_connectors` property should be equal to one of the allowed values: 1, 2, `a_string`, 8'
     );
   });
 
-  it('test major-version-in-path rule using mockFiles/oas3/enabled-rules.yml', function() {
+  it('test major-version-in-path rule using mockFiles/oas3/enabled-rules.yml', function () {
     expect(allOutput).toContain(
       'Major version segment not present in either server URLs or paths'
     );
   });
 });
 
-describe('spectral - test enabled rules - OAS3 In Memory', function() {
+describe('spectral - test enabled rules - OAS3 In Memory', function () {
   let warnings;
 
   beforeAll(async () => {
@@ -343,73 +343,73 @@ describe('spectral - test enabled rules - OAS3 In Memory', function() {
     expect(validationResults.errors).toBeUndefined();
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
-    warnings = validationResults.warnings.map(warn => warn.message);
+    warnings = validationResults.warnings.map((warn) => warn.message);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
-  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Markdown descriptions should not contain `eval(`.'
     );
   });
 
-  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Markdown descriptions should not contain `<script>` tags.'
     );
   });
 
-  it('test openapi-tags rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test openapi-tags rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'OpenAPI object should have non-empty `tags` array.'
     );
   });
 
-  it('test operation-description rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test operation-description rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Operation `description` must be present and non-empty string.'
     );
   });
 
-  it('test operation-parameters rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test operation-parameters rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'A parameter in this operation already exposes the same combination of `name` and `in` values.'
     );
   });
 
-  it('test operation-tags rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test operation-tags rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain('Operation should have non-empty `tags` array.');
   });
 
-  it('test operation-tag-defined rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test operation-tag-defined rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Operation tags should be defined in global tags.'
     );
   });
 
-  it('test path-keys-no-trailing-slash rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test path-keys-no-trailing-slash rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain('paths should not end with a slash.');
   });
 
-  it('test typed-enum rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test typed-enum rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Enum value `a_string` does not respect the specified type `integer`.'
     );
   });
 
-  it('test oas3-api-servers rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test oas3-api-servers rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'OpenAPI `servers` must be present and non-empty array.'
     );
   });
 
-  it('test oas3-examples-value-or-externalValue rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test oas3-examples-value-or-externalValue rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       'Examples should have either a `value` or `externalValue` field.'
     );
   });
 
-  it('test oas3-valid-example rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test oas3-valid-example rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(warnings).toContain(
       '`number_of_coins` property type should be integer'
     );

--- a/test/spectral/tests/path-resolve.test.js
+++ b/test/spectral/tests/path-resolve.test.js
@@ -1,7 +1,7 @@
 const commandLineValidator = require('../../../src/cli-validator/runValidator');
 const { getCapturedText } = require('../../test-utils');
 
-describe('spectral - test file resolve - OAS3', function() {
+describe('spectral - test file resolve - OAS3', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -12,13 +12,13 @@ describe('spectral - test file resolve - OAS3', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test no file read error using mockFiles/oas3/file-resolver/subdir/main.yaml', async function() {
+  it('test no file read error using mockFiles/oas3/file-resolver/subdir/main.yaml', async function () {
     // set up mock user input
     const program = {};
     program.default_mode = true;
     program.print_validator_modules = true;
     program.args = [
-      './test/spectral/mockFiles/oas3/file-resolver/subdir/main.yaml'
+      './test/spectral/mockFiles/oas3/file-resolver/subdir/main.yaml',
     ];
 
     const exitCode = await commandLineValidator(program);
@@ -31,7 +31,7 @@ describe('spectral - test file resolve - OAS3', function() {
   });
 });
 
-describe('spectral - test file resolve - Swagger', function() {
+describe('spectral - test file resolve - Swagger', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -42,13 +42,13 @@ describe('spectral - test file resolve - Swagger', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test no file read error using mockFiles/swagger/file-resolver/subdir/main.yaml', async function() {
+  it('test no file read error using mockFiles/swagger/file-resolver/subdir/main.yaml', async function () {
     // set up mock user input
     const program = {};
     program.default_mode = true;
     program.print_validator_modules = true;
     program.args = [
-      './test/spectral/mockFiles/swagger/file-resolver/subdir/main.yaml'
+      './test/spectral/mockFiles/swagger/file-resolver/subdir/main.yaml',
     ];
 
     const exitCode = await commandLineValidator(program);
@@ -61,7 +61,7 @@ describe('spectral - test file resolve - Swagger', function() {
   });
 });
 
-describe('spectral - test url resolve - OAS3', function() {
+describe('spectral - test url resolve - OAS3', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -72,13 +72,13 @@ describe('spectral - test url resolve - OAS3', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test no file read error using mockFiles/oas3/url-reference-resolver/main.yaml', async function() {
+  it('test no file read error using mockFiles/oas3/url-reference-resolver/main.yaml', async function () {
     // set up mock user input
     const program = {};
     program.default_mode = true;
     program.print_validator_modules = true;
     program.args = [
-      './test/spectral/mockFiles/oas3/url-reference-resolver/main.yaml'
+      './test/spectral/mockFiles/oas3/url-reference-resolver/main.yaml',
     ];
 
     const exitCode = await commandLineValidator(program);
@@ -91,7 +91,7 @@ describe('spectral - test url resolve - OAS3', function() {
   });
 });
 
-describe('spectral - test url resolve - Swagger', function() {
+describe('spectral - test url resolve - Swagger', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -102,13 +102,13 @@ describe('spectral - test url resolve - Swagger', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test no file read error using mockFiles/swagger/url-reference-resolver/main.yaml', async function() {
+  it('test no file read error using mockFiles/swagger/url-reference-resolver/main.yaml', async function () {
     // set up mock user input
     const program = {};
     program.default_mode = true;
     program.print_validator_modules = true;
     program.args = [
-      './test/spectral/mockFiles/swagger/url-reference-resolver/main.yaml'
+      './test/spectral/mockFiles/swagger/url-reference-resolver/main.yaml',
     ];
 
     const exitCode = await commandLineValidator(program);

--- a/test/spectral/tests/spectral-config.test.js
+++ b/test/spectral/tests/spectral-config.test.js
@@ -1,8 +1,8 @@
 const commandLineValidator = require('../../../src/cli-validator/runValidator');
 const { getCapturedText } = require('../../test-utils');
 
-describe('Spectral - test custom configuration', function() {
-  it('test Spectral info and hint rules', async function() {
+describe('Spectral - test custom configuration', function () {
+  it('test Spectral info and hint rules', async function () {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
     // set up mock user input
@@ -44,7 +44,7 @@ describe('Spectral - test custom configuration', function() {
     );
   });
 
-  it('test Spectral custom config that extends ibm:oas', async function() {
+  it('test Spectral custom config that extends ibm:oas', async function () {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
@@ -68,7 +68,7 @@ describe('Spectral - test custom configuration', function() {
 
     // Verify warnings
     expect(jsonOutput['warnings'].length).toBe(35);
-    const warnings = jsonOutput['warnings'].map(w => w['message']);
+    const warnings = jsonOutput['warnings'].map((w) => w['message']);
     // This warning should be turned off
     expect(warnings).not.toContain(
       'OpenAPI object should have non-empty `tags` array.'
@@ -79,7 +79,7 @@ describe('Spectral - test custom configuration', function() {
     );
   });
 
-  it('test Spectral custom config that extends ibm:oas with custom rules', async function() {
+  it('test Spectral custom config that extends ibm:oas with custom rules', async function () {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     // set up mock user input
     const program = {};
@@ -100,7 +100,7 @@ describe('Spectral - test custom configuration', function() {
 
     // Verify warnings
     expect(jsonOutput['warnings'].length).toBe(40);
-    const warnings = jsonOutput['warnings'].map(w => w['message']);
+    const warnings = jsonOutput['warnings'].map((w) => w['message']);
     // This is the new warning -- there should be three occurrences
     const warning = 'All request bodies should have an example.';
     const occurrences = warnings.reduce(

--- a/test/spectral/tests/spectral-validator.test.js
+++ b/test/spectral/tests/spectral-validator.test.js
@@ -7,7 +7,7 @@ const config = require('../../../src/cli-validator/utils/processConfiguration');
 const defaultConfig = require('../../../src/.defaultsForValidator');
 const defaultObject = defaultConfig.defaults;
 
-describe('spectral - test spectral-validator.js', function() {
+describe('spectral - test spectral-validator.js', function () {
   let consoleSpy;
 
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe('spectral - test spectral-validator.js', function() {
     consoleSpy.mockRestore();
   });
 
-  it('test should parse mock spectral result as an error', function() {
+  it('test should parse mock spectral result as an error', function () {
     // Create a mock Spectral result object
     const mockResult = [
       {
@@ -27,8 +27,8 @@ describe('spectral - test spectral-validator.js', function() {
         path: ['paths', '/pet', 'put'],
         severity: 0,
         start: { line: 0, character: 0 },
-        end: { line: 134, character: 15 }
-      }
+        end: { line: 134, character: 15 },
+      },
     ];
     const debug = false;
     const parsedSpectralResults = spectralValidator.parseResults(
@@ -49,7 +49,7 @@ describe('spectral - test spectral-validator.js', function() {
     );
   });
 
-  it('test should parse mock spectral result as a warning', function() {
+  it('test should parse mock spectral result as a warning', function () {
     // Create a mock Spectral result object
     const mockResult = [
       {
@@ -58,8 +58,8 @@ describe('spectral - test spectral-validator.js', function() {
         path: ['paths', '/pet', 'put'],
         severity: 1,
         start: { line: 0, character: 0 },
-        end: { line: 134, character: 15 }
-      }
+        end: { line: 134, character: 15 },
+      },
     ];
     const debug = false;
     const parsedSpectralResults = spectralValidator.parseResults(
@@ -80,7 +80,7 @@ describe('spectral - test spectral-validator.js', function() {
     );
   });
 
-  it('test should output debug statement when failing to parse mock spectral result: incorrect severity', function() {
+  it('test should output debug statement when failing to parse mock spectral result: incorrect severity', function () {
     // Create a mock Spectral result object
     const mockResult = [
       {
@@ -89,8 +89,8 @@ describe('spectral - test spectral-validator.js', function() {
         path: ['paths', '/pet', 'put'],
         severity: 'error',
         start: { line: 0, character: 0 },
-        end: { line: 134, character: 15 }
-      }
+        end: { line: 134, character: 15 },
+      },
     ];
     const debug = true;
     const parsedSpectralResults = spectralValidator.parseResults(
@@ -107,7 +107,7 @@ describe('spectral - test spectral-validator.js', function() {
     );
   });
 
-  it('test promise should be rejected when attempting to setup spectral without a valid instance', async function() {
+  it('test promise should be rejected when attempting to setup spectral without a valid instance', async function () {
     let spectral;
     await expect(spectralValidator.setup(spectral)).rejects.toEqual(
       'Error (spectral-validator): An instance of spectral has not been initialized.'
@@ -115,7 +115,7 @@ describe('spectral - test spectral-validator.js', function() {
   });
 });
 
-describe('spectral - test config file changes with .spectral.yml', function() {
+describe('spectral - test config file changes with .spectral.yml', function () {
   let validationResults;
   let errors;
   let warnings;
@@ -144,14 +144,14 @@ describe('spectral - test config file changes with .spectral.yml', function() {
     expect(validationResults.errors.length).toBeGreaterThan(0);
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
-    errors = validationResults.errors.map(error => error.message);
-    warnings = validationResults.warnings.map(warn => warn.message);
+    errors = validationResults.errors.map((error) => error.message);
+    warnings = validationResults.warnings.map((warn) => warn.message);
     expect(errors.length).toBeGreaterThan(0);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
   // One test should be an error instead of a warning compared to the enable-rules.test.js
-  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(errors).toContain(
       'Markdown descriptions should not contain `eval(`.'
     );
@@ -161,7 +161,7 @@ describe('spectral - test config file changes with .spectral.yml', function() {
   });
 
   // Other tests should be their default severity levels
-  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Markdown descriptions should not contain `<script>` tags.'
     );
@@ -171,7 +171,7 @@ describe('spectral - test config file changes with .spectral.yml', function() {
   });
 });
 
-describe('spectral - test config file changes with .validaterc', function() {
+describe('spectral - test config file changes with .validaterc', function () {
   let validationResults;
   let errors;
   let warnings;
@@ -196,14 +196,14 @@ describe('spectral - test config file changes with .validaterc', function() {
     expect(validationResults.errors.length).toBeGreaterThan(0);
     expect(validationResults.warnings.length).toBeGreaterThan(0);
 
-    errors = validationResults.errors.map(error => error.message);
-    warnings = validationResults.warnings.map(warn => warn.message);
+    errors = validationResults.errors.map((error) => error.message);
+    warnings = validationResults.warnings.map((warn) => warn.message);
     expect(errors.length).toBeGreaterThan(0);
     expect(warnings.length).toBeGreaterThan(0);
   });
 
   // One test should be an error instead of a warning compared to the enable-rules.test.js
-  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test no-script-tags-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(errors).toContain(
       'Markdown descriptions should not contain `<script>` tags.'
     );
@@ -213,7 +213,7 @@ describe('spectral - test config file changes with .validaterc', function() {
   });
 
   // Other tests should be their default severity levels
-  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function() {
+  it('test no-eval-in-markdown rule using mockFiles/oas3/enabled-rules-in-memory', function () {
     expect(errors).not.toContain(
       'Markdown descriptions should not contain `eval(`.'
     );
@@ -223,7 +223,7 @@ describe('spectral - test config file changes with .validaterc', function() {
   });
 });
 
-describe('spectral - test config file changes with .validaterc, all rules off', function() {
+describe('spectral - test config file changes with .validaterc, all rules off', function () {
   let validationResults;
 
   beforeAll(async () => {
@@ -256,7 +256,7 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
       'content-entry-contains-schema': 'off',
       'major-version-in-path': 'off',
       'response-example-provided': 'off',
-      'response-error-response-schema': 'off'
+      'response-error-response-schema': 'off',
     };
     const mockConfig = jest.spyOn(config, 'get').mockReturnValue(mockObject);
 
@@ -270,7 +270,7 @@ describe('spectral - test config file changes with .validaterc, all rules off', 
   });
 
   // There should be no errors and no warnings
-  it('test no spectral errors and no spectral warnings', function() {
+  it('test no spectral errors and no spectral warnings', function () {
     expect(validationResults.errors).toBeUndefined();
     expect(validationResults.warnings).toBeUndefined();
   });

--- a/test/test-utils/get-captured-text.js
+++ b/test/test-utils/get-captured-text.js
@@ -1,13 +1,13 @@
 const stripAnsiFrom = require('strip-ansi');
 
-module.exports.getCapturedText = callsToLog =>
+module.exports.getCapturedText = (callsToLog) =>
   formatCapturedText(callsToLog, false);
 
-module.exports.getCapturedTextWithColor = callsToLog =>
+module.exports.getCapturedTextWithColor = (callsToLog) =>
   formatCapturedText(callsToLog, true);
 
 function formatCapturedText(callsToLog, preserveColors) {
-  return callsToLog.map(args => {
+  return callsToLog.map((args) => {
     // the validator only ever uses the first arg in consolg.log
     const output = preserveColors ? args[0] : stripAnsiFrom(args[0]);
 


### PR DESCRIPTION
Purpose:
- Builds starting to fail due to incongruity in eslint and prettier versions, so update to latest locally and remotely. Also, long list of vulnerabilites given when installing validator dependencies, and `npm audit fix` seems to resolve most or all of those vulnerabilities.

Changes:
- Update version of eslint, prettier, and related packages
- Run `npm audit fix` to resolve vulnerabilities in our dependencies