### PR TITLE
fix: force bump jsonpointer to v5 to solve security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,8 +1569,15 @@
       "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.4.tgz",
       "integrity": "sha512-HFXOerq/6/6YisiTJwCOScwfNaXyGmX7ROAEUoKOrckK9+hJ/QLFm5EofQYEgX4aXkvHokLEbWBs4NMwZ6hQUw==",
       "requires": {
-        "jsonpointer": "^4.0.1",
+        "jsonpointer": "5.0.0",
         "leven": "^3.1.0"
+      },
+      "dependencies": {
+        "jsonpointer": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+          "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
+        }
       }
     },
     "@stoplight/json": {
@@ -3409,6 +3416,16 @@
             "kind-of": "^6.0.2"
           }
         }
+      }
+    },
+    "degenerator": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
+      "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+      "requires": {
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0"
       }
     },
     "del": {
@@ -6227,9 +6244,9 @@
       "integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A=="
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
     },
     "jsonschema": {
       "version": "1.4.0",
@@ -9733,32 +9750,26 @@
         "get-uri": "3",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "5",
-        "pac-resolver": "^4.1.0",
+        "pac-resolver": "5.0.0",
         "raw-body": "^2.2.0",
         "socks-proxy-agent": "5"
       },
       "dependencies": {
-        "degenerator": {
-          "version": "3.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/degenerator/-/degenerator-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdegenerator%2F-%2Fdegenerator-3.0.1.tgz",
-          "integrity": "sha1-fveOwMhXelREdzCN3x0tbojVH1s=",
-          "requires": {
-            "ast-types": "^0.13.2",
-            "escodegen": "^1.8.1",
-            "esprima": "^4.0.0",
-            "vm2": "^3.9.3"
-          }
-        },
         "pac-resolver": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
-          "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
-          "requires": {
-            "degenerator": "^3.0.1",
-            "ip": "^1.1.5",
-            "netmask": "^2.0.1"
-          }
+          "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA=="
         }
+      }
+    },
+    "pac-resolver": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
+      "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
+      "requires": {
+        "degenerator": "^2.2.0",
+        "ip": "^1.1.5",
+        "netmask": "^2.0.1"
       }
     },
     "package-json": {
@@ -12634,11 +12645,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "vm2": {
-      "version": "3.9.5",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-tmp-ace-fr-team-npm-virtual/vm2/-/vm2-3.9.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fvm2%2F-%2Fvm2-3.9.5.tgz",
-      "integrity": "sha1-UogESGC0u6zkQxAfzTvdsqCqJJY="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "testEnvironment": "node"
   },
   "resolutions": {
-    "pac-resolver": "5.0.0"
+    "pac-resolver": "5.0.0",
+    "jsonpointer": "5.0.0"
   }
 }


### PR DESCRIPTION
Use `npm-force-resolutions` to force jsonpointer to version 5.0.0 without spectral upgrade