### PR TITLE
test: add test for external $ref

### DIFF
--- a/test/plugins/validation/2and3/walker.test.js
+++ b/test/plugins/validation/2and3/walker.test.js
@@ -583,6 +583,37 @@ describe('validation plugin - semantic - spec walker', () => {
         expect(res.errors.length).toEqual(0);
         expect(res.warnings.length).toEqual(0);
       });
+
+      it('should not return a problem for a ref to another file', function() {
+        const spec = {
+          paths: {
+            '/foobar': {
+              get: {
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          allOf: [
+                            {
+                              $ref:
+                                'schemas/foobar.yml#/components/schemas/FoobarResourcesDocument'
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const res = validate({ jsSpec: spec, isOAS3: true }, config);
+        expect(res.errors.length).toEqual(0);
+        expect(res.warnings.length).toEqual(0);
+      });
     });
 
     describe('Ref siblings', () => {


### PR DESCRIPTION
Implements #301.

This test ensures that we do not return an error for $refs to external documents.

Because this test passes and I'm not able to reproduce the error outlined in #301, I did not provide an behavioral changes to the validator.