### PR TITLE
fix: allow null values inside enum property.

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
@@ -52,7 +52,7 @@ module.exports.validate = function({ jsSpec, resolvedSpec }, config) {
 
     // check for and flag null values - they are not allowed by the spec and are likely mistakes
     Object.keys(obj).forEach(key => {
-      if (key !== 'default' && obj[key] === null) {
+      if (key !== 'default' && obj[key] === null && path[path.length - 1] !== 'enum') {
         messages.addMessage(
           [...path, key],
           'Null values are not allowed for any property.',

--- a/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/walker-ibm.js
@@ -52,7 +52,11 @@ module.exports.validate = function({ jsSpec, resolvedSpec }, config) {
 
     // check for and flag null values - they are not allowed by the spec and are likely mistakes
     Object.keys(obj).forEach(key => {
-      if (key !== 'default' && obj[key] === null && path[path.length - 1] !== 'enum') {
+      if (
+        key !== 'default' &&
+        obj[key] === null &&
+        path[path.length - 1] !== 'enum'
+      ) {
         messages.addMessage(
           [...path, key],
           'Null values are not allowed for any property.',

--- a/test/plugins/validation/2and3/walker-ibm.test.js
+++ b/test/plugins/validation/2and3/walker-ibm.test.js
@@ -154,6 +154,30 @@ describe('validation plugin - semantic - walker-ibm', () => {
     expect(res.warnings.length).toEqual(0);
   });
 
+  it('should not return an error when the enum property contains a null value', () => {
+    const spec = {
+      paths: {
+        '/pets': {
+          get: {
+            parameters: [
+              {
+                name: 'tags',
+                in: 'query',
+                nullable: true,
+                type: 'string',
+                enum: ['FOO', 'BAR', null]
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const res = validate({ jsSpec: spec }, config);
+    expect(res.errors.length).toEqual(0);
+    expect(res.warnings.length).toEqual(0);
+  });
+
   it('should complain if a description sibling to a $ref matches the referenced schema description', async () => {
     const spec = {
       paths: {


### PR DESCRIPTION
As described in the [docs](https://swagger.io/docs/specification/data-models/enums/) `null` values are allowed inside enums. This PR fixed the lint error when you have nullable enums.