### PR TITLE
fix: 101 and 202 responses do not need content entries

### DIFF
--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -105,7 +105,7 @@ rules:
   content-entry-provided:
     description: Request bodies and non-204 responses should define a content object
     given:
-    - $.paths[*][*].responses[?(@property != '204')]
+    - $.paths[*][*].responses[?(@property != '204' && @property != '202' && @property != '101')]
     - $.paths[*][*].requestBody
     severity: warn
     formats: ["oas3"]

--- a/test/spectral/tests/custom-rules/content-entry-provided.test.js
+++ b/test/spectral/tests/custom-rules/content-entry-provided.test.js
@@ -1,7 +1,7 @@
 const inCodeValidator = require('../../../../src/lib');
 
 describe('spectral - test content entry validation does not produce false positives', function() {
-  it('should not error when content object provided or for 204 response without content', async () => {
+  it('should not error when content object provided or for 101, 202, 204 response without content', async () => {
     const spec = {
       openapi: '3.0.0',
       info: {
@@ -26,6 +26,13 @@ describe('spectral - test content entry validation does not produce false positi
                     $ref: '#/components/schemas/GenericSchema'
                   }
                 }
+              },
+              '101': {
+                description:
+                  'Switching protocols response with no response body'
+              },
+              '202': {
+                description: 'Success response with no response body'
               },
               '204': {
                 description: 'Success response with no response body'


### PR DESCRIPTION
Fixes #298.

Do not warn for missing `content` field for `101` and `202` responses because these protocols do not require response bodies.