### PR TITLE
feat(parameter-case-convention): add new 'parameter-case-convention' rule and remove old rule

### DIFF
--- a/docs/ibm-legacy-rules.md
+++ b/docs/ibm-legacy-rules.md
@@ -141,7 +141,7 @@ The supported rules are described below:
 
 Each rule can be assigned a status. The supported statuses are `error`, `warning`, `info`, `hint` and `off`.
 Some rules can be configured further with configuration options. The format of this configuration is to provide an array, rather than just a string. e.g.
-`"param_name_case_convention": ["error", "lower_camel_case"]`
+`"paths_case_convention": ["error", "lower_camel_case"]`
 If just a string is provided for these rule, the default configuration option will be used. If only one value is provided in the array, it **MUST** be a status. The default configuration option will be used in this case as well. The rules that support configuration options will have **two** values in the [defaults](#default-values) table.
 
 #### Configuration Options
@@ -150,7 +150,7 @@ For rules that accept additional configuration, there will be a limited set of a
 
 ##### Case Convention Options
 - Some rules check strings for adherence to a specific case convention. In some cases, the case convention checked is configurable.
-- Rules with configurable case conventions will end in `_case_convention`, such as `param_name_case_convention`.
+- Rules with configurable case conventions will end in `_case_convention`, such as `paths_case_convention`.
 
 | Option           | Description                                              | Example           |
 | ---------------- | -------------------------------------------------------- | ----------------- |

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -6,6 +6,7 @@ const discriminator = require('./discriminator');
 const enumCaseConvention = require('./enum-case-convention');
 const errorResponseSchema = require('./error-response-schema');
 const paginationStyle = require('./pagination-style');
+const parameterCaseConvention = require('./parameter-case-convention');
 const parameterDefault = require('./parameter-default');
 const parameterDescription = require('./parameter-description');
 const propertyCaseCollision = require('./property-case-collision');
@@ -27,6 +28,7 @@ module.exports = {
   enumCaseConvention,
   errorResponseSchema,
   paginationStyle,
+  parameterCaseConvention,
   parameterDefault,
   parameterDescription,
   propertyCaseCollision,

--- a/packages/ruleset/src/functions/parameter-case-convention.js
+++ b/packages/ruleset/src/functions/parameter-case-convention.js
@@ -1,0 +1,86 @@
+const { casing } = require('@stoplight/spectral-functions');
+const { isSdkExcluded, isDeprecated } = require('../utils');
+
+// Error message prefix for each parameter type.
+const errorMsgPrefix = {
+  query: 'Query parameter names ',
+  path: 'Path parameter names ',
+  header: 'Header parameter names '
+};
+
+const errorMsgNoName = 'Parameters must have a name';
+const errorMsgNoIn = "Parameters must have a valid 'in' value";
+
+module.exports = function(param, options, { path }) {
+  return parameterCaseConvention(param, path, options);
+};
+
+/**
+ * This function will check 'param' to make sure that its name
+ * follows the appropriate case convention, depending on its parameter type.
+ * @param {*} param the parameter object to check
+ * @param {*} path the location of 'param' within the OpenAPI document
+ * @param {*} casingConfig this is the value of the 'functionOptions' field
+ * within this rule's definition (see src/rules/parameter-case-convention.js).
+ * This should be an object with an entry (key) for each parameter type (i.e. 'in' value).
+ * The value of each entry should be an object which is the config to be
+ * passed to Spectral's casing() function to enforce case conventions for that parameter type.
+ * @returns an array containing zero or more error objects
+ */
+function parameterCaseConvention(param, path, casingConfig) {
+  // Don't bother enforcing the rule on excluded or deprecated parameters.
+  if (isSdkExcluded(param) || isDeprecated(param)) {
+    return [];
+  }
+
+  const errors = [];
+
+  // First, let's make sure the 'name' and 'in' properties are present.
+  let hasName = true;
+  let hasIn = true;
+  if (!isNonEmptyString(param.name)) {
+    errors.push({
+      message: errorMsgNoName,
+      path
+    });
+    hasName = false;
+  }
+  if (!isNonEmptyString(param.in)) {
+    errors.push({
+      message: errorMsgNoIn,
+      path
+    });
+    hasIn = false;
+  }
+
+  // If we have 'name' and 'in' properties, then check for the proper casing.
+  if (hasName && hasIn) {
+    const paramIn = param.in
+      .toString()
+      .trim()
+      .toLowerCase();
+
+    // Retrieve the config for the appropriate param type and then use it
+    // to invoke the casing() function.
+    const config = casingConfig[paramIn];
+    const msgPrefix = errorMsgPrefix[paramIn];
+    if (config && msgPrefix) {
+      const result = casing(param.name, config);
+
+      // casing() will return either an array with 1 element or undefined.
+      // We'll prepend the returned error message with our prefix.
+      if (result) {
+        errors.push({
+          message: msgPrefix + result[0].message,
+          path
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
+function isNonEmptyString(s) {
+  return s && s.toString().trim().length;
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -105,6 +105,7 @@ module.exports = {
     'major-version-in-path': ibmRules.majorVersionInPath,
     'missing-required-property': ibmRules.missingRequiredProperty,
     'pagination-style': ibmRules.paginationStyle,
+    'parameter-case-convention': ibmRules.parameterCaseConvention,
     'parameter-default': ibmRules.parameterDefault,
     'parameter-description': ibmRules.parameterDescription,
     'parameter-schema-or-content': ibmRules.parameterSchemaOrContent,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -14,6 +14,7 @@ const ibmSdkOperations = require('./ibm-sdk-operations');
 const majorVersionInPath = require('./major-version-in-path');
 const missingRequiredProperty = require('./missing-required-property');
 const paginationStyle = require('./pagination-style');
+const parameterCaseConvention = require('./parameter-case-convention');
 const parameterDefault = require('./parameter-default');
 const parameterDescription = require('./parameter-description');
 const parameterSchemaOrContent = require('./parameter-schema-or-content');
@@ -46,6 +47,7 @@ module.exports = {
   majorVersionInPath,
   missingRequiredProperty,
   paginationStyle,
+  parameterCaseConvention,
   parameterDefault,
   parameterDescription,
   parameterSchemaOrContent,

--- a/packages/ruleset/src/rules/parameter-case-convention.js
+++ b/packages/ruleset/src/rules/parameter-case-convention.js
@@ -1,0 +1,47 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { parameterCaseConvention } = require('../functions');
+const { parameters } = require('../collections');
+
+module.exports = {
+  description: 'Parameter names must follow case conventions',
+  message: '{{error}}',
+  formats: [oas2, oas3],
+  given: parameters,
+  severity: 'error',
+  resolved: true,
+  then: {
+    function: parameterCaseConvention,
+
+    // The configuration of this rule should be an object
+    // with keys that represent the different parameter types
+    // to be checked for property casing conventions: 'query', 'path', and 'header'.
+    // The value of each key should be an object that is the appropriate
+    // configuration needed by Spectral's casing() function to enforce the desired
+    // case convention for parameters of that type.
+    // To disable case convention checks for a particular parameter type,
+    // simply remove that entry from the config object.
+    functionOptions: {
+      // Allow snake case for query parameter names,
+      // but also allow '.' within the name.
+      query: {
+        type: 'snake',
+        separator: {
+          char: '.'
+        }
+      },
+
+      // Allow snake case for path parameter names.
+      path: {
+        type: 'snake'
+      },
+
+      // Allow header parameter names to be in canonical header name form (e.g. X-My-Header).
+      header: {
+        type: 'pascal',
+        separator: {
+          char: '-'
+        }
+      }
+    }
+  }
+};

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -1,5 +1,6 @@
 const checkCompositeSchemaForConstraint = require('./check-composite-schema-for-constraint');
 const checkCompositeSchemaForProperty = require('./check-composite-schema-for-property');
+const isDeprecated = require('./is-deprecated');
 const isObject = require('./is-object');
 const isSdkExcluded = require('./is-sdk-excluded');
 const mergeAllOfSchemaProperties = require('./merge-allof-schema-properties');
@@ -9,6 +10,7 @@ const validateSubschemas = require('./validate-subschemas');
 module.exports = {
   checkCompositeSchemaForConstraint,
   checkCompositeSchemaForProperty,
+  isDeprecated,
   isObject,
   isSdkExcluded,
   mergeAllOfSchemaProperties,

--- a/packages/ruleset/src/utils/is-deprecated.js
+++ b/packages/ruleset/src/utils/is-deprecated.js
@@ -1,0 +1,10 @@
+const isObject = require('./is-object');
+
+/**
+ * Returns `true` if the input is an object with deprecated=true.
+ */
+const isDeprecated = obj => {
+  return isObject(obj) && obj.deprecated === true;
+};
+
+module.exports = isDeprecated;

--- a/packages/ruleset/test/parameter-case-convention.test.js
+++ b/packages/ruleset/test/parameter-case-convention.test.js
@@ -1,0 +1,307 @@
+const { parameterCaseConvention } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = parameterCaseConvention;
+const ruleId = 'parameter-case-convention';
+const expectedSeverity = severityCodes.error;
+
+const expectedMsgNoName = 'Parameters must have a name';
+const expectedMsgNoIn = "Parameters must have a valid 'in' value";
+const expectedMsgQuery = 'Query parameter names must be snake case';
+const expectedMsgPath = 'Path parameter names must be snake case';
+const expectedMsgHeader = 'Header parameter names must be pascal case';
+
+describe('Spectral rule: parameter-case-convention', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Query parameter with correct case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movie_rating',
+        required: false,
+        in: 'query',
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Query parameter with "." in name', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movie_rating.value',
+        required: false,
+        in: 'query',
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Path parameter with correct case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].parameters = [
+        {
+          description: 'An optional movie rating to filter on.',
+          name: 'movie_rating',
+          required: false,
+          in: 'path',
+          schema: {
+            type: 'string'
+          }
+        }
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Header parameter with correct case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'X-Movie-Rating',
+        required: false,
+        in: 'header',
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Excluded query parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movieRating',
+        required: false,
+        in: 'query',
+        'x-sdk-exclude': true,
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Excluded path parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movieRating',
+        required: false,
+        in: 'path',
+        'x-sdk-exclude': true,
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Excluded header parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movie_rating',
+        required: false,
+        in: 'header',
+        'x-sdk-exclude': true,
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Deprecated query parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movieRating',
+        required: false,
+        in: 'query',
+        deprecated: true,
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Deprecated path parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movieRating',
+        required: false,
+        in: 'path',
+        deprecated: true,
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Deprecated header parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        name: 'movie_rating',
+        required: false,
+        in: 'header',
+        deprecated: true,
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Parameter with no name', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.components.parameters.DrinkIdParam.name;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgNoName);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.parameters.0'
+      );
+    });
+
+    it('Parameter with no "in" value', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.components.parameters.DrinkIdParam.in;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgNoIn);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.parameters.0'
+      );
+    });
+
+    it('Query parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        required: false,
+        name: 'moveRating',
+        in: 'query',
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgQuery);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.get.parameters.3'
+      );
+    });
+
+    it('Path parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.DrinkIdParam.name = 'drinkId';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgPath);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.parameters.0'
+      );
+    });
+
+    it('Path parameter with "." in name', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.DrinkIdParam.name = 'drinkId.value';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgPath);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.parameters.0'
+      );
+    });
+
+    it('Header parameter with incorrect case', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].get.parameters.push({
+        description: 'An optional movie rating to filter on.',
+        required: false,
+        name: 'moveRating',
+        in: 'header',
+        schema: {
+          type: 'string'
+        }
+      });
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgHeader);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.get.parameters.3'
+      );
+    });
+  });
+});

--- a/packages/validator/src/.defaultsForValidator.js
+++ b/packages/validator/src/.defaultsForValidator.js
@@ -94,7 +94,7 @@ const defaults = {
 */
 const deprecated = {
   'no_produces_for_get': 'no_produces',
-  'parameters.snake_case_only': 'param_name_case_convention',
+  'parameters.snake_case_only': 'parameter-case-convention (Spectral rule)',
   'undefined_required_properties': 'missing-required-property (Spectral rule)',
   'array_of_arrays': 'array-of-arrays (Spectral rule)',
   'no_schema_description': 'schema-description (Spectral rule)',


### PR DESCRIPTION
This commit converts the old 'param_name_case_convention' rule
 into a new Spectral-style rule 'parameter-case-convention'.
