### PR TITLE
fix: don't crash when parameter is missing required "in" property

### DIFF
--- a/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
+++ b/src/plugins/validation/2and3/semantic-validators/paths-ibm.js
@@ -55,7 +55,7 @@ module.exports.validate = function({ resolvedSpec }, config) {
       let globalParameters = [];
       if (path.parameters) {
         globalParameters = path.parameters
-          .filter(param => param.in.toLowerCase() === 'path')
+          .filter(param => param.in && param.in.toLowerCase() === 'path')
           .map(param => param.name);
       }
 


### PR DESCRIPTION
Right now, we assume that parameters will have all required properties. This results
in the code crashing ungracefully if the "in" property is missing. This PR corrects
that. Missing "in" properties are already caught by spectral if there aren't other
issues with the property.

Resolves #307 