### PR TITLE
feat: add 'description-mentions-json' spectral rule and remove old rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ The supported rules are described below:
 | snake_case_only             | Flag any property with a `name` that is not lower snake case.                 | shared   |
 | no_schema_description       | Flag any schema without a `description` field.                                | shared   |
 | no_property_description     | Flag any schema that contains a 'property' without a `description` field.     | shared   |
-| description_mentions_json   | Flag any schema with a 'property' description that mentions the word 'JSON'.  | shared   |
 | array_of_arrays             | Flag any schema with a 'property' of type `array` with items of type `array`. | shared   |
 | inconsistent_property_type  | Flag any properties that have the same name but an inconsistent type.         | shared   |
 | property_case_convention    | Flag any property with a `name` that does not follow a given case convention. snake_case_only must be 'off' to use. | shared |
@@ -475,7 +474,6 @@ The default values for each rule are described below.
 | snake_case_only             | off     |
 | no_schema_description       | warning |
 | no_property_description     | warning |
-| description_mentions_json   | warning |
 | array_of_arrays             | warning |
 | inconsistent_property_type  | warning, [code, default, type, value]]<br>(list of property names to exclude) |
 | property_case_convention    | error, lower_snake_case |

--- a/packages/ruleset/src/functions/description-mentions-json.js
+++ b/packages/ruleset/src/functions/description-mentions-json.js
@@ -1,0 +1,26 @@
+const { validateSubschemas } = require('../utils');
+
+module.exports = function(schema, _opts, { path }) {
+  return validateSubschemas(schema, path, descriptionMentionsJSON);
+};
+
+const errorMsg = 'Schema descriptions should avoid mentioning "JSON"';
+
+function descriptionMentionsJSON(schema, path) {
+  const results = [];
+
+  if (
+    schema.description &&
+    schema.description
+      .toString()
+      .toLowerCase()
+      .includes('json')
+  ) {
+    results.push({
+      message: errorMsg,
+      path
+    });
+  }
+
+  return results;
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -1,5 +1,6 @@
 const arrayOfArrays = require('./array-of-arrays');
 const checkMajorVersion = require('./check-major-version');
+const descriptionMentionsJSON = require('./description-mentions-json');
 const discriminator = require('./discriminator');
 const errorResponseSchema = require('./error-response-schema');
 const requiredProperty = require('./required-property');
@@ -12,6 +13,7 @@ const validTypeFormat = require('./valid-type-format');
 module.exports = {
   arrayOfArrays,
   checkMajorVersion,
+  descriptionMentionsJSON,
   discriminator,
   errorResponseSchema,
   requiredProperty,

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -92,6 +92,7 @@ module.exports = {
     'array-of-arrays': ibmRules.arrayOfArrays,
     'content-entry-contains-schema': ibmRules.contentEntryContainsSchema,
     'content-entry-provided': ibmRules.contentEntryProvided,
+    'description-mentions-json': ibmRules.descriptionMentionsJSON,
     discriminator: ibmRules.discriminator,
     'examples-name-contains-space': ibmRules.examplesNameContainsSpace,
     'ibm-content-type-is-specific': ibmRules.ibmContentTypeIsSpecific,

--- a/packages/ruleset/src/rules/description-mentions-json.js
+++ b/packages/ruleset/src/rules/description-mentions-json.js
@@ -1,0 +1,15 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { descriptionMentionsJSON } = require('../functions');
+const { schemas } = require('../collections');
+
+module.exports = {
+  description: 'Schema descriptions should avoid mentioning "JSON"',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'warn',
+  formats: [oas2, oas3],
+  resolved: true,
+  then: {
+    function: descriptionMentionsJSON
+  }
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -1,6 +1,7 @@
 const arrayOfArrays = require('./array-of-arrays');
 const contentEntryContainsSchema = require('./content-entry-contains-schema');
 const contentEntryProvided = require('./content-entry-provided');
+const descriptionMentionsJSON = require('./description-mentions-json');
 const discriminator = require('./discriminator');
 const examplesNameContainsSpace = require('./examples-name-contains-space');
 const ibmContentTypeIsSpecific = require('./ibm-content-type-is-specific');
@@ -22,6 +23,7 @@ module.exports = {
   arrayOfArrays,
   contentEntryContainsSchema,
   contentEntryProvided,
+  descriptionMentionsJSON,
   discriminator,
   examplesNameContainsSpace,
   ibmContentTypeIsSpecific,

--- a/packages/ruleset/test/description-mentions-json.test.js
+++ b/packages/ruleset/test/description-mentions-json.test.js
@@ -1,0 +1,265 @@
+const { descriptionMentionsJSON } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = descriptionMentionsJSON;
+const ruleId = 'description-mentions-json';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg = 'Schema descriptions should avoid mentioning "JSON"';
+
+describe('Spectral rule: description-mentions-json', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Inline request body schema description mentions JSON', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.requestBody.content = {
+        'text/html': {
+          schema: {
+            type: 'string',
+            description: 'Not a JSON object.'
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path).toStrictEqual([
+        'paths',
+        '/v1/drinks',
+        'post',
+        'requestBody',
+        'content',
+        'text/html',
+        'schema'
+      ]);
+    });
+
+    it('Named schema description mentions JSON', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['Drink'].description =
+        'This is a JSON object.';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+      for (const result of results) {
+        expect(result.code).toBe(ruleId);
+        expect(result.message).toBe(expectedMsg);
+        expect(result.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path).toStrictEqual([
+        'paths',
+        '/v1/drinks',
+        'post',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema'
+      ]);
+      expect(results[1].path).toStrictEqual([
+        'paths',
+        '/v1/drinks',
+        'post',
+        'responses',
+        '201',
+        'content',
+        'application/json',
+        'schema'
+      ]);
+    });
+
+    it('Inline response schema description mentions JSON', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post.responses['400'].content[
+        'application/json'
+      ].schema.description = 'A JSON object containing the error details.';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path).toStrictEqual([
+        'paths',
+        '/v1/movies',
+        'post',
+        'responses',
+        '400',
+        'content',
+        'application/json',
+        'schema'
+      ]);
+    });
+
+    it('Re-used oneOf child schema description mentions JSON', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Set description to trigger a rule violation.
+      testDocument.components.schemas['Soda'].description =
+        'A jSoN object that describes a soda.';
+
+      // Add another (non-oneOf) reference to the Soda schema.
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        $ref: '#/components/schemas/Soda'
+      };
+
+      // We should get back a warning ONLY due to the Soda reference in the response (not the oneOf).
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+      for (const result of results) {
+        expect(result.code).toBe(ruleId);
+        expect(result.message).toBe(expectedMsg);
+        expect(result.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path).toStrictEqual([
+        'paths',
+        '/v1/drinks',
+        'post',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+        'oneOf',
+        '1'
+      ]);
+      expect(results[1].path).toStrictEqual([
+        'paths',
+        '/v1/drinks',
+        'post',
+        'responses',
+        '201',
+        'content',
+        'application/json',
+        'schema'
+      ]);
+    });
+
+    it('Re-used string schema description mentions JSON', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['IdString'].description =
+        'This is NOT a JSON object!';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(3);
+      for (const result of results) {
+        expect(result.code).toBe(ruleId);
+        expect(result.message).toBe(expectedMsg);
+        expect(result.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path).toStrictEqual([
+        'paths',
+        '/v1/movies',
+        'post',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'id'
+      ]);
+      expect(results[1].path).toStrictEqual([
+        'paths',
+        '/v1/movies',
+        'post',
+        'responses',
+        '201',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'id'
+      ]);
+      expect(results[2].path).toStrictEqual([
+        'paths',
+        '/v1/movies',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'movies',
+        'items',
+        'properties',
+        'id'
+      ]);
+    });
+
+    it('Property named like x-* has description that mentions JSON', async () => {
+      // This testcase is added here because the old rule (incorrectly) filtered
+      // out properties named like "x-*", purportedly to avoid giving warnings
+      // for extensions.  Well, a schema property named "x-*" is technically
+      // NOT an extension, so the rule should in fact process properties
+      // named like "x-*" just like any other properties.
+
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['Movie'].properties[
+        'x-not-an-extension'
+      ] = {
+        type: 'string',
+        description: 'This is not a JsOn object!'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(3);
+      for (const result of results) {
+        expect(result.code).toBe(ruleId);
+        expect(result.message).toBe(expectedMsg);
+        expect(result.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path).toStrictEqual([
+        'paths',
+        '/v1/movies',
+        'post',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'x-not-an-extension'
+      ]);
+      expect(results[1].path).toStrictEqual([
+        'paths',
+        '/v1/movies',
+        'post',
+        'responses',
+        '201',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'x-not-an-extension'
+      ]);
+      expect(results[2].path).toStrictEqual([
+        'paths',
+        '/v1/movies',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'movies',
+        'items',
+        'properties',
+        'x-not-an-extension'
+      ]);
+    });
+  });
+});

--- a/packages/validator/src/.defaultsForValidator.js
+++ b/packages/validator/src/.defaultsForValidator.js
@@ -61,7 +61,6 @@ const defaults = {
     'schemas': {
       'invalid_type_format_pair': 'error',
       'snake_case_only': 'off',
-      'description_mentions_json': 'warning',
       'inconsistent_property_type': ['warning', ['code', 'default', 'type', 'value']],
       'property_case_convention': ['error', 'lower_snake_case'],
       'property_case_collision': 'error',
@@ -113,7 +112,8 @@ const deprecated = {
   'undefined_required_properties': 'missing-required-property (Spectral rule)',
   'array_of_arrays': 'array-of-arrays (Spectral rule)',
   'no_schema_description': 'schema-description (Spectral rule)',
-  'no_property_description': 'schema-description (Spectral rule)'
+  'no_property_description': 'schema-description (Spectral rule)',
+  'description_mentions_json': 'description-mentions-json (Spectral rule)'
 };
 
 const configOptions = {

--- a/packages/validator/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
+++ b/packages/validator/src/plugins/validation/2and3/semantic-validators/schema-ibm.js
@@ -11,14 +11,13 @@
 // no_property_description: [REMOVED]
 // Properties within schema objects should have descriptions
 
-// description_mentions_json:
+// description_mentions_json: [REMOVED]
 // Schema property descriptions should not state that model will be a JSON object
 
 // array_of_arrays: [REMOVED]
 // Schema properties that are arrays should avoid having items that are also arrays
 
 const forIn = require('lodash/forIn');
-const includes = require('lodash/includes');
 const { checkCase, walk } = require('../../../utils');
 const MessageCarrier = require('../../../utils/message-carrier');
 
@@ -88,8 +87,6 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
 
   schemas.forEach(({ schema, path }) => {
     generateFormatErrors(schema, path, config, isOAS3, messages);
-
-    generateDescriptionWarnings(schema, path, config, isOAS3, messages);
 
     const checkStatus = config.snake_case_only;
     if (checkStatus !== 'off') {
@@ -220,71 +217,6 @@ function typeFormatErrors(obj, path, isOAS3, messages, checkStatus) {
       }
       break;
   }
-}
-
-// http://watson-developer-cloud.github.io/api-guidelines/swagger-coding-style#models
-function generateDescriptionWarnings(
-  schema,
-  contextPath,
-  config,
-  isOAS3,
-  messages
-) {
-  // determine if this is a top-level schema
-  const isTopLevelSchema = isOAS3
-    ? contextPath.length === 3 &&
-      contextPath[0] === 'components' &&
-      contextPath[1] === 'schemas'
-    : contextPath.length === 2 && contextPath[0] === 'definitions';
-
-  // Check description in schema only for "top level" schema
-  const hasDescription =
-    schema.description && schema.description.toString().trim().length;
-  if (isTopLevelSchema && !hasDescription) {
-    // messages.addMessage(
-    //   contextPath,
-    //   'Schema must have a non-empty description.',
-    //   config.no_schema_description,
-    //   'no_schema_description'
-    // );
-  }
-
-  if (!schema.properties) {
-    return;
-  }
-
-  // verify that every property of the model has a description
-  forIn(schema.properties, (property, propName) => {
-    // if property is defined by a ref, it does not need a description
-    if (!property || property.$ref || propName.slice(0, 2) === 'x-') return;
-
-    // if property has a allOf, anyOf, or oneOf schema, it does not needs a description
-    if (property.allOf || property.anyOf || property.oneOf) return;
-
-    const path = contextPath.concat(['properties', propName, 'description']);
-
-    const hasDescription =
-      property.description && property.description.toString().trim().length;
-    if (!hasDescription) {
-      // messages.addMessage(
-      //   path,
-      //   'Schema properties must have a description with content in it.',
-      //   config.no_property_description,
-      //   'no_property_description'
-      // );
-    } else {
-      // if the property does have a description, "Avoid describing a model as a 'JSON object' since this will be incorrect for some SDKs."
-      const mentionsJSON = includes(property.description.toLowerCase(), 'json');
-      if (mentionsJSON) {
-        messages.addMessage(
-          path,
-          'Not all languages use JSON, so descriptions should not state that the model is a JSON object.',
-          config.description_mentions_json,
-          'description_mentions_json'
-        );
-      }
-    }
-  });
 }
 
 // https://pages.github.ibm.com/CloudEngineering/api_handbook/design/terminology.html#formatting

--- a/packages/validator/test/plugins/validation/2and3/schema-ibm.test.js
+++ b/packages/validator/test/plugins/validation/2and3/schema-ibm.test.js
@@ -434,51 +434,6 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
     expect(res.warnings.length).toEqual(0);
   });
 
-  it('should return an error when JSON is in the description', () => {
-    const spec = {
-      paths: {
-        '/pets': {
-          get: {
-            parameters: [
-              {
-                name: 'good_name',
-                in: 'body',
-                description: 'Not a bad description',
-                schema: {
-                  type: 'object',
-                  properties: {
-                    any_object: {
-                      type: 'object',
-                      description: 'it is not always a JSON object'
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        }
-      }
-    };
-
-    const res = validate({ jsSpec: spec }, config);
-    expect(res.errors.length).toEqual(0);
-    expect(res.warnings.length).toEqual(1);
-    expect(res.warnings[0].path).toEqual([
-      'paths',
-      '/pets',
-      'get',
-      'parameters',
-      '0',
-      'schema',
-      'properties',
-      'any_object',
-      'description'
-    ]);
-    expect(res.warnings[0].message).toEqual(
-      'Not all languages use JSON, so descriptions should not state that the model is a JSON object.'
-    );
-  });
-
   it('should not die when a schema contains a description property', () => {
     const spec = {
       definitions: {
@@ -497,37 +452,6 @@ describe('validation plugin - semantic - schema-ibm - Swagger 2', () => {
               readOnly: true,
               description: 'The description of the notice'
             }
-          }
-        }
-      }
-    };
-
-    const res = validate({ jsSpec: spec }, config);
-    expect(res.errors.length).toEqual(0);
-    expect(res.warnings.length).toEqual(0);
-  });
-
-  it('should not return an error when JSON is in the description of a vendor extension', () => {
-    const spec = {
-      paths: {
-        '/pets': {
-          get: {
-            parameters: [
-              {
-                name: 'good_name',
-                in: 'body',
-                description: 'Not a bad description',
-                schema: {
-                  type: 'object',
-                  properties: {
-                    'x-vendor-anyObject': {
-                      type: 'object',
-                      description: 'it is not always a JSON object'
-                    }
-                  }
-                }
-              }
-            ]
           }
         }
       }


### PR DESCRIPTION
This commit adds support for a new spectral-style rule
with id 'description-mentions-json' and removes the old rule
'description_mentions_json'.
Also included are changes to tests in the validator package
to reflect the removal of the old rule.