### PR TITLE
fix: when `limit` and `offset` properties included in `allOf`

### DIFF
--- a/src/plugins/utils/mergeAllOfSchemaProperties.js
+++ b/src/plugins/utils/mergeAllOfSchemaProperties.js
@@ -1,0 +1,30 @@
+const { isObject, mergeWith } = require('lodash');
+
+// Takes a schema, and if an allOf field is provided,
+// merges all allOf schema properties to create one schema
+module.exports = function(schema) {
+  const mergedSchema = Object.assign({}, schema);
+  const allOfArr = mergedSchema['allOf'];
+  // delete now, so it is not merged back into the final result
+  delete mergedSchema['allOf'];
+  if (allOfArr && Array.isArray(allOfArr)) {
+    allOfArr.forEach(function(allOfSchema) {
+      // deep merges the allOf schema into the aggregate schema
+      // uses a function to concatenate arrays instead of overwriting
+      mergeWith(mergedSchema, allOfSchema, customizer);
+    });
+  }
+  return mergedSchema;
+};
+
+function customizer(objValue, srcValue) {
+  // keep the original values for non-object fields instead of overwriting
+  // will maintain the `type`, `description`, `summary`, etc. fields
+  if (!isObject(objValue)) {
+    return objValue;
+  }
+  // if the object is an array combine the arrays
+  // otherwise, not an array, so return undefined and
+  // mergeWith will do default object deep merging
+  return Array.isArray(objValue) ? objValue.concat(srcValue) : undefined;
+}

--- a/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
+++ b/src/plugins/validation/oas3/semantic-validators/pagination-ibm.js
@@ -17,6 +17,7 @@
 // - The response body must contain an array property with the same plural resource name appearing in the collection’s URL.
 
 const MessageCarrier = require('../../../utils/messageCarrier');
+const mergeAllOfSchemaProperties = require('../../../utils/mergeAllOfSchemaProperties');
 
 module.exports.validate = function({ resolvedSpec }, config) {
   const messages = new MessageCarrier();
@@ -55,9 +56,11 @@ module.exports.validate = function({ resolvedSpec }, config) {
       continue;
     }
 
+    const jsonResponseSchema = mergeAllOfSchemaProperties(jsonResponse.schema);
+
     // If no array at top level of response, skip this path
     if (
-      !Object.values(jsonResponse.schema.properties).some(
+      !Object.values(jsonResponseSchema.properties).some(
         prop => prop.type === 'array'
       )
     ) {
@@ -154,7 +157,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       'properties'
     ];
 
-    const limitProp = jsonResponse.schema.properties.limit;
+    const limitProp = jsonResponseSchema.properties.limit;
     if (!limitProp) {
       messages.addMessage(
         propertiesPath,
@@ -164,8 +167,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
       );
     } else if (
       limitProp.type !== 'integer' ||
-      !jsonResponse.schema.required ||
-      jsonResponse.schema.required.indexOf('limit') === -1
+      !jsonResponseSchema.required ||
+      jsonResponseSchema.required.indexOf('limit') === -1
     ) {
       messages.addMessage(
         [...propertiesPath, 'limit'],
@@ -178,7 +181,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     // - If the operation has an `offset` query parameter, the response body must contain an `offset` property this is type integer and required
 
     if (offsetParamIndex !== -1) {
-      const offsetProp = jsonResponse.schema.properties.offset;
+      const offsetProp = jsonResponseSchema.properties.offset;
       if (!offsetProp) {
         messages.addMessage(
           propertiesPath,
@@ -188,8 +191,8 @@ module.exports.validate = function({ resolvedSpec }, config) {
         );
       } else if (
         offsetProp.type !== 'integer' ||
-        !jsonResponse.schema.required ||
-        jsonResponse.schema.required.indexOf('offset') === -1
+        !jsonResponseSchema.required ||
+        jsonResponseSchema.required.indexOf('offset') === -1
       ) {
         messages.addMessage(
           [...propertiesPath, 'offset'],
@@ -203,7 +206,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
     // - The response body must contain an array property with the same plural resource name appearing in the collection’s URL.
 
     const pluralResourceName = path.split('/').pop();
-    const resourcesProp = jsonResponse.schema.properties[pluralResourceName];
+    const resourcesProp = jsonResponseSchema.properties[pluralResourceName];
     if (!resourcesProp || resourcesProp.type !== 'array') {
       messages.addMessage(
         propertiesPath,

--- a/test/plugins/utils/mergeAllOfSchemaProperties.test.js
+++ b/test/plugins/utils/mergeAllOfSchemaProperties.test.js
@@ -1,0 +1,121 @@
+const mergeAllOfSchemaProperties = require('../../../src/plugins/utils/mergeAllOfSchemaProperties');
+
+describe('mergeAllOfSchemaProperties - util', () => {
+  it('should not overwrite original values, should merge all properties, and should not modify original schema', () => {
+    const exampleObject = {
+      schema: {
+        description: 'original description',
+        type: 'object',
+        properties: {
+          prop1: {
+            type: 'string'
+          },
+          prop2: {
+            type: 'integer'
+          }
+        },
+        allOf: [
+          {
+            description: 'description should not overwrite',
+            type: 'object1', // test that type stays as 'object'
+            properties: {
+              prop3: {
+                type: 'number'
+              },
+              prop4: {
+                type: 'boolean'
+              }
+            }
+          },
+          {
+            description: 'description should not overwrite',
+            type: 'object1', // test that type stays as 'object'
+            properties: {
+              prop5: {
+                type: 'number'
+              },
+              prop6: {
+                type: 'boolean'
+              }
+            }
+          }
+        ]
+      }
+    };
+
+    const origSchema = exampleObject.schema;
+    const mergedSchema = mergeAllOfSchemaProperties(exampleObject.schema);
+
+    expect(exampleObject.schema).toBe(origSchema); // original schema not modified
+
+    expect(mergedSchema.description).toEqual('original description');
+    expect(mergedSchema.type).toEqual('object');
+
+    expect(mergedSchema.properties).toHaveProperty('prop1');
+    expect(mergedSchema.properties).toHaveProperty('prop2');
+    expect(mergedSchema.properties).toHaveProperty('prop3');
+    expect(mergedSchema.properties).toHaveProperty('prop4');
+    expect(mergedSchema.properties).toHaveProperty('prop5');
+    expect(mergedSchema.properties).toHaveProperty('prop6');
+  });
+
+  it('should properly merge arrays', () => {
+    const exampleObject = {
+      schema: {
+        required: ['prop1', 'prop2'],
+        description: 'original description',
+        type: 'object',
+        properties: {
+          prop1: {
+            type: 'string'
+          },
+          prop2: {
+            type: 'integer'
+          }
+        },
+        allOf: [
+          {
+            required: ['prop3', 'prop4'],
+            description: 'description should not overwrite',
+            type: 'object1', // test that type stays as 'object'
+            properties: {
+              prop3: {
+                type: 'number'
+              },
+              prop4: {
+                type: 'boolean'
+              }
+            }
+          },
+          {
+            required: ['prop5', 'prop6'],
+            description: 'description should not overwrite',
+            type: 'object1', // test that type stays as 'object'
+            properties: {
+              prop5: {
+                type: 'number'
+              },
+              prop6: {
+                type: 'boolean'
+              }
+            }
+          }
+        ]
+      }
+    };
+
+    const origSchema = exampleObject.schema;
+    const mergedSchema = mergeAllOfSchemaProperties(exampleObject.schema);
+
+    expect(exampleObject.schema).toBe(origSchema); // original schema not modified
+
+    expect(mergedSchema.required).toEqual([
+      'prop1',
+      'prop2',
+      'prop3',
+      'prop4',
+      'prop5',
+      'prop6'
+    ]);
+  });
+});

--- a/test/plugins/validation/oas3/pagination-ibm.test.js
+++ b/test/plugins/validation/oas3/pagination-ibm.test.js
@@ -147,6 +147,78 @@ describe('validation plugin - semantic - pagaination - oas3', function() {
     });
   });
 
+  it('should not complain when limit and offset params in allOf schema', function() {
+    const spec = {
+      paths: {
+        '/resources': {
+          get: {
+            summary: 'this is a summary',
+            operationId: 'operationId',
+            parameters: [
+              {
+                name: 'limit',
+                in: 'query',
+                description: 'limit',
+                required: false,
+                schema: {
+                  type: 'integer',
+                  default: 10,
+                  maximum: 50
+                }
+              }
+            ],
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      description: 'A collection of resources',
+                      type: 'object',
+                      properties: {
+                        resources: {
+                          description: 'An array of resources',
+                          type: 'array',
+                          items: {
+                            type: 'string'
+                          }
+                        }
+                      },
+                      allOf: [
+                        {
+                          description: 'Pagination response properties',
+                          type: 'object',
+                          required: ['limit', 'offset'],
+                          properties: {
+                            limit: {
+                              description:
+                                'The maximum number of items returned in this response',
+                              type: 'integer',
+                              format: 'int32'
+                            },
+                            offset: {
+                              description:
+                                'The offset in the collection of the first element in this page',
+                              type: 'integer',
+                              format: 'int32'
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = validate({ resolvedSpec: spec, isOAS3: true }, config);
+    expect(res.warnings.length).toEqual(0);
+    expect(res.errors.length).toEqual(0);
+  });
+
   describe('limit query parameter', function() {
     it('should complain when limit parameter is not an integer', function() {
       const spec = {


### PR DESCRIPTION
Purpose:
- When validating pagination, validator produces a false positive when the limit and offset properties are included in an allOf combined schema, and this fix resolves the bug.

Changes:
- Merges `allOf` schemas and top-level schema. Allows validation to be done as if one schema provided.

Tests:
- Ensure no errors occur when limit and offset are provided in allOf schema.