### PR TITLE
fix(major-version-in-path): tolerate invalid server.url value

### DIFF
--- a/packages/ruleset/src/functions/check-major-version.js
+++ b/packages/ruleset/src/functions/check-major-version.js
@@ -14,9 +14,27 @@ module.exports = targetVal => {
   if (oas3) {
     const servers = targetVal['servers'];
     if (servers && Array.isArray(servers)) {
-      const urls = servers.map(o => o['url']);
-      const versions = urls.map(url => getVersion(url));
+      // Gather up all the unique path segments that
+      // indicate the API major version (e.g. /v1) within
+      // the URLs defined in the servers list.
+      const versions = [];
+      for (let i = 0; i < servers.length; i++) {
+        // Obtain the URL string from the server entry by resolving any
+        // variable references with each variable's default value.
+        const url = getDefaultUrl(servers[i]);
+        if (url) {
+          try {
+            const version = getVersion(url);
+            if (version) {
+              versions.push(version);
+            }
+          } catch (error) {
+            // Ignore any exceptions while parsing the URL string.
+          }
+        }
+      }
 
+      // If we have more than one unique "version" segment, then flag it.
       if (versions.length > 1 && !versions.every(v => v === versions[0])) {
         const uniqueVersions = versions.filter(
           (val, i, self) => self.indexOf(val) === i
@@ -88,9 +106,41 @@ module.exports = targetVal => {
   }
 };
 
-// Return the first segment of a path that matches the pattern 'v\d+'
-function getVersion(path) {
-  const url = new URL(path, 'https://foo.bar');
+/**
+ * Returns the first segment of the path portion of "urlString" that matches the pattern 'v\d+'
+ * @param {*} urlString an absolute or relative URL string (e.g. "https://myhost.com/api/v1" or "/v1/clouds").
+ * @returns the first path segment that appears to indicate the API major version (e.g. "v1").
+ */
+function getVersion(urlString) {
+  const url = new URL(urlString, 'https://foo.bar');
   const segments = url.pathname.split('/');
   return segments.find(segment => segment.match(/v[0-9]+/));
+}
+
+/**
+ * Returns the "default" server URL for the specified server object.
+ *
+ * @param {object} server an entry from the API definition's "servers" list.
+ * @returns the default URL string which is the result of replacing server
+ * variable references found in the server object's "url" field with
+ * the default value for each referenced server variable.
+ */
+function getDefaultUrl(server) {
+  let urlString = null;
+  if (server && server.url) {
+    urlString = server.url;
+
+    if (server.variables) {
+      for (const variable of Object.entries(server.variables)) {
+        const varName = variable[0];
+        const varObj = variable[1];
+        if (varName && varObj && varObj.default) {
+          const varRefRE = new RegExp('{' + varName + '}', 'g');
+          urlString = urlString.replace(varRefRE, varObj.default);
+        }
+      }
+    }
+  }
+
+  return urlString;
 }

--- a/packages/ruleset/test/major-version-in-path.test.js
+++ b/packages/ruleset/test/major-version-in-path.test.js
@@ -10,6 +10,51 @@ describe('Spectral rule: major-version-in-path', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('should not error when servers object contains parameterized urls', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.servers = [
+      {
+        url: 'https://some-madeup-url.com:{port}/api/{apiVersion}',
+        variables: {
+          port: {
+            default: '443'
+          },
+          apiVersion: {
+            default: 'v1'
+          }
+        }
+      },
+      {
+        url: 'https://some-madeup-url.com:443/api/v1'
+      }
+    ];
+
+    const results = await testRule(name, majorVersionInPath, testDocument);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not error when server.url is unparseable', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.servers = [
+      {
+        url: 'https://some-madeup-url.com:{port}/api/{apiVersion}',
+        variables: {
+          port: {
+            description: 'No default value for this one'
+          },
+          apiVersion: {
+            default: 'v1'
+          }
+        }
+      }
+    ];
+
+    const results = await testRule(name, majorVersionInPath, testDocument);
+
+    expect(results).toHaveLength(0);
+  });
+
   it('should error when servers have urls with different versions', async () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.servers = [


### PR DESCRIPTION
## PR summary
This PR modifies the checkMajorVersion function so that:
1. it now attempts to resolve a parameterized server.url value using the default values of the server entry's variables.
2. it tolerates a malformed URL string by catching and absorbing any exception that might get thrown while parsing the server.url value. 

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

