### PR TITLE
fix: display details for 'Error running Nimma' errors

### DIFF
--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -259,8 +259,9 @@ const processInput = async function(program) {
       spectralResults = await spectral.run(doc);
     } catch (err) {
       printError(chalk, 'There was a problem with spectral.', getError(err));
-      if (debug) {
-        console.log(err.stack);
+      if (debug || err.message === 'Error running Nimma') {
+        printError(chalk, 'Additional error details:');
+        console.log(err);
       }
       // this check can be removed once we support spectral overrides
       if (err.message.startsWith('Document must have some source assigned.')) {


### PR DESCRIPTION
This commit makes a small change to our exception handling
so that if spectral returns a "Error running Nimma" exception,
we'll print out the details of the exception even if debug is
not currently enabled.