### PR TITLE
feat: enable spectral overrides

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-12-16T16:20:17Z",
+  "generated_at": "2022-01-13T15:24:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15704,7 +15704,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/spectral-formats": "^1.0.1",
@@ -16806,10 +16806,10 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "0.51.3",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "0.0.1",
+        "@ibm-cloud/openapi-ruleset": "0.1.1",
         "@stoplight/spectral-cli": "^6.1.0",
         "@stoplight/spectral-core": "^1.6.1",
         "@stoplight/spectral-parsers": "^1.0.1",
@@ -23182,7 +23182,7 @@
     "ibm-openapi-validator": {
       "version": "file:packages/validator",
       "requires": {
-        "@ibm-cloud/openapi-ruleset": "0.0.1",
+        "@ibm-cloud/openapi-ruleset": "0.1.1",
         "@stoplight/spectral-cli": "^6.1.0",
         "@stoplight/spectral-core": "^1.6.1",
         "@stoplight/spectral-parsers": "^1.0.1",

--- a/packages/validator/src/cli-validator/utils/custom-deduplication.js
+++ b/packages/validator/src/cli-validator/utils/custom-deduplication.js
@@ -1,0 +1,24 @@
+// this is the same as spectral's default deduplication function, except it
+// takes the message into account. the default implementation does not,
+// which leads it to ignore validations that come from the same rule (code)
+// and path.
+
+module.exports = function(rule, hash) {
+  let id = String(rule.code);
+
+  if (rule.path.length > 0) {
+    id += JSON.stringify(rule.path);
+  } else {
+    id += JSON.stringify(rule.range);
+  }
+
+  if (rule.source !== void 0) {
+    id += rule.source;
+  }
+
+  if (rule.message !== void 0) {
+    id += rule.message;
+  }
+
+  return hash(id);
+};

--- a/packages/validator/src/cli-validator/utils/no-deduplication.js
+++ b/packages/validator/src/cli-validator/utils/no-deduplication.js
@@ -1,7 +1,0 @@
-let globalId = 0;
-
-// assigns a unique id to each error
-module.exports = function() {
-  globalId += 1;
-  return globalId;
-};

--- a/packages/validator/src/spectral/spectral-validator.js
+++ b/packages/validator/src/spectral/spectral-validator.js
@@ -5,7 +5,7 @@ const {
 const ibmRuleset = require('@ibm-cloud/openapi-ruleset');
 const MessageCarrier = require('../plugins/utils/message-carrier');
 const config = require('../cli-validator/utils/process-configuration');
-const dedupFunction = require('../cli-validator/utils/no-deduplication');
+const dedupFunction = require('../cli-validator/utils/custom-deduplication');
 
 const parseResults = function(results, debug) {
   const messages = new MessageCarrier();

--- a/packages/validator/test/cli-validator/mock-files/oas3/component-path-example.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/component-path-example.yaml
@@ -1,0 +1,139 @@
+openapi: "3.0.0"
+info:
+  description: Sample API definition with one problem in two instances
+  version: 1.0.0
+  title: Character Supply
+  license:
+    name: MIT
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  contact:
+    email: "apiteam@swagger.io"
+servers:
+  - url: http://chars.swagger.io/v1
+tags:
+  - name: letters
+    description: A letter
+  - name: special_characters
+    description: A special character
+paths:
+  /letters:
+    get:
+      summary: List all letters
+      description: List all letters
+      operationId: list_letters
+      tags:
+        - letters
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            maximum: 100
+        - name: offset
+          in: query
+          description: Offset of first element to return in results.
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          $ref: "#/components/responses/StringsResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /special_characters:
+    get:
+      summary: List all special characters
+      description: List all special characters
+      operationId: list_special_characters
+      tags:
+        - special_characters
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            maximum: 100
+        - name: offset
+          in: query
+          description: Offset of first element to return in results.
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          $ref: "#/components/responses/StringsResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  responses:
+    StringsResponse:
+      description: not very good
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ListOfCharacters"
+  schemas:
+    ListOfCharacters:
+      description: object holding a list of strings
+      type: object
+      required:
+        - chars
+        - limit
+        - offset
+      properties:
+        chars:
+          type: array
+          description: all the characters
+          items:
+            type: string
+        limit:
+          type: integer
+          description: for pagination
+        offset:
+          type: integer
+          description: for pagination
+      example:
+        chars:
+          - a
+          - b
+          - c
+        limit: 100
+        offset: 10
+    Error:
+      description:
+        An error in processing a service request
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: "code property"
+        message:
+          type: string
+          description: "message property"
+          pattern: '^[a-zA-Z0-9_ ]*$'
+          minLength: 1
+          maxLength: 300
+      example:
+        code: 123
+        message: "error occurred"

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -377,12 +377,14 @@ describe('test expected output - OpenAPI 3', function() {
 
   it('should include the path to the component (if it exists) when in verbose mode', async function() {
     const program = {};
-    program.args = ['./test/cli-validator/mock-files/oas3/testoneof.yaml'];
+    program.args = [
+      './test/cli-validator/mock-files/oas3/component-path-example.yaml'
+    ];
     program.default_mode = true;
     program.verbose = 1;
 
     const exitCode = await commandLineValidator(program);
-    expect(exitCode).toEqual(1);
+    expect(exitCode).toEqual(0);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     const allText = capturedText.join();
@@ -392,26 +394,27 @@ describe('test expected output - OpenAPI 3', function() {
 
   it('should include the path to the component (if it exists) when in verbose mode and json mode', async function() {
     const program = {};
-    program.args = ['./test/cli-validator/mock-files/oas3/testoneof.yaml'];
+    program.args = [
+      './test/cli-validator/mock-files/oas3/component-path-example.yaml'
+    ];
     program.default_mode = true;
     program.verbose = 1;
     program.json = true;
 
     const exitCode = await commandLineValidator(program);
-    expect(exitCode).toEqual(1);
+    expect(exitCode).toEqual(0);
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     const jsonOutput = JSON.parse(capturedText);
-    const warningToCheck = jsonOutput.warnings[3];
+    const warningToCheck = jsonOutput.warnings[0];
 
-    expect(warningToCheck.rule).toEqual('response-example-provided');
+    expect(warningToCheck.rule).toEqual('pagination_style');
     expect(warningToCheck.componentPath).toEqual([
       'components',
-      'responses',
-      'Ok',
-      'content',
-      'application/json'
+      'schemas',
+      'ListOfCharacters',
+      'properties'
     ]);
-    expect(warningToCheck.componentLine).toEqual(8);
+    expect(warningToCheck.componentLine).toEqual(101);
   });
 });

--- a/packages/validator/test/cli-validator/tests/info-and-hint.test.js
+++ b/packages/validator/test/cli-validator/tests/info-and-hint.test.js
@@ -35,7 +35,7 @@ describe('test info and hint rules - OAS3', function() {
     expect(jsonOutput['errors'].length).toBe(4);
 
     // Verify warnings
-    expect(jsonOutput['warnings'].length).toBe(37);
+    expect(jsonOutput['warnings'].length).toBe(16);
 
     // Verify infos
     expect(jsonOutput['infos'].length).toBe(1);


### PR DESCRIPTION
This commit updates the format in which we provide the document data to spectral,
which in turns allows end users to take advantage of spectral "overrides". This
feature allows users to ignore specific parts of their document if they need,
rather than turning off entire rules.

In doing this, we give spectral greater control over the validations it returns.
This allows us to take advantage of another spectral feature - automatically
resolving component paths. Before, if a schema contained a problem and two references
pointed to it, some rules would return two validations pointing to the reference
instances. Now, the validation returns one validation, pointing to the base schema.
This will result in some output changes for some users but it should be a positive
change overall.

This commit also adds a customized verson of spectral's deduplication logic to prevent
the resolved component paths from being duplicated.