### PR TITLE
fix: add supported formats to invalid_type_format_pair rule

### DIFF
--- a/packages/validator/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/packages/validator/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -194,11 +194,16 @@ function typeFormatErrors(obj, path, isOAS3, messages, checkStatus) {
   const validIntegerFormats = ['int32', 'int64'];
   const validNumberFormats = ['float', 'double'];
   const validStringFormats = [
-    'byte',
     'binary',
+    'byte',
+    'crn',
     'date',
     'date-time',
-    'password'
+    'email',
+    'identifier',
+    'password',
+    'url',
+    'uuid'
   ];
   const validTypes = [
     'integer',

--- a/packages/validator/test/cli-validator/mock-files/oas3/test-formats.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/test-formats.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.0
+servers:
+  - url: https://typeformats.com/api
+paths:
+  /formats:
+    post:
+      summary: test formats
+      description: exercise different format values
+      operationId: test_formats
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: body with some properties that use various formats
+              type: object
+              properties:
+                s_binary:
+                  type: string
+                  format: binary
+                s_byte:
+                  type: string
+                  format: byte
+                s_crn:
+                  type: string
+                  format: crn
+                s_date:
+                  type: string
+                  format: date
+                s_datetime:
+                  type: string
+                  format: date-time
+                s_email:
+                  type: string
+                  format: email
+                s_identifier:
+                  type: string
+                  format: identifier
+                s_password:
+                  type: string
+                  format: password
+                s_url:
+                  type: string
+                  format: url
+                s_uuid:
+                  type: string
+                  format: uuid
+                s_invalid:
+                  type: string
+                  format: bad-one
+                i_int32:
+                  type: integer
+                  format: int32
+                i_int64:
+                  type: integer
+                  format: int64
+                i_invalid:
+                  type: integer
+                  format: bad-one
+                n_float:
+                  type: number
+                  format: float
+                n_double:
+                  type: number
+                  format: double
+                n_invalid:
+                  type: number
+                  format: bad-one
+      responses:
+        '204':
+          description: response ok

--- a/packages/validator/test/cli-validator/mock-files/oas3/testoneof.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/testoneof.yaml
@@ -32,7 +32,7 @@ components:
           - description: 'foo type'
         - anyOf:
           - type: string
-            format: url
+            format: bad_format
             description: 'url string'
             pattern: 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
             minLength: 0

--- a/packages/validator/test/plugins/validation/2and3/schema-ibm.test.js
+++ b/packages/validator/test/plugins/validation/2and3/schema-ibm.test.js
@@ -1163,7 +1163,25 @@ describe('validation plugin - semantic - schema-ibm - OpenAPI 3', () => {
       'Invalid type. Valid types are: integer, number, string, boolean, object, array.'
     );
     expect(res.errors[1].message).toEqual(
-      'Schema of type string should use one of the following formats: byte, binary, date, date-time, password.'
+      'Schema of type string should use one of the following formats: binary, byte, crn, date, date-time, email, identifier, password, url, uuid.'
+    );
+  });
+
+  it('should return an error for invalid format values', () => {
+    const spec = yaml.safeLoad(
+      fs.readFileSync('test/cli-validator/mock-files/oas3/test-formats.yaml')
+    );
+
+    const res = validate({ jsSpec: spec, isOAS3: true }, config);
+    expect(res.errors.length).toEqual(3);
+    expect(res.errors[0].message).toEqual(
+      'Schema of type string should use one of the following formats: binary, byte, crn, date, date-time, email, identifier, password, url, uuid.'
+    );
+    expect(res.errors[1].message).toEqual(
+      'Schema of type integer should use one of the following formats: int32, int64.'
+    );
+    expect(res.errors[2].message).toEqual(
+      'Schema of type number should use one of the following formats: float, double.'
     );
   });
 


### PR DESCRIPTION
This commit adds "crn", "email", "identifier", "url", and "uuid"
to the list of allowable format values for a string schema,
and adds a new test related to type/format pairs.