### PR TITLE
Minor fixes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-node_modules
-.DS_Store
-npm-debug.log*
-.eslintcache
-.validaterc

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ Type: `boolean`
 Default: `false`
 If set to true, the validator will ignore the `.validaterc` file and will use the [configuration defaults](#default-values).
 
+###### configFileOverride
+Type: `string`
+Default: `null`
+A path to a custom `.validaterc` file. Note that we are in the process of moving all of our configuration to Spectral. Once the transition is complete, this option will instead provide a path to a custom Spectral config file.
+
+###### debug
+Type: `boolean`
+Default: `false`
+If set to true, the validator will log additional debug information during execution.
+
 #### Validation results
 The Promise returned from the validator resolves into a JSON object. The structure of the object is:
 ```

--- a/packages/validator/src/cli-validator/utils/process-configuration.js
+++ b/packages/validator/src/cli-validator/utils/process-configuration.js
@@ -211,15 +211,6 @@ const getConfigObject = async function(defaultMode, chalk, configFileOverride) {
   // if the user does not have a config file, run in default mode and warn them
   // (findUp returns null if it does not find a file)
   if (configFile === null && !defaultMode) {
-    console.log(
-      '\n' +
-        chalk.yellow('[Warning]') +
-        ` No ${chalk.underline(
-          '.validaterc'
-        )} file found. The validator will run in ` +
-        chalk.bold.cyan('default mode.')
-    );
-    console.log(`To configure the validator, create a .validaterc file.`);
     defaultMode = true;
   }
 

--- a/packages/validator/src/lib/index.js
+++ b/packages/validator/src/lib/index.js
@@ -11,7 +11,8 @@ const validator = require('../cli-validator/utils/validator');
 module.exports = async function(
   input,
   defaultMode = false,
-  configFileOverride = null
+  configFileOverride = null,
+  debug = false
 ) {
   // process the config file for the validations &
   // create an instance of spectral & load the spectral ruleset, either a user's
@@ -28,7 +29,7 @@ module.exports = async function(
   const swagger = await buildSwaggerObject(input);
 
   try {
-    const spectral = await spectralValidator.setup();
+    const spectral = await spectralValidator.setup(null, debug, chalk);
     spectralResults = await spectral.run(input);
   } catch (err) {
     return Promise.reject(err);


### PR DESCRIPTION
First commit: remove .npmignore file in favor of .gitignore

If there is no .npmignore file, NPM will use the patterns within the
.gitignore instead. Since we don't want anything in the .gitignore file
to be published and there is nothing outside the .gitignore that we don't
want published, it seems best to rely on the .gitignore file for now.

Second commit: add debug option to programmatic validator api

This allows those using the in-code validator to print out debugging statements
that would otherwise be swallowed.

Also, remove warning about running the validator in default mode. We no longer
want to be pushing that method of configuration and it is confusing when printed
alongside Spectral config file warnings.