### PR TITLE
docs: update outdated customization section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,7 @@ The default configuration uses both OpenAPI 3.0 rules as well as Spectral rules.
 
 ### Customization
 
-You can modify the behavior of the validator for your project to meet your preferred standards. Specific validation "rules" can be turned off, or configured to trigger an error, warning, info, or hint message in the validator output.
-
-Some validations can be configured even further, such as switching the case convention for parameter names.
-There are also currently some validations that cannot be disabled or configured to a different severity.
-You can see the rule associated with each message produced by the validator with the `-v` command line option.
-**Rules that are not configurable will show the name `builtin`.**
-
-The validator also employs the [`Spectral`](https://github.com/stoplightio/spectral) validation/linting engine to detect certain issues in the API document.
-Spectral rules can also be configured to trigger an error, warning, info, or hint message in the validator output with the `.spectral.yaml` configuration file.
-When the validator issues a message as the result of a Spectral rule, the rule name displayed will correspond to the Spectral rule. You must add a Spectral configuration if you want to create a new rule, as opposed to modifying an existing one.
-
-To get started configuring the validator, [set up](#setup) a [configuration file](#configuration-file).  See the [Spectral configuration](#spectral-configuration) section for more details on customization with Spectral.
+You can modify the behavior of the validator for your project to meet your preferred standards. See the [customization documentation](docs/ibm-cloud-rules.md#customization) for more information.
 
 ## Installation
 There are two main ways to install the validator, either using NPM or building from source. Installing with NPM is recommended.


### PR DESCRIPTION
This section focused on the legacy format and included some broken links.
This commit redirects the reader to the appropriate documentation.
