### PR TITLE
feat: string schema should define enum or pattern, minLength, maxLength

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- 10
 - 12
+- 14
 cache:
   npm: false
 script:

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -6,6 +6,7 @@ functions:
   - required-property
   - response-example-provided
   - schema-or-content-provided
+  - string-boundary
 rules:
 
   # Original list created from Spectral with:
@@ -218,3 +219,16 @@ rules:
       functionOptions:
         values:
         - object
+  # ensure string has explicit boundaries
+  string-boundary:
+    description: 'string schemas should have explicit boundaries defined'
+    message: "{{error}}"
+    severity: warn
+    formats: ["oas3"]
+    resolved: true
+    given:
+    - $.paths[*][*][parameters][*].schema
+    - $.paths[*][*][parameters][*].content[*].schema
+    - $.paths[*][*].requestBody.content[*].schema
+    then:
+      function: string-boundary

--- a/src/spectral/rulesets/ibm-oas/string-boundary.js
+++ b/src/spectral/rulesets/ibm-oas/string-boundary.js
@@ -44,7 +44,7 @@ function traverseSchema(schema, path) {
 function stringBoundaryErrors(stringSchema, path) {
   const errors = [];
   if (!stringSchema.enum) {
-    if (!stringSchema.pattern) {
+    if (!stringSchema.pattern && !['binary', 'date', 'date-time'].includes(stringSchema.format)) {
       errors.push({
         message: 'Should define a pattern for a valid string',
         path

--- a/src/spectral/rulesets/ibm-oas/string-boundary.js
+++ b/src/spectral/rulesets/ibm-oas/string-boundary.js
@@ -27,7 +27,6 @@ function traverseSchema(schema, path) {
     const composedSchemas = schema[whichComposedSchemaType];
     if (Array.isArray(composedSchemas)) {
       composedSchemas.forEach(function(composedSchema, index) {
-        // TODO: is this the right way to get the index?
         errors.push(
           ...traverseSchema(composedSchema, [
             ...path,

--- a/src/spectral/rulesets/ibm-oas/string-boundary.js
+++ b/src/spectral/rulesets/ibm-oas/string-boundary.js
@@ -44,7 +44,10 @@ function traverseSchema(schema, path) {
 function stringBoundaryErrors(stringSchema, path) {
   const errors = [];
   if (!stringSchema.enum) {
-    if (!stringSchema.pattern && !['binary', 'date', 'date-time'].includes(stringSchema.format)) {
+    if (
+      !stringSchema.pattern &&
+      !['binary', 'date', 'date-time'].includes(stringSchema.format)
+    ) {
       errors.push({
         message: 'Should define a pattern for a valid string',
         path

--- a/src/spectral/rulesets/ibm-oas/string-boundary.js
+++ b/src/spectral/rulesets/ibm-oas/string-boundary.js
@@ -1,0 +1,67 @@
+module.exports = function(schema, _opts, paths) {
+  const rootPath = paths.target !== void 0 ? paths.target : paths.given;
+  return traverseSchema(schema, rootPath);
+};
+
+function traverseSchema(schema, path) {
+  if (schema.type === 'string') {
+    return stringBoundaryErrors(schema, path);
+  }
+  const errors = [];
+  if (schema.properties) {
+    Object.entries(schema.properties).forEach(function(prop) {
+      const propName = prop[0];
+      const propSchema = prop[1];
+      errors.push(
+        ...traverseSchema(propSchema, [...path, 'properties', propName])
+      );
+    });
+  } else if (schema.items) {
+    errors.push(...traverseSchema(schema.items, [...path, 'items']));
+  } else if (schema.allOf || schema.anyOf || schema.oneOf) {
+    const whichComposedSchemaType = schema.allOf
+      ? 'allOf'
+      : schema.anyOf
+      ? 'anyOf'
+      : 'oneOf';
+    const composedSchemas = schema[whichComposedSchemaType];
+    if (Array.isArray(composedSchemas)) {
+      composedSchemas.forEach(function(composedSchema, index) {
+        // TODO: is this the right way to get the index?
+        errors.push(
+          ...traverseSchema(composedSchema, [
+            ...path,
+            whichComposedSchemaType,
+            index
+          ])
+        );
+      });
+    }
+  }
+  return errors;
+}
+
+function stringBoundaryErrors(stringSchema, path) {
+  const errors = [];
+  if (!stringSchema.enum) {
+    if (!stringSchema.pattern) {
+      errors.push({
+        message: 'Should define a pattern for a valid string',
+        path
+      });
+    }
+    if (!stringSchema.minLength) {
+      errors.push({
+        message: 'Should define a minLength for a valid string',
+        path
+      });
+    }
+    if (!stringSchema.maxLength) {
+      errors.push({
+        message: 'Should define a maxLength for a valid string',
+        path
+      });
+    }
+  }
+  return errors;
+}

--- a/test/cli-validator/mockFiles/oas3/clean.yml
+++ b/test/cli-validator/mockFiles/oas3/clean.yml
@@ -85,6 +85,9 @@ paths:
           description: The id of the pet to retrieve
           schema:
             type: string
+            pattern: '[0-9]+'
+            minLength: 1
+            maxLength: 100
       responses:
         '200':
           description: Expected response to a valid request
@@ -114,9 +117,15 @@ components:
         name:
           type: string
           description: "name property"
+          pattern: '[a-zA-Z0-9]+'
+          minLength: 1
+          maxLength: 50
         tag:
           type: string
           description: "tag property"
+          pattern: '[a-zA-Z0-9]+'
+          minLength: 1
+          maxLength: 50
       example:
         id: 1
         name: doggie
@@ -173,6 +182,9 @@ components:
         message:
           type: string
           description: "message property"
+          pattern: '^[a-zA-Z0-9_ ]*$'
+          minLength: 1
+          maxLength: 300
       example:
         code: 123
         message: "error occurred"

--- a/test/cli-validator/mockFiles/oas3/testoneof.yaml
+++ b/test/cli-validator/mockFiles/oas3/testoneof.yaml
@@ -11,6 +11,9 @@ components:
     A:
       description: a string
       type: string
+      pattern: '[a-zA-Z0-9]'
+      minLength: 1
+      maxLength: 40
     B:
       description: a boolean
       type: boolean
@@ -29,6 +32,9 @@ components:
           - type: string
             format: url
             description: 'url string'
+            pattern: 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
+            minLength: 0
+            maxLength: 100
     Ok:
       description: ok object
       type: object

--- a/test/cli-validator/tests/expected-output.test.js
+++ b/test/cli-validator/tests/expected-output.test.js
@@ -363,7 +363,7 @@ describe('test expected output - OpenAPI 3', function() {
     const validationResults = await inCodeValidator(oas3Object, defaultMode);
 
     expect(validationResults.errors.length).toBe(4);
-    expect(validationResults.warnings.length).toBe(16);
+    expect(validationResults.warnings.length).toBe(40);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 

--- a/test/cli-validator/tests/info-and-hint.test.js
+++ b/test/cli-validator/tests/info-and-hint.test.js
@@ -35,7 +35,7 @@ describe('test info and hint rules - OAS3', function() {
     expect(jsonOutput['errors'].length).toBe(4);
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(13);
+    expect(jsonOutput['warnings'].length).toBe(37);
 
     // Verify infos
     expect(jsonOutput['infos'].length).toBe(1);

--- a/test/spectral/mockFiles/oas3/disabled-rules.yml
+++ b/test/spectral/mockFiles/oas3/disabled-rules.yml
@@ -134,6 +134,9 @@ paths:
           description: The id of the pet to retrieve
           schema:
             type: string
+            pattern: '^[a-zA-Z0-9]*$'
+            minLength: 1
+            maxLength: 50
       security:
         - apikey: []
       responses:
@@ -163,6 +166,9 @@ paths:
           required: true
           schema:
             type: string
+            pattern: '^[a-zA-Z0-9]*$'
+            minLength: 1
+            maxLength: 50
       responses:
         405:
           description: "Invalid input"
@@ -197,9 +203,15 @@ components:
         name:
           type: string
           description: "name property"
+          pattern: '^[a-zA-Z0-9]*$'
+          minLength: 1
+          maxLength: 50
         tag:
           type: string
           description: "tag property"
+          pattern: '^[a-zA-Z0-9]*$'
+          minLength: 1
+          maxLength: 50
       example:
         id: 1
         name: doggie

--- a/test/spectral/tests/custom-rules/string-boundary.test.js
+++ b/test/spectral/tests/custom-rules/string-boundary.test.js
@@ -1,0 +1,306 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - test validation that required properties are in the schema', function() {
+  it('should error only when required property is missing', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: {
+        description:
+          'This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.',
+        version: '1.0.0',
+        title: 'Swagger Petstore'
+      },
+      paths: {
+        '/createPet': {
+          post: {
+            operationId: 'addPet',
+            parameters: [
+              {
+                name: 'param1',
+                in: 'query',
+                schema: {
+                  type: 'string',
+                  pattern: '[a-zA-Z0-9]+',
+                  minLength: 1,
+                  maxLength: 30
+                }
+              },
+              {
+                name: 'param2',
+                in: 'query',
+                schema: {
+                  type: 'string' // missing pattern, minLength, maxLength
+                }
+              }
+            ],
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      prop1: {
+                        type: 'object',
+                        properties: {
+                          string_prop1: {
+                            type: 'string',
+                            pattern: '[a-zA-Z0-9]+',
+                            minLength: 1,
+                            maxLength: 30
+                          },
+                          string_prop2: {
+                            type: 'string' // missing pattern, minLength, maxLength
+                          },
+                          array_prop: {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              anyOf: [
+                                {
+                                  type: 'object',
+                                  properties: {
+                                    any_of_prop1: {
+                                      type: 'string',
+                                      enum: ['enum1'] // valid, enum defined
+                                    },
+                                    any_of_prop2: {
+                                      type: 'string' // missing pattern, minLength, maxLength
+                                    }
+                                  }
+                                },
+                                {
+                                  type: 'string' // missing pattern, minLength, maxLength
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            responses: {
+              '201': {
+                description: 'pet created'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const res = await inCodeValidator(spec, true);
+    const expectedWarnings = res.warnings.filter(
+      err => err.rule === 'string-boundary'
+    );
+
+    expect(expectedWarnings.length).toBe(12); // 4 props x 3 warnings per prop
+
+    expect(expectedWarnings[0].message).toBe(
+      'Should define a pattern for a valid string'
+    );
+    expect(expectedWarnings[0].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'parameters',
+      '1',
+      'schema'
+    ]);
+    expect(expectedWarnings[1].message).toBe(
+      'Should define a minLength for a valid string'
+    );
+    expect(expectedWarnings[1].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'parameters',
+      '1',
+      'schema'
+    ]);
+    expect(expectedWarnings[2].message).toBe(
+      'Should define a maxLength for a valid string'
+    );
+    expect(expectedWarnings[2].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'parameters',
+      '1',
+      'schema'
+    ]);
+
+    expect(expectedWarnings[3].message).toBe(
+      'Should define a pattern for a valid string'
+    );
+    expect(expectedWarnings[3].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'string_prop2'
+    ]);
+    expect(expectedWarnings[4].message).toBe(
+      'Should define a minLength for a valid string'
+    );
+    expect(expectedWarnings[4].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'string_prop2'
+    ]);
+    expect(expectedWarnings[5].message).toBe(
+      'Should define a maxLength for a valid string'
+    );
+    expect(expectedWarnings[5].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'string_prop2'
+    ]);
+
+    expect(expectedWarnings[6].message).toBe(
+      'Should define a pattern for a valid string'
+    );
+    expect(expectedWarnings[6].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'array_prop',
+      'items',
+      'anyOf',
+      '0',
+      'properties',
+      'any_of_prop2'
+    ]);
+    expect(expectedWarnings[7].message).toBe(
+      'Should define a minLength for a valid string'
+    );
+    expect(expectedWarnings[7].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'array_prop',
+      'items',
+      'anyOf',
+      '0',
+      'properties',
+      'any_of_prop2'
+    ]);
+    expect(expectedWarnings[8].message).toBe(
+      'Should define a maxLength for a valid string'
+    );
+    expect(expectedWarnings[8].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'array_prop',
+      'items',
+      'anyOf',
+      '0',
+      'properties',
+      'any_of_prop2'
+    ]);
+
+    expect(expectedWarnings[9].message).toBe(
+      'Should define a pattern for a valid string'
+    );
+    expect(expectedWarnings[9].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'array_prop',
+      'items',
+      'anyOf',
+      '1'
+    ]);
+    expect(expectedWarnings[10].message).toBe(
+      'Should define a minLength for a valid string'
+    );
+    expect(expectedWarnings[10].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'array_prop',
+      'items',
+      'anyOf',
+      '1'
+    ]);
+    expect(expectedWarnings[11].message).toBe(
+      'Should define a maxLength for a valid string'
+    );
+    expect(expectedWarnings[11].path).toEqual([
+      'paths',
+      '/createPet',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      'properties',
+      'prop1',
+      'properties',
+      'array_prop',
+      'items',
+      'anyOf',
+      '1'
+    ]);
+  });
+});

--- a/test/spectral/tests/custom-rules/string-boundary.test.js
+++ b/test/spectral/tests/custom-rules/string-boundary.test.js
@@ -42,11 +42,9 @@ describe('spectral - test validation that required properties are in the schema'
                       prop1: {
                         type: 'object',
                         properties: {
-                          string_prop1: {
+                          date_prop1: {
                             type: 'string',
-                            pattern: '[a-zA-Z0-9]+',
-                            minLength: 1,
-                            maxLength: 30
+                            format: 'date'
                           },
                           string_prop2: {
                             type: 'string' // missing pattern, minLength, maxLength

--- a/test/spectral/tests/custom-rules/string-boundary.test.js
+++ b/test/spectral/tests/custom-rules/string-boundary.test.js
@@ -44,7 +44,9 @@ describe('spectral - test validation that required properties are in the schema'
                         properties: {
                           date_prop1: {
                             type: 'string',
-                            format: 'date'
+                            format: 'date',
+                            minLength: 1,
+                            maxLength: 10
                           },
                           string_prop2: {
                             type: 'string' // missing pattern, minLength, maxLength


### PR DESCRIPTION
Purpose: encourage users to define schemas with explicit boundaries for valid string input.

Enforces use of `pattern`, `minLength`, and `maxLength` on `parameter` and `requestBody` string schemas.

Exceptions:
- `enum` defined