### PR TITLE
feat: prohibit sentence style summaries

### DIFF
--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -232,3 +232,16 @@ rules:
     - $.paths[*][*].requestBody.content[*].schema
     then:
       function: string-boundary
+  # ensure summary field does not have trailing comma
+  prohibit-summary-sentence-style:
+    description: 'Summary should not have a trailing period'
+    message: "{{description}}"
+    severity: error
+    formats: ["oas3"]
+    resolved: false
+    given:
+    - $.paths[*][*].summary
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: "\\.$"

--- a/src/spectral/rulesets/.defaultsForSpectral.yaml
+++ b/src/spectral/rulesets/.defaultsForSpectral.yaml
@@ -247,7 +247,7 @@ rules:
   prohibit-summary-sentence-style:
     description: 'Summary should not have a trailing period'
     message: "{{description}}"
-    severity: error
+    severity: warn
     formats: ["oas3"]
     resolved: false
     given:

--- a/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
+++ b/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
@@ -21,7 +21,7 @@ describe('spectral - summaries do not have trailing period', () => {
     };
 
     const result = await inCodeValidator(spec, true);
-    const relevantError = result.errors.find(
+    const relevantError = result.warnings.find(
       v => v.rule === 'prohibit-summary-sentence-style'
     );
     expect(relevantError).toBeUndefined();
@@ -48,7 +48,7 @@ describe('spectral - summaries do not have trailing period', () => {
 
     const validationResult = await inCodeValidator(spec, true);
     expect(validationResult.errors).not.toBeUndefined();
-    const error = validationResult.errors.find(
+    const error = validationResult.warnings.find(
       v => v.rule === 'prohibit-summary-sentence-style'
     );
     expect(error).not.toBeUndefined();
@@ -86,7 +86,7 @@ describe('spectral - summaries do not have trailing period', () => {
 
     const validationResult = await inCodeValidator(spec, true);
     expect(validationResult.errors).not.toBeUndefined();
-    const errors = validationResult.errors.filter(
+    const errors = validationResult.warnings.filter(
       v => v.rule === 'prohibit-summary-sentence-style'
     );
     expect(errors.length).toBe(2);

--- a/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
+++ b/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
@@ -90,28 +90,13 @@ describe('spectral - summaries do not have trailing period', () => {
       v => v.rule === 'prohibit-summary-sentence-style'
     );
     expect(errors.length).toBe(2);
-    const createTrailingPeriodErrorPath = [
+
+    expect(errors[0].path).toEqual([
       'paths',
       'createTrailingPeriod',
       'post',
       'summary'
-    ]
-      .sort()
-      .join('');
-    const createUserErrorPath = ['paths', 'createUser', 'post', 'summary']
-      .sort()
-      .join('');
-
-    let counter = 0;
-    for (let i = 0; i < errors.length; i++) {
-      const errorPath = errors[i].path.sort().join('');
-      if (
-        errorPath === createTrailingPeriodErrorPath ||
-        errorPath === createUserErrorPath
-      ) {
-        counter++;
-      }
-    }
-    expect(counter).toBe(2);
+    ]);
+    expect(errors[1].path).toEqual(['paths', 'createUser', 'post', 'summary']);
   });
 });

--- a/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
+++ b/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
@@ -1,0 +1,117 @@
+const inCodeValidator = require('../../../../src/lib');
+
+describe('spectral - summaries do not have trailing period', () => {
+  it('should not display error when summary does not have trailing period', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'Summary does not have trailing comma'
+      },
+      servers: {},
+      paths: {
+        createTrailingPeriod: {
+          post: {
+            operationId: 'createTrailingPeriod',
+            description: 'creates trailing period',
+            summary: 'No trailing period here'
+          }
+        }
+      }
+    };
+
+    const result = await inCodeValidator(spec, true);
+    const relevantError = result.errors.find(
+      v => v.rule === 'prohibit-summary-sentence-style'
+    );
+    expect(relevantError).toBeUndefined();
+  });
+
+  it('should display error when a summary has trailing period', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'Summary has trailing period'
+      },
+      servers: {},
+      paths: {
+        createTrailingPeriod: {
+          post: {
+            operationId: 'createTrailingPeriod',
+            description: 'creates trailing period',
+            summary: 'There is a trailing period here.'
+          }
+        }
+      }
+    };
+
+    const validationResult = await inCodeValidator(spec, true);
+    expect(validationResult.errors).not.toBeUndefined();
+    const error = validationResult.errors.find(
+      v => v.rule === 'prohibit-summary-sentence-style'
+    );
+    expect(error).not.toBeUndefined();
+    const errorPath = ['paths', 'createTrailingPeriod', 'post', 'summary']
+      .sort()
+      .join('');
+    expect(errorPath).toBe(error.path.sort().join(''));
+  });
+
+  it('should display errors when multiple summaries have trailing periods', async () => {
+    const spec = {
+      openapi: '3.0.0.',
+      info: {
+        version: '1.0.0.',
+        title: 'Summary has trailing period'
+      },
+      servers: {},
+      paths: {
+        createTrailingPeriod: {
+          post: {
+            operationId: 'createTrailingPeriod',
+            description: 'creates trailing period',
+            summary: 'Adds trailing period.'
+          }
+        },
+        createUser: {
+          post: {
+            operationId: 'createUser',
+            description: 'Creates a new user',
+            summary: 'Creates a new user.'
+          }
+        }
+      }
+    };
+
+    const validationResult = await inCodeValidator(spec, true);
+    expect(validationResult.errors).not.toBeUndefined();
+    const errors = validationResult.errors.filter(
+      v => v.rule === 'prohibit-summary-sentence-style'
+    );
+    expect(errors.length).toBe(2);
+    const createTrailingPeriodErrorPath = [
+      'paths',
+      'createTrailingPeriod',
+      'post',
+      'summary'
+    ]
+      .sort()
+      .join('');
+    const createUserErrorPath = ['paths', 'createUser', 'post', 'summary']
+      .sort()
+      .join('');
+
+    let counter = 0;
+    for (let i = 0; i < errors.length; i++) {
+      const errorPath = errors[i].path.sort().join('');
+      if (
+        errorPath === createTrailingPeriodErrorPath ||
+        errorPath === createUserErrorPath
+      ) {
+        counter++;
+      }
+    }
+    expect(counter).toBe(2);
+  });
+});

--- a/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
+++ b/test/spectral/tests/custom-rules/prohibit-sentence-style-summaries.test.js
@@ -48,14 +48,17 @@ describe('spectral - summaries do not have trailing period', () => {
 
     const validationResult = await inCodeValidator(spec, true);
     expect(validationResult.errors).not.toBeUndefined();
-    const error = validationResult.warnings.find(
+    const errors = validationResult.warnings.filter(
       v => v.rule === 'prohibit-summary-sentence-style'
     );
-    expect(error).not.toBeUndefined();
-    const errorPath = ['paths', 'createTrailingPeriod', 'post', 'summary']
-      .sort()
-      .join('');
-    expect(errorPath).toBe(error.path.sort().join(''));
+    expect(errors).not.toBeUndefined();
+    expect(errors.length).toBe(1);
+    expect(errors[0].path).toEqual([
+      'paths',
+      'createTrailingPeriod',
+      'post',
+      'summary'
+    ]);
   });
 
   it('should display errors when multiple summaries have trailing periods', async () => {


### PR DESCRIPTION
This PR brings that when `summary` field has a trailing period,
an error will be displayed.

The following example will result a validation error.
```json
{
  "openapi": "3.0.0",
  "info": {
    "version": "1.0.0",
    "title": "Summary does not have trailing period"
  },
  "servers": {},
  "paths": {
    "createTrailingPeriod": {
      "post": {
        "operationId": "createTrailingPeriod",
        "description": "creates trailing period",
        "summary": "Adds trailing period."
      }
    }
  }
}
```