### PR TITLE
chore: fix typo in .defaultsForValidator.js

### DIFF
--- a/packages/validator/src/.defaultsForValidator.js
+++ b/packages/validator/src/.defaultsForValidator.js
@@ -107,7 +107,7 @@ const deprecated = {
   'accept_type_parameter': 'accept-parameter (Spectral rule)',
   'content_type_parameter': 'content-type-parameter (Spectral rule)',
   'property_case_convention': 'property-case-convention (Spectral rule)',
-  'enum_case_convention': 'enum-case-convention (Sectral rule)',
+  'enum_case_convention': 'enum-case-convention (Spectral rule)',
   'pagination_style': 'pagination-style (Spectral rule)'
 };
 


### PR DESCRIPTION
## PR summary
This PR just fixes a typo "Sectral" vs "Spectral" :)

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

