### PR TITLE
fix: omit lodash.set vuln until spectral approves fix

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -10,5 +10,9 @@
     {
         "cve": "SNYK-JS-JSONSCHEMA-1920922",
         "alwaysOmit": true
+    },
+    {
+        "cve": "SNYK-JS-LODASHSET-1320032",
+        "alwaysOmit": true
     }
 ]


### PR DESCRIPTION
Snyk vulnerability `SNYK-JS-LODASHSET-1320032` should be ignored until spectral approves fix mentioned here: https://github.com/stoplightio/spectral/issues/2017