### PR TITLE
fix(pagination-style): fix bug in pagination-style rule

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-01-13T15:24:33Z",
+  "generated_at": "2022-03-14T17:01:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -86,7 +86,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.40.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/packages/ruleset/src/functions/pagination-style.js
+++ b/packages/ruleset/src/functions/pagination-style.js
@@ -46,7 +46,7 @@ function paginationStyle(pathItem, path) {
   // 2. If the path item doesn't have a 'get' operation.
   // 3. The 'get' operation is excluded via the 'x-sdk-exclude' extension.
   if (/}$/.test(pathStr) || !operation || isSdkExcluded(operation)) {
-    debug('"get" operation doesnt exist or is excluded');
+    debug('"get" operation doesn\'t exist or is excluded');
     return [];
   }
 
@@ -86,8 +86,12 @@ function paginationStyle(pathItem, path) {
     return [];
   }
 
-  // Grab the operation's parameters list for easy access below.
+  // Next, make sure this operation has parameters.
   const params = operation.parameters;
+  if (!params) {
+    debug('Operation has no parameters');
+    return [];
+  }
 
   // Check to see if the operation defines a page token-type query param.
   // This could have any of the names below.
@@ -116,10 +120,9 @@ function paginationStyle(pathItem, path) {
   }
 
   //
-  // If we made it this far, we know we that the operation is at least attempting to
+  // If we made it this far, we know that the operation is at least attempting to
   // support pagination, so we'll perform the various checks below.
   //
-
   const results = [];
 
   // Check #1: If the operation has a 'limit' query param, it must be type integer, optional,

--- a/packages/ruleset/test/pagination-style.test.js
+++ b/packages/ruleset/test/pagination-style.test.js
@@ -193,6 +193,15 @@ describe('Spectral rule: pagination-style', () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+    it('Response indicates pagination, but operation has no parameters', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Remove the operation's entire parameters field.
+      delete testDocument.paths['/v1/drinks'].get.parameters;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
   describe('Should yield errors', () => {
     // Within this section, the nested 'describe' blocks will indicate which check


### PR DESCRIPTION
## PR summary
This PR fixes a bug in the pagination-style rule that would occur when a list-type operation appears to support a paginated response schema, but yet the operation had no parameters at all.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

