### PR TITLE
add configFileOverride to code validator

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,7 +7,7 @@ const spectralValidator = require('../spectral/utils/spectral-validator');
 const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 
-module.exports = async function(input, defaultMode = false) {
+module.exports = async function(input, defaultMode = false, configFileOverride = null) {
   // process the config file for the validations &
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset
@@ -18,7 +18,7 @@ module.exports = async function(input, defaultMode = false) {
   });
 
   try {
-    configObject = await config.get(defaultMode, chalk);
+    configObject = await config.get(defaultMode, chalk, configFileOverride);
     await spectralValidator.setup(spectral, null, configObject);
   } catch (err) {
     return Promise.reject(err);


### PR DESCRIPTION
Currently is it impossible to specify where the .validatorrc can be found with the codevalidator. This minor change will allow the user to specify where the .validaterc is.

Currently without this change is it difficult for us to use IBM validator as the .validaterc might not be in a parent repository. The use case in our case is that we want to upload both a open api spec and a .validaterc to a separate service that validates the open api spec. 