### PR TITLE
feat: add new 'parameter-default' rule and remove old rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ The supported rules are described below:
 ##### parameters
 | Rule                        | Description                                                              | Spec   |
 | --------------------------- | ------------------------------------------------------------------------ | ------ |
-| required_param_has_default  | Flag any required parameter that specifies a default value.              | shared |
 | no_parameter_description    | Flag any parameter that does not contain a `description` field.          | shared |
 | param_name_case_convention  | Flag any parameter with a `name` field that does not follow a given case convention. | shared |
 | invalid_type_format_pair    | Flag any parameter that does not follow the [data type/format rules.][2] | shared |
@@ -447,7 +446,6 @@ The default values for each rule are described below.
 | content_type_parameter      | error   |
 | accept_type_parameter       | error   |
 | authorization_parameter     | warning |
-| required_param_has_default  | warning |
 
 ###### paths
 | Rule                        | Default |

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -3,6 +3,7 @@ const checkMajorVersion = require('./check-major-version');
 const descriptionMentionsJSON = require('./description-mentions-json');
 const discriminator = require('./discriminator');
 const errorResponseSchema = require('./error-response-schema');
+const parameterDefault = require('./parameter-default');
 const parameterDescription = require('./parameter-description');
 const propertyCaseCollision = require('./property-case-collision');
 const propertyCaseConvention = require('./property-case-convention');
@@ -20,6 +21,7 @@ module.exports = {
   descriptionMentionsJSON,
   discriminator,
   errorResponseSchema,
+  parameterDefault,
   parameterDescription,
   propertyCaseCollision,
   propertyCaseConvention,

--- a/packages/ruleset/src/functions/parameter-default.js
+++ b/packages/ruleset/src/functions/parameter-default.js
@@ -1,0 +1,32 @@
+const { isSdkExcluded } = require('../utils');
+
+module.exports = function(param, _opts, { path }) {
+  return parameterDefault(param, path);
+};
+
+const errorMsg = 'Required parameter should not define a default value';
+
+function parameterDefault(param, path) {
+  const results = [];
+
+  if (!isSdkExcluded(param) && param.required && paramHasDefault(param)) {
+    results.push({
+      message: errorMsg,
+      path
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Returns true if 'param' has a default value defined in it.
+ * This needs to take into account the oas2 flavor of a parameter
+ * where the default value would be defined directly on the param object,
+ * and the oas3 flavor where it is defined inside the param's schema.
+ */
+function paramHasDefault(param) {
+  return param.schema
+    ? param.schema.default !== undefined
+    : param.default !== undefined;
+}

--- a/packages/ruleset/src/functions/parameter-description.js
+++ b/packages/ruleset/src/functions/parameter-description.js
@@ -1,9 +1,11 @@
+const { isSdkExcluded } = require('../utils');
+
 module.exports = function(param, _opts, { path }) {
   return parameterDescription(param, path);
 };
 
 function parameterDescription(param, path) {
-  if (!shouldSkip(param) && !paramHasDescription(param)) {
+  if (!isSdkExcluded(param) && !paramHasDescription(param)) {
     return [
       {
         message: 'Parameter should have a non-empty description',
@@ -17,8 +19,4 @@ function parameterDescription(param, path) {
 
 function paramHasDescription(param) {
   return param.description && param.description.toString().trim().length;
-}
-
-function shouldSkip(param) {
-  return param['x-sdk-exclude'] === true;
 }

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -100,6 +100,7 @@ module.exports = {
     'ibm-sdk-operations': ibmRules.ibmSdkOperations,
     'major-version-in-path': ibmRules.majorVersionInPath,
     'missing-required-property': ibmRules.missingRequiredProperty,
+    'parameter-default': ibmRules.parameterDefault,
     'parameter-description': ibmRules.parameterDescription,
     'parameter-schema-or-content': ibmRules.parameterSchemaOrContent,
     'prohibit-summary-sentence-style': ibmRules.prohibitSummarySentenceStyle,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -9,6 +9,7 @@ const ibmErrorContentTypeIsJson = require('./ibm-error-content-type-is-json');
 const ibmSdkOperations = require('./ibm-sdk-operations');
 const majorVersionInPath = require('./major-version-in-path');
 const missingRequiredProperty = require('./missing-required-property');
+const parameterDefault = require('./parameter-default');
 const parameterDescription = require('./parameter-description');
 const parameterSchemaOrContent = require('./parameter-schema-or-content');
 const prohibitSummarySentenceStyle = require('./prohibit-summary-sentence-style');
@@ -35,6 +36,7 @@ module.exports = {
   ibmSdkOperations,
   majorVersionInPath,
   missingRequiredProperty,
+  parameterDefault,
   parameterDescription,
   parameterSchemaOrContent,
   prohibitSummarySentenceStyle,

--- a/packages/ruleset/src/rules/parameter-default.js
+++ b/packages/ruleset/src/rules/parameter-default.js
@@ -1,0 +1,15 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { parameterDefault } = require('../functions');
+const { parameters } = require('../collections');
+
+module.exports = {
+  description: 'Required parameters should not define a default value',
+  message: '{{error}}',
+  given: parameters,
+  severity: 'warn',
+  formats: [oas2, oas3],
+  resolved: true,
+  then: {
+    function: parameterDefault
+  }
+};

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -1,6 +1,7 @@
 const checkCompositeSchemaForConstraint = require('./check-composite-schema-for-constraint');
 const checkCompositeSchemaForProperty = require('./check-composite-schema-for-property');
 const isObject = require('./is-object');
+const isSdkExcluded = require('./is-sdk-excluded');
 const pathMatchesRegexp = require('./path-matches-regexp');
 const validateSubschemas = require('./validate-subschemas');
 
@@ -8,6 +9,7 @@ module.exports = {
   checkCompositeSchemaForConstraint,
   checkCompositeSchemaForProperty,
   isObject,
+  isSdkExcluded,
   pathMatchesRegexp,
   validateSubschemas
 };

--- a/packages/ruleset/src/utils/is-sdk-excluded.js
+++ b/packages/ruleset/src/utils/is-sdk-excluded.js
@@ -1,0 +1,11 @@
+const isObject = require('./is-object');
+
+/**
+ * Returns `true` if the input is an object with x-sdk-exclude
+ * extension set to true.
+ */
+const isSdkExcluded = obj => {
+  return isObject(obj) && obj['x-sdk-exclude'] === true;
+};
+
+module.exports = isSdkExcluded;

--- a/packages/ruleset/test/parameter-default.test.js
+++ b/packages/ruleset/test/parameter-default.test.js
@@ -1,0 +1,70 @@
+const { parameterDefault } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = parameterDefault;
+const ruleId = 'parameter-default';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg = 'Required parameter should not define a default value';
+
+describe('Spectral rule: parameter-default', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Excluded required parameter with default', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters['DrinkIdParam'].schema.default = 'foo';
+      testDocument.components.parameters['DrinkIdParam'][
+        'x-sdk-exclude'
+      ] = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Optional parameter with default', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters['VerboseParam'].schema.default = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Referenced required parameter with default', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters['DrinkIdParam'].schema.default = 'foo';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.parameters.0'
+      );
+    });
+
+    it('Inline required parameter with default', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters[0].required = true;
+      testDocument.paths['/v1/movies'].get.parameters[0].schema.default = 'foo';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.get.parameters.0'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/utils/test-rule.js
+++ b/packages/ruleset/test/utils/test-rule.js
@@ -16,5 +16,11 @@ module.exports = async (ruleName, rule, doc) => {
     }
   });
 
-  return spectral.run(doc);
+  try {
+    const results = await spectral.run(doc);
+    return results;
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
 };

--- a/packages/validator/src/.defaultsForValidator.js
+++ b/packages/validator/src/.defaultsForValidator.js
@@ -38,8 +38,7 @@ const defaults = {
       'invalid_type_format_pair': 'error',
       'content_type_parameter': 'error',
       'accept_type_parameter': 'error',
-      'authorization_parameter': 'warning',
-      'required_param_has_default': 'warning'
+      'authorization_parameter': 'warning'
     },
     'paths': {
       'missing_path_parameter': 'error',
@@ -113,7 +112,8 @@ const deprecated = {
   'no_property_description': 'property-description (Spectral rule)',
   'description_mentions_json': 'description-mentions-json (Spectral rule)',
   'property_case_convention': 'property_case_convention (Spectral rule)',
-  'no_parameter_description': 'parameter-description (Spectral rule)'
+  'no_parameter_description': 'parameter-description (Spectral rule)',
+  'required_param_has_default': 'parameter-default (Spectral rule)'
 };
 
 const configOptions = {

--- a/packages/validator/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
+++ b/packages/validator/src/plugins/validation/2and3/semantic-validators/parameters-ibm.js
@@ -111,23 +111,6 @@ module.exports.validate = function({ jsSpec, isOAS3 }, config) {
           );
         }
       }
-
-      const isParameterRequired = obj.required;
-      let isDefaultDefined;
-      if (isOAS3) {
-        isDefaultDefined = obj.schema && obj.schema.default !== undefined;
-      } else {
-        isDefaultDefined = obj.default !== undefined;
-      }
-
-      if (isParameterRequired && isDefaultDefined) {
-        messages.addMessage(
-          path,
-          'Required parameters should not specify default values.',
-          config.required_param_has_default,
-          'required_param_has_default'
-        );
-      }
     }
   });
 

--- a/packages/validator/test/plugins/validation/2and3/parameters-ibm.test.js
+++ b/packages/validator/test/plugins/validation/2and3/parameters-ibm.test.js
@@ -174,66 +174,6 @@ describe('validation plugin - semantic - parameters-ibm', () => {
       );
     });
 
-    it('should flag a required parameter that specifies a default value', () => {
-      const spec = {
-        paths: {
-          '/pets': {
-            get: {
-              parameters: [
-                {
-                  name: 'tags',
-                  in: 'query',
-                  required: true,
-                  description: 'tags to filter by',
-                  type: 'string',
-                  default: 'reptile'
-                }
-              ]
-            }
-          }
-        }
-      };
-
-      const res = validate({ jsSpec: spec }, config);
-      expect(res.warnings.length).toEqual(1);
-      expect(res.warnings[0].path).toEqual([
-        'paths',
-        '/pets',
-        'get',
-        'parameters',
-        '0'
-      ]);
-      expect(res.warnings[0].message).toEqual(
-        'Required parameters should not specify default values.'
-      );
-      expect(res.errors.length).toEqual(0);
-    });
-
-    it('should not flag an optional parameter that specifies a default value', () => {
-      const spec = {
-        paths: {
-          '/pets': {
-            get: {
-              parameters: [
-                {
-                  name: 'tags',
-                  in: 'query',
-                  required: false,
-                  description: 'tags to filter by',
-                  type: 'string',
-                  default: 'reptile'
-                }
-              ]
-            }
-          }
-        }
-      };
-
-      const res = validate({ jsSpec: spec }, config);
-      expect(res.warnings.length).toEqual(0);
-      expect(res.errors.length).toEqual(0);
-    });
-
     it('should not return an error for formData parameters of type file', () => {
       const spec = {
         paths: {
@@ -370,43 +310,6 @@ describe('validation plugin - semantic - parameters-ibm', () => {
       expect(res.warnings[0].message).toEqual(
         'Parameters must not explicitly define `Authorization`. Rely on the `securitySchemes` and `security` fields to specify authorization methods. This check will be converted to an `error` in an upcoming release.'
       );
-    });
-
-    it('should flag a required parameter that specifies a default value', () => {
-      const spec = {
-        paths: {
-          '/pets': {
-            get: {
-              parameters: [
-                {
-                  name: 'tags',
-                  in: 'query',
-                  required: true,
-                  description: 'tags to filter by',
-                  schema: {
-                    type: 'string',
-                    default: 'reptile'
-                  }
-                }
-              ]
-            }
-          }
-        }
-      };
-
-      const res = validate({ jsSpec: spec, isOAS3: true }, config);
-      expect(res.warnings.length).toEqual(1);
-      expect(res.warnings[0].path).toEqual([
-        'paths',
-        '/pets',
-        'get',
-        'parameters',
-        '0'
-      ]);
-      expect(res.warnings[0].message).toEqual(
-        'Required parameters should not specify default values.'
-      );
-      expect(res.errors.length).toEqual(0);
     });
 
     it('should not flag an optional parameter that does not specify a default value', () => {


### PR DESCRIPTION
This commit converts the old 'required_param_has_default' rule
into a new Spectral-style rule 'parameter-default'.

Disregard the oldest commit because this PR is stacked up behind my previous PR re: the parameter-description rule.  Once that PR is merged, I'll rebase this one.
