### PR TITLE
chore: ignore node_modules in codescan

### DIFF
--- a/appscan-config.xml
+++ b/appscan-config.xml
@@ -3,6 +3,7 @@
     <Target path=".">
       <Exclude>test/</Exclude>
       <Exclude>README.md</Exclude>
+      <Exclude>node_modules/</Exclude>
     </Target>
   </Targets>
 </Configuration>


### PR DESCRIPTION
This PR excludes the `node_modules` directory from our routine code scans after the most recent runs detected problems in a dependency.