### PR TITLE
feat: warn for invalid content types

### DIFF
--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -56,6 +56,33 @@ responses:
 
 **Default Severity**: warn
 
+## ibm-content-type-is-specific
+
+Should avoid the use of `*/*` content type unless the API actually supports all content types. When the API does support all content types, this warning should be ignored.
+
+**Bad Example**
+
+```yaml
+responses:
+  200:
+    content:
+      '*/*':
+```
+
+**Good Example**
+
+```yaml
+responses:
+  200:
+    content:
+      'application/json':
+        ...
+      'text/plain':
+        ...
+```
+
+**Default Severity**: warn
+
 ## major-version-in-path
 
 Validates that every path contains a path segment for the API major version, of the form `v<n>`, and that all paths have the same major version segment. The major version can appear in either the server URL (oas3), the basePath (oas2), or in each path entry.

--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -83,6 +83,30 @@ responses:
 
 **Default Severity**: warn
 
+## ibm-error-content-type-is-json
+
+An error response likely returns `application/json` and this rule warns when `application/json` is not the content type. This rule should be ignored when the API actually returns an error response that is not `application/json`.
+
+**Bad Example**
+
+```yaml
+responses:
+  400:
+    content:
+      'application/octet-stream':
+```
+
+**Good Example**
+
+```yaml
+responses:
+  400:
+    content:
+      'application/json':
+```
+
+**Default Severity**: warn
+
 ## major-version-in-path
 
 Validates that every path contains a path segment for the API major version, of the form `v<n>`, and that all paths have the same major version segment. The major version can appear in either the server URL (oas3), the basePath (oas2), or in each path entry.

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -135,6 +135,17 @@ rules:
     then:
       field: '*/*'
       function: falsy
+  # custom Spectral rule to warn for error response without application/json content
+  ibm-error-content-type-is-json:
+    description: 'error response should support application/json'
+    formats: ["oas3"]
+    severity: warn
+    resolved: true
+    message: "{{description}}"
+    given: $.paths[*][*].responses[?(@property >= 400 && @property < 600)].content
+    then:
+      field: 'application/json'
+      function: truthy
   # custom Spectral rule to ensure response example provided
   response-example-provided:
     message: "{{error}}"

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -122,6 +122,19 @@ rules:
     then:
       field: schema
       function: truthy
+  # custom Spectral rule to warn for */*
+  ibm-content-type-is-specific:
+    description: '*/* should only be used when all content types are supported'
+    formats: ["oas3"]
+    severity: warn
+    resolved: true
+    message: "{{description}}"
+    given:
+    - $.paths[*][*][parameters,responses][*].content
+    - $.paths[*][*][requestBody].content
+    then:
+      field: '*/*'
+      function: falsy
   # custom Spectral rule to ensure response example provided
   response-example-provided:
     message: "{{error}}"

--- a/test/spectral/tests/custom-rules/ibm-content-type-is-specific.test.js
+++ b/test/spectral/tests/custom-rules/ibm-content-type-is-specific.test.js
@@ -1,0 +1,81 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test content type is not */*', function() {
+  it('should error only when the content type is */*', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      paths: {
+        path1: {
+          post: {
+            requestBody: {
+              content: {
+                // error 1
+                '*/*': {
+                  $ref: '#/components/schemas/GenericSchema'
+                }
+              }
+            },
+            parameters: [
+              {
+                name: 'param1',
+                in: 'query',
+                content: {
+                  // error 2
+                  '*/*': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              }
+            ],
+            responses: {
+              '200': {
+                content: {
+                  // error 3
+                  '*/*': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              },
+              '201': {
+                content: {
+                  // no error
+                  'application/json': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              },
+              '202': {
+                content: {
+                  // no error
+                  'image/*': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          GenericSchema: {
+            type: 'object',
+            properties: {
+              prop: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn =>
+        warn.message ===
+        '*/* should only be used when all content types are supported'
+    );
+    expect(expectedWarnings.length).toBe(3);
+  });
+});

--- a/test/spectral/tests/custom-rules/ibm-error-content-type-is-json.test.js
+++ b/test/spectral/tests/custom-rules/ibm-error-content-type-is-json.test.js
@@ -1,0 +1,59 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test error response content type is application/json', function() {
+  it('should error only when the error response content type is not application/json', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      paths: {
+        path1: {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  // no error
+                  'application/octet-stream': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              },
+              '400': {
+                content: {
+                  // error 1
+                  'application/octet-stream': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              },
+              '404': {
+                content: {
+                  // no error
+                  'application/json': {
+                    $ref: '#/components/schemas/GenericSchema'
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          GenericSchema: {
+            type: 'object',
+            properties: {
+              prop: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.message === 'error response should support application/json'
+    );
+    expect(expectedWarnings.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Purpose:
- Identify cases where the content type should be more specific or should likely just be application/json to ensure API and API definition are following good design principles.

Changes:
- Add Spectral rule to warn on any occurrence of `*/*` content-type
- Add Spectral rule to warn when error response content type does not support `application/json` because the error response is highly likely just be `application/json`

Tests:
- Add test specs for each that include both good practices and violations and ensure the proper number of errors occur

Docs:
- Document each rule