### PR TITLE
feat(property-description): add new 'property-description' rule

### DIFF
--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -5,6 +5,7 @@ const discriminator = require('./discriminator');
 const errorResponseSchema = require('./error-response-schema');
 const propertyCaseCollision = require('./property-case-collision');
 const propertyCaseConvention = require('./property-case-convention');
+const propertyDescription = require('./property-description');
 const requiredProperty = require('./required-property');
 const responseExampleProvided = require('./response-example-provided');
 const schemaDescription = require('./schema-description.js');
@@ -20,6 +21,7 @@ module.exports = {
   errorResponseSchema,
   propertyCaseCollision,
   propertyCaseConvention,
+  propertyDescription,
   requiredProperty,
   responseExampleProvided,
   schemaDescription,

--- a/packages/ruleset/src/functions/property-description.js
+++ b/packages/ruleset/src/functions/property-description.js
@@ -1,0 +1,36 @@
+const {
+  validateSubschemas,
+  pathMatchesRegexp,
+  checkCompositeSchemaForConstraint
+} = require('../utils');
+
+module.exports = function(schema, _opts, { path }) {
+  return validateSubschemas(schema, path, propertyDescription);
+};
+
+function propertyDescription(schema, path) {
+  // If "schema" is a schema property, then check for a description.
+  const isSchemaProperty = pathMatchesRegexp(path, /^.*,properties,[^,]*$/);
+  if (isSchemaProperty && !schemaHasDescription(schema)) {
+    return [
+      {
+        message: 'Schema property should have a non-empty description',
+        path
+      }
+    ];
+  }
+
+  return [];
+}
+
+// This function will return true if one of the following is true:
+// 1. 'schema' has a non-empty description.
+// 2. 'schema' has an allOf list and AT LEAST ONE list element schema has a non-empty description.
+// 3. 'schema' has a oneOf or anyOf list and ALL of the list element schemas
+//    have a non-empty description.
+function schemaHasDescription(schema) {
+  return checkCompositeSchemaForConstraint(
+    schema,
+    s => s && s.description && s.description.toString().trim().length
+  );
+}

--- a/packages/ruleset/src/functions/schema-description.js
+++ b/packages/ruleset/src/functions/schema-description.js
@@ -8,56 +8,33 @@ module.exports = function(schema, _opts, { path }) {
   return validateSubschemas(schema, path, schemaDescription);
 };
 
-const errorMsgSchema = 'Schema should have a non-empty description';
-const errorMsgProp = 'Schema property should have a non-empty description';
-
 function schemaDescription(schema, path) {
-  const results = [];
-
-  // This rule is configured with "resolved=true", so we shouldn't be called
-  // with a "ref" schema.
-
-  // Use "path" to determine some characteristics of "schema".
-  // We want this function to be called for all possible schema locations within
-  // the API (except for those in components.schemas because resolved=true),
-  // but there are specific types of schemas for which we do not want to
-  // return a warning. For example, a oneOf/anyOf list element schema, or
-  // a schema associated with a parameter object.
-  // We're mainly interested in "primary" schemas and schema properties.
-  // A "primary" schema is (loosely termed) a schema associated with a
-  // requestBody/response or other location where the path ends in "schema".
   //
-  // Note: the regexp used below to capture "isPrimarySchema" uses a "lookbehind assertion"
+  // Check to see if "path" represents a primary schema (i.e. not a schema property).
+  // Note: the regexp used below uses a "lookbehind assertion"
   // (i.e. the "(?<!,parameters,\d+)" part) to match paths that end with the "schema" part,
   // but not paths where "schema" is preceded by "parameters" and "<digits>".
   // So a primary schema is one with a path like:
   // ["paths", "/v1/drinks", "requestBody", "content", "application/json", "schema"]
-  // but not one with a path like:
+  // but not one with a path like these:
   // ["paths", "/v1/drinks", "parameters", "0", "schema"]
+  // ["paths", "/v1/drinks", "requestBody", "content", "application/json", "schema", "properties", "prop1"]
   //
   const isPrimarySchema = pathMatchesRegexp(
     path,
     /^.*(?<!,parameters,\d+),schema$/
   );
-  const isSchemaProperty = pathMatchesRegexp(path, /^.*,properties,[^,]*$/);
-
   // If "schema" is a primary schema, then check for a description.
   if (isPrimarySchema && !schemaHasDescription(schema)) {
-    results.push({
-      message: errorMsgSchema,
-      path
-    });
+    return [
+      {
+        message: 'Schema should have a non-empty description',
+        path
+      }
+    ];
   }
 
-  // If "schema" is a schema property, then check for a description.
-  if (isSchemaProperty && !schemaHasDescription(schema)) {
-    results.push({
-      message: errorMsgProp,
-      path
-    });
-  }
-
-  return results;
+  return [];
 }
 
 // This function will return true if one of the following is true:

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -104,6 +104,7 @@ module.exports = {
     'prohibit-summary-sentence-style': ibmRules.prohibitSummarySentenceStyle,
     'property-case-collision': ibmRules.propertyCaseCollision,
     'property-case-convention': ibmRules.propertyCaseConvention,
+    'property-description': ibmRules.propertyDescription,
     'request-body-object': ibmRules.requestBodyObject,
     'response-error-response-schema': ibmRules.responseErrorResponseSchema,
     'response-example-provided': ibmRules.responseExampleProvided,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -13,6 +13,7 @@ const parameterSchemaOrContent = require('./parameter-schema-or-content');
 const prohibitSummarySentenceStyle = require('./prohibit-summary-sentence-style');
 const propertyCaseCollision = require('./property-case-collision');
 const propertyCaseConvention = require('./property-case-convention');
+const propertyDescription = require('./property-description');
 const requestBodyObject = require('./request-body-object');
 const responseErrorResponseSchema = require('./response-error-response-schema');
 const responseExampleProvided = require('./response-example-provided');
@@ -37,6 +38,7 @@ module.exports = {
   prohibitSummarySentenceStyle,
   propertyCaseCollision,
   propertyCaseConvention,
+  propertyDescription,
   requestBodyObject,
   responseErrorResponseSchema,
   responseExampleProvided,

--- a/packages/ruleset/src/rules/property-description.js
+++ b/packages/ruleset/src/rules/property-description.js
@@ -1,0 +1,15 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { propertyDescription } = require('../functions');
+const { schemas } = require('../collections');
+
+module.exports = {
+  description: 'Schema properties should have a non-empty description',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'warn',
+  formats: [oas2, oas3],
+  resolved: true,
+  then: {
+    function: propertyDescription
+  }
+};

--- a/packages/ruleset/test/property-description.test.js
+++ b/packages/ruleset/test/property-description.test.js
@@ -1,0 +1,404 @@
+const { propertyDescription } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = propertyDescription;
+const ruleId = 'property-description';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg = 'Schema property should have a non-empty description';
+
+describe('Spectral rule: property-description', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Schema property w/ description in allOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'Drink response schema',
+        properties: {
+          main_prop: {
+            allOf: [
+              {
+                description: 'a description',
+                properties: {
+                  prop1: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              },
+              {
+                properties: {
+                  prop2: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Schema property uses nested allOf/oneOf w/descriptions', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'Drink response schema',
+        properties: {
+          main_prop: {
+            // At least one of the allOf schemas should have a description.
+            allOf: [
+              {
+                // Each of the oneOf schemas should have a description.
+                oneOf: [
+                  {
+                    description: 'a description',
+                    properties: {
+                      prop1: {
+                        description: 'a description',
+                        type: 'string'
+                      }
+                    }
+                  },
+                  {
+                    description: 'a description',
+                    properties: {
+                      prop2: {
+                        description: 'a description',
+                        type: 'string'
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                properties: {
+                  prop3: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Response schema property with no description', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Make a copy of Movie named Movie2, and make Movie2 the response schema
+      // for the create operation only.
+      const movie2 = makeCopy(testDocument.components.schemas['Movie']);
+      movie2.properties['director'] = {
+        type: 'string'
+      };
+      testDocument.components.schemas['Movie2'] = movie2;
+      testDocument.paths['/v1/movies'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        $ref: '#/components/schemas/Movie2'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.201.content.application/json.schema.properties.director'
+      );
+    });
+
+    it('Inline response schema property with only spaces in the description', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post.responses['400'].content[
+        'application/json'
+      ].schema.properties['trace'].description = '     ';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.400.content.application/json.schema.properties.trace'
+      );
+    });
+
+    it('Named schema with an empty description', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['IdString'].description = '';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(3);
+      for (const result of results) {
+        expect(result.code).toBe(ruleId);
+        expect(result.message).toBe(expectedMsg);
+        expect(result.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.application/json.schema.properties.id'
+      );
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.201.content.application/json.schema.properties.id'
+      );
+      expect(results[2].path.join('.')).toBe(
+        'paths./v1/movies.get.responses.200.content.application/json.schema.properties.movies.items.properties.id'
+      );
+    });
+
+    it('Schema property uses allOf w/no descriptions', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            allOf: [
+              {
+                properties: {
+                  prop1: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              },
+              {
+                properties: {
+                  prop2: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses oneOf w/missing descriptions', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            oneOf: [
+              {
+                properties: {
+                  prop1: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              },
+              {
+                description: 'a description',
+                properties: {
+                  prop2: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses anyOf w/missing descriptions', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            anyOf: [
+              {
+                properties: {
+                  prop1: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              },
+              {
+                description: 'a description',
+                properties: {
+                  prop2: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses nested allOf/oneOf w/missing descriptions', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            oneOf: [
+              {
+                allOf: [
+                  {
+                    properties: {
+                      prop1a: {
+                        description: 'a description',
+                        type: 'string'
+                      }
+                    }
+                  },
+                  {
+                    properties: {
+                      prop1b: {
+                        description: 'a description',
+                        type: 'string'
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                description: 'a description',
+                properties: {
+                  prop2: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses nested allOf/anyOf w/missing descriptions', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            anyOf: [
+              {
+                allOf: [
+                  {
+                    properties: {
+                      prop1a: {
+                        description: 'a description',
+                        type: 'string'
+                      }
+                    }
+                  },
+                  {
+                    properties: {
+                      prop1b: {
+                        description: 'a description',
+                        type: 'string'
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                description: 'a description',
+                properties: {
+                  prop2: {
+                    description: 'a description',
+                    type: 'string'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/schema-description.test.js
+++ b/packages/ruleset/test/schema-description.test.js
@@ -4,15 +4,13 @@ const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 const rule = schemaDescription;
 const ruleId = 'schema-description';
 const expectedSeverity = severityCodes.warning;
-const expectedMsgSchema = 'Schema should have a non-empty description';
-const expectedMsgProp = 'Schema property should have a non-empty description';
+const expectedMsg = 'Schema should have a non-empty description';
 
 describe('Spectral rule: schema-description', () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
-      // console.log(JSON.stringify(rootDocument, null, 2));
     });
 
     it('OneOf child schema with no description', async () => {
@@ -88,93 +86,6 @@ describe('Spectral rule: schema-description', () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
-
-    it('Schema property w/ description in allOf', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        description: 'Drink response schema',
-        properties: {
-          main_prop: {
-            allOf: [
-              {
-                description: 'a description',
-                properties: {
-                  prop1: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              },
-              {
-                properties: {
-                  prop2: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(0);
-    });
-
-    it('Schema property uses nested allOf/oneOf w/descriptions', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        description: 'Drink response schema',
-        properties: {
-          main_prop: {
-            // At least one of the allOf schemas should have a description.
-            allOf: [
-              {
-                // Each of the oneOf schemas should have a description.
-                oneOf: [
-                  {
-                    description: 'a description',
-                    properties: {
-                      prop1: {
-                        description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  },
-                  {
-                    description: 'a description',
-                    properties: {
-                      prop2: {
-                        description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                properties: {
-                  prop3: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(0);
-    });
   });
 
   describe('Should yield errors', () => {
@@ -192,69 +103,11 @@ describe('Spectral rule: schema-description', () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
       expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgSchema);
+      expect(results[0].message).toBe(expectedMsg);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'post',
-        'requestBody',
-        'content',
-        'text/html',
-        'schema'
-      ]);
-    });
-
-    it('Named schema with an empty description', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.components.schemas['IdString'].description = '';
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(3);
-      for (const result of results) {
-        expect(result.code).toBe(ruleId);
-        expect(result.message).toBe(expectedMsgProp);
-        expect(result.severity).toBe(expectedSeverity);
-      }
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'id'
-      ]);
-      expect(results[1].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'id'
-      ]);
-      expect(results[2].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'movies',
-        'items',
-        'properties',
-        'id'
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.requestBody.content.text/html.schema'
+      );
     });
 
     it('Response schema with only spaces in the description', async () => {
@@ -267,79 +120,11 @@ describe('Spectral rule: schema-description', () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
       expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgSchema);
+      expect(results[0].message).toBe(expectedMsg);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'responses',
-        '400',
-        'content',
-        'application/json',
-        'schema'
-      ]);
-    });
-
-    it('Response schema property with no description', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      // Make a copy of Movie named Movie2, and make Movie2 the response schema
-      // for the create operation only.
-      const movie2 = makeCopy(testDocument.components.schemas['Movie']);
-      movie2.properties['director'] = {
-        type: 'string'
-      };
-      testDocument.components.schemas['Movie2'] = movie2;
-      testDocument.paths['/v1/movies'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        $ref: '#/components/schemas/Movie2'
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgProp);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'director'
-      ]);
-    });
-
-    it('Inline response schema property with only spaces in the description', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/movies'].post.responses['400'].content[
-        'application/json'
-      ].schema.properties['trace'].description = '     ';
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgProp);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'responses',
-        '400',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'trace'
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.400.content.application/json.schema'
+      );
     });
 
     it('Re-used oneOf child schema with no description', async () => {
@@ -359,296 +144,11 @@ describe('Spectral rule: schema-description', () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
       expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgSchema);
+      expect(results[0].message).toBe(expectedMsg);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema'
-      ]);
-    });
-
-    it('Schema property uses allOf w/no descriptions', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        description: 'a description',
-        properties: {
-          main_prop: {
-            allOf: [
-              {
-                properties: {
-                  prop1: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              },
-              {
-                properties: {
-                  prop2: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgProp);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'main_prop'
-      ]);
-    });
-
-    it('Schema property uses oneOf w/missing descriptions', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        description: 'a description',
-        properties: {
-          main_prop: {
-            oneOf: [
-              {
-                properties: {
-                  prop1: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              },
-              {
-                description: 'a description',
-                properties: {
-                  prop2: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgProp);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'main_prop'
-      ]);
-    });
-
-    it('Schema property uses anyOf w/missing descriptions', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        description: 'a description',
-        properties: {
-          main_prop: {
-            anyOf: [
-              {
-                properties: {
-                  prop1: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              },
-              {
-                description: 'a description',
-                properties: {
-                  prop2: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgProp);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'main_prop'
-      ]);
-    });
-
-    it('Schema property uses nested allOf/oneOf w/missing descriptions', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        description: 'a description',
-        properties: {
-          main_prop: {
-            oneOf: [
-              {
-                allOf: [
-                  {
-                    properties: {
-                      prop1a: {
-                        description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  },
-                  {
-                    properties: {
-                      prop1b: {
-                        description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                description: 'a description',
-                properties: {
-                  prop2: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgProp);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'main_prop'
-      ]);
-    });
-
-    it('Schema property uses nested allOf/anyOf w/missing descriptions', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.responses['201'].content[
-        'application/json'
-      ].schema = {
-        description: 'a description',
-        properties: {
-          main_prop: {
-            anyOf: [
-              {
-                allOf: [
-                  {
-                    properties: {
-                      prop1a: {
-                        description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  },
-                  {
-                    properties: {
-                      prop1b: {
-                        description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                description: 'a description',
-                properties: {
-                  prop2: {
-                    description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgProp);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'properties',
-        'main_prop'
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema'
+      );
     });
   });
 });

--- a/packages/validator/src/.defaultsForValidator.js
+++ b/packages/validator/src/.defaultsForValidator.js
@@ -111,7 +111,7 @@ const deprecated = {
   'undefined_required_properties': 'missing-required-property (Spectral rule)',
   'array_of_arrays': 'array-of-arrays (Spectral rule)',
   'no_schema_description': 'schema-description (Spectral rule)',
-  'no_property_description': 'schema-description (Spectral rule)',
+  'no_property_description': 'property-description (Spectral rule)',
   'description_mentions_json': 'description-mentions-json (Spectral rule)',
   'property_case_convention': 'property_case_convention (Spectral rule)'
 };


### PR DESCRIPTION
A recent change was made that converted the old
'no_property_description' and 'no_schema_description' rules
into a single new 'schema-description' Spectral-style rule.
This commit introduces a new 'property-description' rule
and removes the property-related checks from the
'schema-description' rule.
So now, 'schema-description' will specifically ensure that
schemas have a non-empty description, while the new
'property-description' rule will ensure that
schema properties have a non-empty description.
This change is being made so that each rule can be
enabled/disabled separately according to user requirements.