### PR TITLE
fix(string-boundary): include parameters defined at path level

### DIFF
--- a/packages/ruleset/src/rules/string-boundary.js
+++ b/packages/ruleset/src/rules/string-boundary.js
@@ -8,6 +8,8 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   given: [
+    '$.paths[*][parameters][*].schema',
+    '$.paths[*][parameters][*].content[*].schema',
     '$.paths[*][*][parameters][*].schema',
     '$.paths[*][*][parameters][*].content[*].schema',
     '$.paths[*][*].requestBody.content[*].schema'

--- a/packages/ruleset/test/string-boundary.test.js
+++ b/packages/ruleset/test/string-boundary.test.js
@@ -287,4 +287,37 @@ describe('Spectral rule: string-boundary', () => {
       '0'
     ]);
   });
+
+  it('should error if faulty string schema is defined at path level', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['/v1/movies'].parameters = [
+      {
+        name: 'filter',
+        in: 'query',
+        schema: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 15
+        }
+      }
+    ];
+
+    const results = await testRule(name, stringBoundary, testDocument);
+
+    expect(results).toHaveLength(1);
+
+    const validation = results[0];
+    expect(validation.code).toBe(name);
+    expect(validation.message).toBe(
+      'Should define a pattern for a valid string'
+    );
+    expect(validation.path).toStrictEqual([
+      'paths',
+      '/v1/movies',
+      'parameters',
+      '0',
+      'schema'
+    ]);
+    expect(validation.severity).toBe(severityCodes.warning);
+  });
 });


### PR DESCRIPTION
Currently, the custom string-boundary rule only validates parameters
defined at the operation level and request body properties. However,
parameters can also be defined at the path level. This commit adds
that scenario to the rule.

Resolves #352 

FYI @meem 