### PR TITLE
fix(string-boundary): update string-boundary rule with new formats

### DIFF
--- a/packages/ruleset/src/functions/string-boundary.js
+++ b/packages/ruleset/src/functions/string-boundary.js
@@ -4,32 +4,59 @@ module.exports = function(schema, _opts, { path }) {
   return validateSubschemas(schema, path, stringBoundaryErrors);
 };
 
-function stringBoundaryErrors(schema, path) {
-  const errors = [];
-  if (schema.type !== 'string') {
-    return errors;
+// Rudimentary debug logging that is useful in debugging this rule.
+const debugEnabled = false;
+function debug(msg) {
+  if (debugEnabled) {
+    console.log(msg);
   }
+}
+
+// An object holding a list of "format" values to be bypassed when checking
+// for the "pattern", "minLength" and "maxLength" fields of a string property, respectively.
+const bypassFormats = {
+  pattern: ['binary', 'byte', 'date', 'date-time', 'url'],
+  minLength: ['date', 'identifier', 'url'],
+  maxLength: ['date']
+};
+
+function stringBoundaryErrors(schema, path) {
+  // We're only interested in checking string properties.
+  if (schema.type !== 'string') {
+    return [];
+  }
+
+  const errors = [];
   if (isUndefinedOrNull(schema.enum)) {
     if (
       isUndefinedOrNull(schema.pattern) &&
-      !['binary', 'date', 'date-time'].includes(schema.format)
+      !bypassFormats.pattern.includes(schema.format)
     ) {
       errors.push({
         message: 'Should define a pattern for a valid string',
         path
       });
+      debug('>>> pattern field missing for: ' + path.join('.'));
     }
-    if (isUndefinedOrNull(schema.minLength)) {
+    if (
+      isUndefinedOrNull(schema.minLength) &&
+      !bypassFormats.minLength.includes(schema.format)
+    ) {
       errors.push({
         message: 'Should define a minLength for a valid string',
         path
       });
+      debug('>>> minLength field missing for: ' + path.join('.'));
     }
-    if (isUndefinedOrNull(schema.maxLength)) {
+    if (
+      isUndefinedOrNull(schema.maxLength) &&
+      !bypassFormats.maxLength.includes(schema.format)
+    ) {
       errors.push({
         message: 'Should define a maxLength for a valid string',
         path
       });
+      debug('>>> maxLength field missing for: ' + path.join('.'));
     }
     if (
       !isUndefinedOrNull(schema.minLength) &&
@@ -40,6 +67,7 @@ function stringBoundaryErrors(schema, path) {
         message: 'minLength must be less than maxLength',
         path
       });
+      debug('>>> minLength >= maxLength for: ' + path.join('.'));
     }
   }
   return errors;

--- a/packages/ruleset/src/rules/string-boundary.js
+++ b/packages/ruleset/src/rules/string-boundary.js
@@ -2,7 +2,7 @@ const { oas3 } = require('@stoplight/spectral-formats');
 const { stringBoundary } = require('../functions');
 
 module.exports = {
-  description: 'string schemas should have explicit boundaries defined',
+  description: 'String schemas should have explicit boundaries defined',
   message: '{{error}}',
   severity: 'warn',
   formats: [oas3],

--- a/packages/ruleset/test/string-boundary.test.js
+++ b/packages/ruleset/test/string-boundary.test.js
@@ -28,7 +28,7 @@ describe('Spectral rule: string-boundary', () => {
     expect(results).toHaveLength(0);
   });
 
-  it('should not error for missing pattern when format is binary, date, or date-time', async () => {
+  it('should not error for missing pattern when format is binary, byte, date, date-time, or url', async () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].post.parameters = [
       {
@@ -42,13 +42,21 @@ describe('Spectral rule: string-boundary', () => {
         }
       },
       {
+        name: 'trailer',
+        in: 'query',
+        schema: {
+          type: 'string',
+          format: 'byte',
+          minLength: 0,
+          maxLength: 1024
+        }
+      },
+      {
         name: 'before_date',
         in: 'query',
         schema: {
           type: 'string',
-          format: 'date',
-          minLength: 1,
-          maxLength: 15
+          format: 'date'
         }
       },
       {
@@ -60,11 +68,19 @@ describe('Spectral rule: string-boundary', () => {
           minLength: 1,
           maxLength: 15
         }
+      },
+      {
+        name: 'imdb_url',
+        in: 'query',
+        schema: {
+          type: 'string',
+          format: 'url',
+          maxLength: 1024
+        }
       }
     ];
 
     const results = await testRule(name, stringBoundary, testDocument);
-
     expect(results).toHaveLength(0);
   });
 

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -382,6 +382,16 @@ module.exports = {
             type: 'integer',
             format: 'int32',
             description: 'The length of the movie, in minutes.'
+          },
+          imdb_url: {
+            $ref: '#/components/schemas/UrlString'
+          },
+          trailer: {
+            type: 'string',
+            format: 'byte',
+            description: 'A short trailer for the movie.',
+            minLength: 0,
+            maxLength: 1024
           }
         },
         example: {
@@ -453,6 +463,12 @@ module.exports = {
         pattern: '[a-zA-Z0-9]+',
         minLength: 1,
         maxLength: 10
+      },
+      UrlString: {
+        description: 'A URL of some sort.',
+        type: 'string',
+        format: 'url',
+        maxLength: 1024
       },
       DrinkCollection: {
         description: 'A single page of results containing Drink instances.',


### PR DESCRIPTION
## PR summary
This commit updates the string-boundary rule slightly to be a bit
more accurate in terms of the warnings that are issued for
string properties with various format values specified for them.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

