### PR TITLE
feat: warn when parameters can be defined as global param

### DIFF
--- a/docs/spectral-rules.md
+++ b/docs/spectral-rules.md
@@ -107,11 +107,59 @@ responses:
 
 **Default Severity**: warn
 
+## ibm-global-params
+
+When a parameter is used in every operation, the parameter should have a field, `x-sdk-global-param: true`.
+
+**Bad Example**
+
+```yaml
+/path1:
+  get:
+    parameters:
+    - name: globalParam
+      in: query
+      description: this parameter is used in every operation
+      schema:
+        type: string
+/path2:
+  get:
+    parameters:
+    - name: globalParam
+      in: query
+      description: this parameter is used in every operation
+      schema:
+        type: string
+```
+
+**Good Example**
+
+```yaml
+/path1:
+  get:
+    parameters:
+    - name: globalParam
+      in: query
+      description: this parameter is used in every operation
+      x-sdk-global-param: true
+      schema:
+        type: string
+/path2:
+  get:
+    parameters:
+    - name: globalParam
+      in: query
+      description: this parameter is used in every operation
+      x-sdk-global-param: true
+      schema:
+        type: string
+```
+
+**Default Severity**: warn
+
 ## ibm-sdk-operations
 
 Validates the structure of the `x-sdk-operations` object using [this JSON Schema document](/src/spectral/schemas/x-sdk-operations.json).
-
-**Default Severity**: warn
 
 ## major-version-in-path
 

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -3,6 +3,7 @@ functionsDir: './ibm-oas'
 functions:
   - check-major-version
   - error-response-schema
+  - global-params
   - response-example-provided
   - schema-or-content-provided
 rules:
@@ -146,6 +147,15 @@ rules:
     then:
       field: 'application/json'
       function: truthy
+  # rule to locate candidates to be x-sdk-global-params
+  ibm-global-params:
+    description: 'parameter defined on every method, add `x-sdk-global-param` with value `true`'
+    severity: warn
+    resolved: true
+    message: "{{error}}"
+    given: $.paths
+    then:
+      function: global-params
   # custom Spectral rule to ensure valid x-sdk-operations schema
   ibm-sdk-operations:
     message: "{{error}}"

--- a/src/spectral/rulesets/ibm-oas/global-params.js
+++ b/src/spectral/rulesets/ibm-oas/global-params.js
@@ -1,0 +1,74 @@
+const { each, isEqual, omit } = require('lodash');
+
+const GLOBAL_PARAM_FIELD = 'x-sdk-global-param';
+
+module.exports = function(paths) {
+  const pathName = Object.keys(paths)[0];
+  const opName = Object.keys(paths[pathName])[0];
+  const arbitraryParametersArr = paths[pathName][opName].parameters;
+  const allParameterArrays = getAllOrNoParameterArrays(paths);
+  if (allParameterArrays.length && arbitraryParametersArr) {
+    const results = [];
+    each(arbitraryParametersArr, function(arbitraryParam) {
+      if (arbitraryParamDefinedInEveryOp(allParameterArrays, arbitraryParam)) {
+        results.push(...addWarningsForMissingGlobalTag(arbitraryParam, paths));
+      }
+    });
+    return results;
+  }
+};
+
+// assumes the given param is a global param
+// issues a warning when the known global param does not have `x-sdk-global-param` field
+function addWarningsForMissingGlobalTag(globalParam, paths) {
+  const warnings = [];
+  each(paths, function(path, pathName) {
+    each(path, function(operation, opName) {
+      each(operation.parameters, function(opParam, index) {
+        if (
+          globalParamsEqual(globalParam, opParam) &&
+          opParam[GLOBAL_PARAM_FIELD] !== true
+        ) {
+          warnings.push({
+            message:
+              'parameter defined on every method, add `x-sdk-global-param` field with value `true`',
+            path: ['paths', pathName, opName, 'parameters', index]
+          });
+        }
+      });
+    });
+  });
+  return warnings;
+}
+
+function arbitraryParamDefinedInEveryOp(allParameterArrays, arbitraryParam) {
+  return allParameterArrays.every(function(paramArray) {
+    return paramArray.some(function(param) {
+      return globalParamsEqual(param, arbitraryParam);
+    });
+  });
+}
+
+// if at least one operation does not have parameters, returns an empty array
+// otherwise, returns an array of all the parameter arrays
+function getAllOrNoParameterArrays(paths) {
+  const allParameterArrays = [];
+  each(paths, function(path) {
+    each(path, function(operation) {
+      if (operation.parameters) {
+        allParameterArrays.push(operation.parameters);
+      } else {
+        // operation has no parameters, so no global parameters to find
+        return [];
+      }
+    });
+  });
+  return allParameterArrays;
+}
+
+function globalParamsEqual(param1, param2) {
+  return isEqual(
+    omit(param1, GLOBAL_PARAM_FIELD),
+    omit(param2, GLOBAL_PARAM_FIELD)
+  );
+}

--- a/test/cli-validator/tests/error-handling.test.js
+++ b/test/cli-validator/tests/error-handling.test.js
@@ -200,7 +200,7 @@ describe('cli tool - test error handling', function() {
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
     expect(exitCode).toEqual(1);
-    expect(capturedText.length).toEqual(29);
+    expect(capturedText.length).toEqual(37);
     expect(capturedText[0].trim()).toEqual(
       '[Error] Trailing comma on line 36 of file ./test/cli-validator/mockFiles/trailing-comma.json.'
     );

--- a/test/spectral/tests/custom-rules/ibm-global-params.test.js
+++ b/test/spectral/tests/custom-rules/ibm-global-params.test.js
@@ -1,0 +1,126 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test global params validation', function() {
+  it('should issue warning only for unmarked global params', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      paths: {
+        path1: {
+          get: {
+            parameters: [
+              {
+                // no warning, not global
+                name: 'dummyParam',
+                in: 'query',
+                description: 'not global',
+                schema: {
+                  type: 'string'
+                }
+              },
+              {
+                name: 'globalParam1',
+                in: 'query',
+                description: 'global parameter',
+                // no warning, x-sdk-global-param used correctly
+                'x-sdk-global-param': true,
+                schema: {
+                  type: 'string'
+                }
+              },
+              {
+                name: 'globalParam2',
+                in: 'query',
+                description: 'global parameter',
+                // warning 1, missing x-sdk-global-param
+                schema: {
+                  type: 'string'
+                }
+              }
+            ]
+          },
+          post: {
+            parameters: [
+              {
+                name: 'globalParam1',
+                in: 'query',
+                description: 'global parameter',
+                // warning 2, missing x-sdk-global-param
+                schema: {
+                  type: 'string'
+                }
+              },
+              {
+                name: 'globalParam2',
+                in: 'query',
+                description: 'global parameter',
+                // no warning, x-sdk-global-param used correctly
+                'x-sdk-global-param': true,
+                schema: {
+                  type: 'string'
+                }
+              }
+            ]
+          }
+        },
+        path2: {
+          get: {
+            parameters: [
+              {
+                name: 'globalParam1',
+                in: 'query',
+                description: 'global parameter',
+                // warning 3, missing x-sdk-global-param
+                schema: {
+                  type: 'string'
+                }
+              },
+              {
+                name: 'globalParam2',
+                in: 'query',
+                description: 'global parameter',
+                // warning 4, missing x-sdk-global-param
+                schema: {
+                  type: 'string'
+                }
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      warn => warn.rule === 'ibm-global-params'
+    );
+    expect(expectedWarnings.length).toBe(4);
+    expect(expectedWarnings[0].path).toEqual([
+      'paths',
+      'path1',
+      'get',
+      'parameters',
+      '2'
+    ]);
+    expect(expectedWarnings[1].path).toEqual([
+      'paths',
+      'path1',
+      'post',
+      'parameters',
+      '0'
+    ]);
+    expect(expectedWarnings[2].path).toEqual([
+      'paths',
+      'path2',
+      'get',
+      'parameters',
+      '0'
+    ]);
+    expect(expectedWarnings[3].path).toEqual([
+      'paths',
+      'path2',
+      'get',
+      'parameters',
+      '1'
+    ]);
+  });
+});


### PR DESCRIPTION
Purpose:
- tooling uses the `x-sdk-global-param` field. Ensure parameters are marked properly when the parameter is eligible to use this extension.

Changes:
- Add a custom function that looks for global params and warns if they are not marked properly.
- Add a custom rule that utilizes this function

Test:
- Add a test that checks both that the validator issues a warning only in the correct cases.

Docs:
- Document the `ibm-global-params` rule