### PR TITLE
feat: validate `x-sdk-operations` extension

### DIFF
--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -107,6 +107,12 @@ responses:
 
 **Default Severity**: warn
 
+## ibm-sdk-operations
+
+Validates the structure of the `x-sdk-operations` object using [this JSON Schema document](/src/spectral/schemas/x-sdk-operations.json).
+
+**Default Severity**: warn
+
 ## major-version-in-path
 
 Validates that every path contains a path segment for the API major version, of the form `v<n>`, and that all paths have the same major version segment. The major version can appear in either the server URL (oas3), the basePath (oas2), or in each path entry.

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -146,6 +146,18 @@ rules:
     then:
       field: 'application/json'
       function: truthy
+  # custom Spectral rule to ensure valid x-sdk-operations schema
+  ibm-sdk-operations:
+    message: "{{error}}"
+    given: $.
+    severity: warn
+    formats: ["oas3"]
+    resolved: true
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          $ref: './schemas/x-sdk-operations.json'
   # custom Spectral rule to ensure response example provided
   response-example-provided:
     message: "{{error}}"

--- a/src/spectral/rulesets/schemas/x-sdk-operations.json
+++ b/src/spectral/rulesets/schemas/x-sdk-operations.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IBM SDK Operations Extension",
+  "description": "sdk operations extension schema",
+  "type": "object",
+  "properties": {
+    "paths": {
+      "$ref": "#/definitions/Paths"
+    }
+  },
+  "definitions": {
+    "Paths": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/PathItem"
+        }
+      }
+    },
+    "PathItem": {
+      "type": "object",
+      "patternProperties": {
+        "^(get|put|post|delete|options|head|patch|trace)$": {
+          "$ref": "#/definitions/Operation"
+        }
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "properties": {
+        "x-sdk-operations": {
+          "$ref": "#/definitions/SdkOperations"
+        }
+      }
+    },
+    "SdkOperations": {
+      "type": "object",
+      "properties": {
+        "request-examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/x-sdk-request-examples-array"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "x-sdk-request-examples-array": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/x-sdk-request-example"
+      }
+    },
+    "x-sdk-request-example": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name or title of the example. In documentation it should appear as a header above the example."
+        },
+        "contentType": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The media type of the response in this example."
+          }
+        },
+        "example": {
+          "type": "array",
+          "description": "An array of code or text elements that make up the example",
+          "items": {
+            "$ref": "#/definitions/x-sdk-request-example-element"
+          }
+        },
+        "response": {},
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "example"
+      ],
+      "additionalProperties": false
+    },
+    "x-sdk-request-example-element": {
+      "type": "object",
+      "description": "An element of the request example.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name or title of the example element. In documentation it should appear as a header above the example element."
+        },
+        "type": {
+          "type": "string",
+          "description": "The element type indicates the type of content in the element. `text` elements contain a textual description or explanation, possibly using markdown for rich text elements. `code` elements contain code appropriate for the language of the request example. `code` elements will be presented in a `<pre><code>` block in documentation and should contain no markup or escapes other than escapes for quote and backslash (required for JSON).",
+          "enum": [
+            "text",
+            "code"
+          ]
+        },
+        "source": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Content of the example element as an array of strings. The content is formed by simple concatenation of the array elements."
+        }
+      },
+      "required": [
+        "type",
+        "source"
+      ]
+    }
+  }
+}

--- a/src/spectral/utils/spectral-validator.js
+++ b/src/spectral/utils/spectral-validator.js
@@ -70,11 +70,7 @@ const setup = async function(spectral, rulesetFileOverride, configObject) {
 
   // Add IBM default ruleset to static assets to allow extends to reference it
   const staticAssets = require('@stoplight/spectral/rulesets/assets/assets.json');
-  setupStaticAssets(
-    staticAssets,
-    defaultSpectralRulesetURI,
-    spectralRulesetURI
-  );
+  setupStaticAssets(staticAssets, defaultSpectralRulesetURI);
   Spectral.registerStaticAssets(staticAssets);
 
   // Register formats
@@ -98,8 +94,7 @@ const setup = async function(spectral, rulesetFileOverride, configObject) {
 
 function setupStaticAssets(staticAssets, defaultSpectralRulesetURI) {
   // register ruleset
-  const content = fs.readFileSync(defaultSpectralRulesetURI, 'utf8');
-  staticAssets['ibm:oas'] = content;
+  staticAssets['ibm:oas'] = addDataToSpectralConfig(defaultSpectralRulesetURI);
 
   const parentDirectory = path.parse(defaultSpectralRulesetURI).dir;
 
@@ -116,6 +111,14 @@ function setupStaticAssets(staticAssets, defaultSpectralRulesetURI) {
       'utf8'
     );
   });
+}
+
+function addDataToSpectralConfig(defaultSpectralRulesetURI) {
+  const content = fs.readFileSync(defaultSpectralRulesetURI, 'utf8');
+  return content.replace(
+    '\\./schemas',
+    path.join(__dirname, '../rulesets/schemas')
+  );
 }
 
 module.exports = {

--- a/test/spectral/tests/custom-rules/ibm-sdk-operations.test.js
+++ b/test/spectral/tests/custom-rules/ibm-sdk-operations.test.js
@@ -1,0 +1,45 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test that x-sdk-operations schema violations cause errors', function() {
+  let res;
+
+  beforeAll(async () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'ErrorAPI'
+      },
+      servers: [{ url: 'http://api.errorapi.com/v1' }],
+      paths: {
+        path1: {
+          post: {
+            'x-sdk-operations': {
+              'request-examples': {
+                type: 13,
+                notafield: 'asdf'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    res = await inCodeValidator(spec, true);
+  });
+
+  it('should warn for invalid x-sdk-operations schema', function() {
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.rule === 'ibm-sdk-operations'
+    );
+    expect(expectedWarnings.length).toBe(1);
+    expect(expectedWarnings[0].path).toEqual([
+      'paths',
+      'path1',
+      'post',
+      'x-sdk-operations',
+      'request-examples',
+      'type'
+    ]);
+  });
+});


### PR DESCRIPTION
**Description:** 
- This PR uses a provided Spectral function to do JSON Schema validation. This is a positive because it is a well-defined way to invoke the AJV validator.
- The one drawback is that we need to dynamically convert the relative path to an absolute path before loading the default config into STATIC_ASSETS because we need to ensure Spectral can always find the schema regardless of the current working directory.
- The Spectral `schema` function has the same problem we observed (in Spectral `5.8.1` and below) in the `oas3-schema` rule where only one error is returned at a time. We will want to follow up on this implementation by raising this issue to Spectral and fixing the `schema` function.

Purpose:
- Validate that the x-sdk-operations extension is used correctly.

Changes:
- Load the absolute path to the JSON Schema into static assets, so when the `ibm:oas` ruleset is extended, still able to find the JSON Schema
- Replace relative references to `./schema` in `.defaultsforspectral.yaml` with their absolute path using regex replace

Tests:
- Ensure `ibm-sdk-operations` rule catches errors

Docs:
- Document the `ibm-sdk-operations` rule