### PR TITLE
fix: handle multi-file spec circular reference edge case

### DIFF
--- a/test/cli-validator/mockFiles/multi-file-spec/city.yaml
+++ b/test/cli-validator/mockFiles/multi-file-spec/city.yaml
@@ -1,0 +1,7 @@
+schema:
+  properties:
+    name:
+      type: string
+    primary_team:
+      type: object
+      $ref: ./sports-team.yaml#/schema

--- a/test/cli-validator/mockFiles/multi-file-spec/main.yaml
+++ b/test/cli-validator/mockFiles/multi-file-spec/main.yaml
@@ -10,3 +10,13 @@ paths:
             application/json:
               schema:
                 $ref: "./schema.yaml#/components/schemas/SchemaDef"
+  /circular_example:
+    get:
+      summary: Summary
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./schema.yaml#/components/schemas/CircularSchema"

--- a/test/cli-validator/mockFiles/multi-file-spec/schema.yaml
+++ b/test/cli-validator/mockFiles/multi-file-spec/schema.yaml
@@ -4,3 +4,10 @@ components:
   schemas:
     SchemaDef:
       type: object
+    CircularSchema:
+      type: object
+      properties:
+        id:
+          type: string
+        city:
+          $ref: ./city.yaml#/schema

--- a/test/cli-validator/mockFiles/multi-file-spec/sports-team.yaml
+++ b/test/cli-validator/mockFiles/multi-file-spec/sports-team.yaml
@@ -1,0 +1,7 @@
+schema:
+  properties:
+    name:
+      type: string
+    location:
+      type: object
+      $ref: ./city.yaml#/schema


### PR DESCRIPTION
The validator chokes on a specific scenario - when a multi-file spec
has schemas that reference each other in a ciruclar manner across files.
The bundler we use to put together mutli-file specs doesn't store the
reference in a helpful way, so there's not really a way to report the
location of the circular reference the way we do for other scenarios.
All we can really do is avoid crashing completely and send the user the
fully resolved path to the problematic schema that they will need to
trace manually.

A test is added to capture the behavior. This test case would exhibit the
crash without the fix.

Resolves #326 