### PR TITLE
Update Readme.md to include "request-body-object" spectral rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ operation-tags: true
 operation-tag-defined: true
 path-keys-no-trailing-slash: true
 path-not-include-query: true
+request-body-object: true
 typed-enum: true
 oas2-api-host: true
 oas2-api-schemes: true


### PR DESCRIPTION
By default the validator doesn't accept array request bodies but that fact is not documented. This will likely help devs navigate to the spectral rule config faster. :)