### PR TITLE
feat: add configFileOverride to in-code validator

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,7 +7,7 @@ const spectralValidator = require('../spectral/utils/spectral-validator');
 const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 
-module.exports = async function(input, defaultMode = false) {
+module.exports = async function(input, defaultMode = false, configFileOverride = null) {
   // process the config file for the validations &
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset
@@ -18,7 +18,7 @@ module.exports = async function(input, defaultMode = false) {
   });
 
   try {
-    configObject = await config.get(defaultMode, chalk);
+    configObject = await config.get(defaultMode, chalk, configFileOverride);
     await spectralValidator.setup(spectral, null, configObject);
   } catch (err) {
     return Promise.reject(err);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,7 +7,11 @@ const spectralValidator = require('../spectral/utils/spectral-validator');
 const dedupFunction = require('../cli-validator/utils/noDeduplication');
 const { Spectral } = require('@stoplight/spectral');
 
-module.exports = async function(input, defaultMode = false, configFileOverride = null) {
+module.exports = async function(
+  input,
+  defaultMode = false,
+  configFileOverride = null
+) {
   // process the config file for the validations &
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset

--- a/test/cli-validator/tests/inCodeConfigFileOverride.test.js
+++ b/test/cli-validator/tests/inCodeConfigFileOverride.test.js
@@ -1,0 +1,25 @@
+const inCodeValidator = require('../../../src/lib');
+const config = require('../../../src/cli-validator/utils/processConfiguration');
+
+const defaultConfig = require('../../../src/.defaultsForValidator').defaults;
+
+const chalk = require('chalk');
+const yaml = require('yaml-js');
+const fs = require('fs');
+
+describe('configFileOverride', function() {
+  it('should utilize call processConfiguration.get with the correct argument', async function() {
+    const mockConfig = jest.spyOn(config, 'get').mockReturnValue(defaultConfig);
+
+    const content = fs
+      .readFileSync('./test/cli-validator/mockFiles/clean.yml')
+      .toString();
+    const spec = yaml.load(content);
+
+    const defaultMode = false;
+    const configFileOverride = 'config-file-name.yaml';
+    await inCodeValidator(spec, defaultMode, configFileOverride);
+
+    expect(mockConfig).toBeCalledWith(defaultMode, chalk, configFileOverride);
+  });
+});


### PR DESCRIPTION
Expands on #323.

Provides parameter for custom `configFileOverride` file.

Adds a test to ensure the `configFileOverride` is passed to `processConfiguration.get`.