### PR TITLE
build: run release script on node v14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ deploy:
   skip_cleanup: true
   script: npx -p @qiwi/semrel-toolkit multi-semrel --deps.release inherit
   on:
-    node: 12
+    node: 14
     branch: main


### PR DESCRIPTION
Bumping this up from v12 as semantic release now recommends
running with v14.