### PR TITLE
feat(request-body-name): add new request-body-name rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -54,6 +54,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: property-case-convention](#rule-property-case-convention)
   * [Rule: property-description](#rule-property-description)
   * [Rule: property-inconsistent-name-and-type](#rule-property-inconsistent-name-and-type)
+  * [Rule: request-body-name](#rule-request-body-name)
   * [Rule: request-body-object](#rule-request-body-object)
   * [Rule: response-error-response-schema](#rule-response-error-response-schema)
   * [Rule: response-example-provided](#rule-response-example-provided)
@@ -237,6 +238,13 @@ is provided in the [Reference](#reference) section below.
 <td>warn</td>
 <td>Avoid using the same property name for properties of different types.</td>
 <td>oas2, oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-request-body-name">request-body-name</a></td>
+<td>warn</td>
+<td>An operation should specify a request body name (with the <code>x-codegen-request-body-name</code> extension) if its requestBody
+has non-form content.</td>
+<td>oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-request-body-object">request-body-object</a></td>
@@ -2066,6 +2074,71 @@ components:
         name:
           description: The name of the OtherThing.
           type: string
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: request-body-name
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>request-body-name</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>The <code>x-codegen-request-body-name</code> extension can be set on an operation to provide a language-agnostic
+name for any body parameter that might appear within generated SDK code.
+For operations that support multipart-form-based request body content, this isn't necessary since the
+names of the form parameters are inferred from the property names within the request body schema.
+However, for operations that support other non-form-based request body content (json-based and non-json-based content alike),
+it is a good practice to provide the request body name via the extension, especially in situations where there is no other
+way to infer a logical name for the operation's body parameter.
+<p>This rule analyzes each operation to determine if a request body name is needed, and if so, checks to make sure 
+that the <code>x-codegen-request-body-name</code> extension is set on the operation.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/logs':
+    post:
+      operationId: upload_logfile
+      requestBody:
+        content:
+          'application/octet-stream':
+            schema:
+              type: string
+              format: binary
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/logs':
+    post:
+      operationId: upload_logfile
+      x-code-gen-request-body-name: log_file   &lt;&lt;&lt;
+      requestBody:
+        content:
+          'application/octet-stream':
+            schema:
+              type: string
+              format: binary
 </pre>
 </td>
 </tr>

--- a/docs/ibm-legacy-rules.md
+++ b/docs/ibm-legacy-rules.md
@@ -81,7 +81,6 @@ The supported rules are described below:
 | no_array_responses           | Flag any operations with a top-level array response.                                | shared   |
 | parameter_order              | Flag any operations with optional parameters before a required param.               | shared   |
 | operation_id_naming_convention | Flag any `operationId` that does not follow naming convention.                    | shared   |
-| no_request_body_name         | Flag any operations with a non-form `requestBody` that does not have a name set with `x-codegen-request-body-name`. | oas3|
 
 
 ##### paths
@@ -186,7 +185,6 @@ The default values for each rule are described below.
 ###### operations
 | Rule                        | Default |
 | --------------------------- | ------- |
-| no_request_body_name        | warning |
 
 ##### responses
 | Rule                      | Default |

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -14,6 +14,7 @@ const propertyCaseCollision = require('./property-case-collision');
 const propertyCaseConvention = require('./property-case-convention');
 const propertyDescription = require('./property-description');
 const propertyInconsistentNameAndType = require('./property-inconsistent-name-and-type');
+const requestBodyName = require('./request-body-name');
 const requiredProperty = require('./required-property');
 const responseExampleProvided = require('./response-example-provided');
 const schemaDescription = require('./schema-description.js');
@@ -40,6 +41,7 @@ module.exports = {
   propertyCaseConvention,
   propertyDescription,
   propertyInconsistentNameAndType,
+  requestBodyName,
   requiredProperty,
   responseExampleProvided,
   schemaDescription,

--- a/packages/ruleset/src/functions/request-body-name.js
+++ b/packages/ruleset/src/functions/request-body-name.js
@@ -1,0 +1,142 @@
+const { isJsonMimeType, isFormMimeType } = require('../utils');
+
+module.exports = function(operation, _opts, { path }) {
+  return requestBodyName(operation, path);
+};
+
+// Rudimentary debug logging that is useful in debugging this rule.
+const debugEnabled = false;
+function debug(msg) {
+  if (debugEnabled) {
+    console.log(msg);
+  }
+}
+
+// Name of the extension that we're looking for.
+const REQUEST_BODY_NAME = 'x-codegen-request-body-name';
+
+/**
+ * This function implements the 'request-body-name' rule.
+ * Specifically, it checks to make sure that an operation
+ * contains the 'x-codegen-request-body-name' extension if its requestBody
+ * "needs" a name.
+ * In this context, "needs a name" implies that the operation will have
+ * a single body param and the request body is not being "exploded".
+ *
+ * @param {*} op the operation to check
+ * @param {*} path the array of path segments indicating the "location" of "op" within the API definition
+ * @returns an array containing the violations found or [] if no violations
+ */
+function requestBodyName(op, path) {
+  debug(
+    '>>> Visiting operation: ' + op.operationId + ' [' + path.join('.') + ']'
+  );
+
+  const errors = [];
+
+  // If this operation needs a request body name, then check for one.
+  if (
+    op &&
+    op.requestBody &&
+    op.requestBody.content &&
+    needRequestBodyName(op.requestBody)
+  ) {
+    const hasRequestBodyName =
+      op[REQUEST_BODY_NAME] && op[REQUEST_BODY_NAME].trim().length;
+
+    if (!hasRequestBodyName) {
+      errors.push({
+        message:
+          'Operations with non-form request bodies should set a name with the x-codegen-request-body-name extension.',
+        path
+      });
+    }
+  }
+
+  if (errors.length) {
+    debug('>>> Returning errors: ' + JSON.stringify(errors, null, 2));
+  } else {
+    debug('>>> PASSED!');
+  }
+
+  return errors;
+}
+
+/**
+ * Returns true if and only if "requestBody" should have a request body name specified for it.
+ * This will be true IF there is requestBody content and we won't be exploding the body.
+ * @param {*} requestBody the operation's requestBody field
+ */
+function needRequestBodyName(requestBody) {
+  const content = requestBody.content;
+  const mimeTypes = Object.keys(content);
+  if (!mimeTypes.length) {
+    return false;
+  }
+
+  // Request body has content for at least one mimetype,
+  // so let's check if the body will be exploded.
+
+  // Does the operation support JSON content?
+  const jsonMimeType = mimeTypes.find(m => isJsonMimeType(m));
+
+  // Does the operation support non-JSON content?
+  const hasNonJsonContent = mimeTypes.find(m => !isJsonMimeType(m));
+
+  // Grab the requestBody schema for the JSON mimetype (if present).
+  const bodySchema = jsonMimeType && content[jsonMimeType].schema;
+
+  // Is the request body schema an array?
+  const isArraySchema = bodySchema && bodySchema.type === 'array';
+
+  // Does the schema contain oneOf/anyOf?
+  const isAbstract = isSchemaAbstract(bodySchema);
+
+  // Does the schema support additionalProperties?
+  const isDynamic = isSchemaDynamic(bodySchema);
+
+  // Does the schema have a discriminator?
+  const hasDiscriminator = bodySchema && bodySchema.discriminator;
+
+  // Does the request body have just a single mimetype?
+  const hasSingleMimeType = mimeTypes.length === 1;
+
+  // Determine if the request body will be exploded by the SDK generator.
+  const bodyWillBeExploded =
+    bodySchema &&
+    hasSingleMimeType &&
+    !isArraySchema &&
+    !hasNonJsonContent &&
+    !isAbstract &&
+    !isDynamic &&
+    !hasDiscriminator;
+
+  const hasFormContent = mimeTypes.find(m => isFormMimeType(m));
+
+  return !bodyWillBeExploded && !hasFormContent;
+}
+
+/**
+ * Returns true if and only if "schema" supports additional properties.
+ * @param {*} schema the schema to check
+ * @returns true if "schema" supports additional properties.
+ */
+function isSchemaDynamic(schema) {
+  const hasAdditionalProperties = schema && schema.additionalProperties;
+  return hasAdditionalProperties;
+}
+
+/**
+ * Returns true if and only if "schema" contains a oneOf or anyOf list.
+ * @param {object} schema the schema to check
+ * @returns true if "schema" contains oneOf or anyOf.
+ */
+function isSchemaAbstract(schema) {
+  if (schema && schema.oneOf && schema.oneOf.length) {
+    return true;
+  }
+  if (schema && schema.anyOf && schema.anyOf.length) {
+    return true;
+  }
+  return false;
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -116,6 +116,7 @@ module.exports = {
     'property-description': ibmRules.propertyDescription,
     'property-inconsistent-name-and-type':
       ibmRules.propertyInconsistentNameAndType,
+    'request-body-name': ibmRules.requestBodyName,
     'request-body-object': ibmRules.requestBodyObject,
     'response-error-response-schema': ibmRules.responseErrorResponseSchema,
     'response-example-provided': ibmRules.responseExampleProvided,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -24,6 +24,7 @@ const propertyCaseCollision = require('./property-case-collision');
 const propertyCaseConvention = require('./property-case-convention');
 const propertyDescription = require('./property-description');
 const propertyInconsistentNameAndType = require('./property-inconsistent-name-and-type');
+const requestBodyName = require('./request-body-name');
 const requestBodyObject = require('./request-body-object');
 const responseErrorResponseSchema = require('./response-error-response-schema');
 const responseExampleProvided = require('./response-example-provided');
@@ -61,6 +62,7 @@ module.exports = {
   propertyCaseConvention,
   propertyDescription,
   propertyInconsistentNameAndType,
+  requestBodyName,
   requestBodyObject,
   responseErrorResponseSchema,
   responseExampleProvided,

--- a/packages/ruleset/src/rules/request-body-name.js
+++ b/packages/ruleset/src/rules/request-body-name.js
@@ -1,0 +1,16 @@
+const { oas3 } = require('@stoplight/spectral-formats');
+const { requestBodyName } = require('../functions');
+const { operations } = require('../collections');
+
+module.exports = {
+  description:
+    'Verify that operations have the x-codegen-request-body-name extension set when needed',
+  message: '{{error}}',
+  given: operations,
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  then: {
+    function: requestBodyName
+  }
+};

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -1,6 +1,8 @@
 const checkCompositeSchemaForConstraint = require('./check-composite-schema-for-constraint');
 const checkCompositeSchemaForProperty = require('./check-composite-schema-for-property');
 const isDeprecated = require('./is-deprecated');
+const isFormMimeType = require('./is-form-mimetype');
+const isJsonMimeType = require('./is-json-mimetype');
 const isObject = require('./is-object');
 const isSdkExcluded = require('./is-sdk-excluded');
 const mergeAllOfSchemaProperties = require('./merge-allof-schema-properties');
@@ -11,6 +13,8 @@ module.exports = {
   checkCompositeSchemaForConstraint,
   checkCompositeSchemaForProperty,
   isDeprecated,
+  isFormMimeType,
+  isJsonMimeType,
   isObject,
   isSdkExcluded,
   mergeAllOfSchemaProperties,

--- a/packages/ruleset/src/utils/is-form-mimetype.js
+++ b/packages/ruleset/src/utils/is-form-mimetype.js
@@ -1,0 +1,23 @@
+/**
+ * Returns true if and only if "mimeType" is a form-related mime type
+ * (e.g. "multipart/form-data; charset=utf-8").
+ * @param {string} mimeType the mimeType string
+ * @returns true if "mimeType" indicates form content
+ */
+function isFormMimeType(mimeType) {
+  if (!mimeType) {
+    return false;
+  }
+
+  // Form-related mimetype regex's.
+  const formMimeTypeREs = [
+    /^multipart\/form-data(;.*)*$/,
+    /^multipart\/related(;.*)*$/,
+    /^multipart\/mixed(;.*)*$/,
+    /^application\/x-www-form-urlencoded(;.*)*$/
+  ];
+
+  return !!formMimeTypeREs.find(re => mimeType.match(re));
+}
+
+module.exports = isFormMimeType;

--- a/packages/ruleset/src/utils/is-json-mimetype.js
+++ b/packages/ruleset/src/utils/is-json-mimetype.js
@@ -1,0 +1,20 @@
+/**
+ * Returns true if and only if "mimeType" is a "JSON-like" mime type
+ * (e.g. "application/json; charset=utf-8").
+ * @param {string} mimeType the mimeType string
+ * @returns true if "mimeType" represents a JSON media type
+ */
+function isJsonMimeType(mimeType) {
+  if (!mimeType) {
+    return false;
+  }
+
+  // application/json; charset=utf-8
+  if (mimeType.match(/^application\/json(;.*)*$/)) {
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = isJsonMimeType;

--- a/packages/ruleset/test/is-form-mimetype.test.js
+++ b/packages/ruleset/test/is-form-mimetype.test.js
@@ -1,0 +1,31 @@
+const { isFormMimeType } = require('../src/utils');
+
+describe('Utility function: isFormMimeType()', () => {
+  it('should return `false` for `undefined`', async () => {
+    expect(isFormMimeType(undefined)).toBe(false);
+  });
+
+  it('should return `false` for `null`', async () => {
+    expect(isFormMimeType(null)).toBe(false);
+  });
+
+  it('should return `false` for empty-string', async () => {
+    expect(isFormMimeType('')).toBe(false);
+  });
+
+  it('should return `false` for non-form mimetype', async () => {
+    expect(isFormMimeType('application/octect-stream')).toBe(false);
+    expect(isFormMimeType('text/plain')).toBe(false);
+    expect(isFormMimeType('application/json; charset=utf-8')).toBe(false);
+  });
+
+  it('should return `true` for a form-based mimetype', async () => {
+    expect(isFormMimeType('multipart/form-data')).toBe(true);
+    expect(isFormMimeType('multipart/form-data; charset=utf-8')).toBe(true);
+    expect(isFormMimeType('multipart/mixed')).toBe(true);
+    expect(isFormMimeType('multipart/related')).toBe(true);
+    expect(
+      isFormMimeType('application/x-www-form-urlencoded; extrabits=xyz')
+    ).toBe(true);
+  });
+});

--- a/packages/ruleset/test/is-json-mimetype.test.js
+++ b/packages/ruleset/test/is-json-mimetype.test.js
@@ -1,0 +1,26 @@
+const { isJsonMimeType } = require('../src/utils');
+
+describe('Utility function: isJsonMimeType()', () => {
+  it('should return `false` for `undefined`', async () => {
+    expect(isJsonMimeType(undefined)).toBe(false);
+  });
+
+  it('should return `false` for `null`', async () => {
+    expect(isJsonMimeType(null)).toBe(false);
+  });
+
+  it('should return `false` for empty-string', async () => {
+    expect(isJsonMimeType('')).toBe(false);
+  });
+
+  it('should return `false` for non-JSON mimetype', async () => {
+    expect(isJsonMimeType('application/octect-stream')).toBe(false);
+    expect(isJsonMimeType('text/plain')).toBe(false);
+    expect(isJsonMimeType('multipart/form-data; charset=utf-8')).toBe(false);
+  });
+
+  it('should return `true` for a JSON mimetype', async () => {
+    expect(isJsonMimeType('application/json')).toBe(true);
+    expect(isJsonMimeType('application/json;charset=utf-8')).toBe(true);
+  });
+});

--- a/packages/ruleset/test/request-body-name.test.js
+++ b/packages/ruleset/test/request-body-name.test.js
@@ -1,0 +1,233 @@
+const { requestBodyName } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = requestBodyName;
+const ruleId = 'request-body-name';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg =
+  'Operations with non-form request bodies should set a name with the x-codegen-request-body-name extension.';
+
+describe('Spectral rule: request-body-name', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Request body has multi-content, extension present', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Add the extension and an additional requestBody content entry to the "create_movie" operation.
+      testDocument.paths['/v1/movies'].post['x-codegen-request-body-name'] =
+        'movie';
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'application/octet-stream'
+      ] = {
+        schema: {
+          $ref: '#/components/schemas/Movie'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Request body schema is dynamic, extension present', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post['x-codegen-request-body-name'] =
+        'movie';
+      testDocument.components.schemas.Movie.additionalProperties = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Request body schema has discriminator, extension present', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post['x-codegen-request-body-name'] =
+        'movie';
+      testDocument.components.schemas.Movie.discriminator = {
+        propertyName: 'type'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Request body has non-json content, extension present', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post['x-codegen-request-body-name'] =
+        'movie';
+      testDocument.paths['/v1/movies'].post.requestBody.content = {
+        'application/octet-stream': {
+          schema: {
+            type: 'string',
+            format: 'binary'
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Request body is an array, extension present', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post['x-codegen-request-body-name'] =
+        'movie';
+      testDocument.paths['/v1/movies'].post.requestBody.content = {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Request body has form content, no extension needed', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post.requestBody.content = {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              form_param_1: {
+                $ref: '#/components/schemas/NormalString'
+              },
+              form_param_2: {
+                $ref: '#/components/schemas/NormalString'
+              },
+              form_param_3: {
+                type: 'string',
+                format: 'binary'
+              }
+            }
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Request body has multi-content, extension missing', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Add a second mimeType to the requestBody content field.
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'application/octet-stream'
+      ] = {
+        schema: {
+          $ref: '#/components/schemas/Movie'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/movies.post');
+    });
+
+    it('Request body schema is abstract, extension missing', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // The Drink schema is already abstract, so just remove the extension
+      // to simulate the error.
+      delete testDocument.paths['/v1/drinks'].post[
+        'x-codegen-request-body-name'
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/drinks.post');
+    });
+
+    it('Request body schema is dynamic, extension missing', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.additionalProperties = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/movies.post');
+    });
+
+    it('Request body schema has discriminator, extension missing', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.discriminator = {
+        propertyName: 'type'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/movies.post');
+    });
+
+    it('Request body has non-json content, extension missing', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post.requestBody.content = {
+        'application/octet-stream': {
+          schema: {
+            type: 'string',
+            format: 'binary'
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/movies.post');
+    });
+
+    it('Request body is an array, extension missing', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post.requestBody.content = {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/movies.post');
+    });
+  });
+});

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -36,6 +36,7 @@ module.exports = {
             DrinkScheme: ['mixologist']
           }
         ],
+        'x-codegen-request-body-name': 'drink',
         requestBody: {
           content: {
             'application/json': {

--- a/packages/validator/src/.defaultsForValidator.js
+++ b/packages/validator/src/.defaultsForValidator.js
@@ -54,9 +54,6 @@ const defaults = {
     }
   },
   'oas3': {
-    'operations': {
-      'no_request_body_name': 'warning'
-    },
     'responses': {
       'no_success_response_codes': 'warning',
       'protocol_switching_and_success_code': 'error',
@@ -104,6 +101,7 @@ const deprecated = {
   'no_operation_id': 'operation-operationId (spectral:oas rule)',
   'undefined_tag': 'operation-tag-defined (spectral:oas rule)',
   'unused_tag': 'unused-tag (Spectral rule)',
+  'no_request_body_name': 'request-body-name (Spectral rule)',
 };
 
 const configOptions = {

--- a/packages/validator/test/plugins/validation/oas3/operations.test.js
+++ b/packages/validator/test/plugins/validation/oas3/operations.test.js
@@ -5,40 +5,6 @@ const {
 const config = require('../../../../src/.defaultsForValidator').defaults.oas3;
 
 describe('validation plugin - semantic - operations - oas3', function() {
-  it('should warn about an operation with a non-form, array schema request body that does not set a name', function() {
-    const spec = {
-      paths: {
-        '/pets': {
-          post: {
-            summary: 'this is a summary',
-            operationId: 'operationId',
-            requestBody: {
-              description: 'body for request',
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'array',
-                    items: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    };
-
-    const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
-    expect(res.warnings.length).toEqual(1);
-    expect(res.warnings[0].path).toEqual('paths./pets.post');
-    expect(res.warnings[0].message).toEqual(
-      'Operations with non-form request bodies should set a name with the x-codegen-request-body-name annotation.'
-    );
-    expect(res.errors.length).toEqual(0);
-  });
-
   it('should not warn about an operation with a non-array application/json request body that does not set a name', function() {
     const spec = {
       paths: {
@@ -190,40 +156,6 @@ describe('validation plugin - semantic - operations - oas3', function() {
 
     const res = validate({ resolvedSpec, jsSpec }, config);
     expect(res.warnings.length).toEqual(0);
-    expect(res.errors.length).toEqual(0);
-  });
-
-  it('should not crash in request body name check when path name contains a period', function() {
-    const spec = {
-      paths: {
-        '/other.pets': {
-          post: {
-            summary: 'this is a summary',
-            operationId: 'operationId',
-            requestBody: {
-              description: 'body for request',
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'array',
-                    items: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    };
-
-    const res = validate({ resolvedSpec: spec, jsSpec: spec }, config);
-    expect(res.warnings.length).toEqual(1);
-    expect(res.warnings[0].path).toEqual('paths./other.pets.post');
-    expect(res.warnings[0].message).toEqual(
-      'Operations with non-form request bodies should set a name with the x-codegen-request-body-name annotation.'
-    );
     expect(res.errors.length).toEqual(0);
   });
 


### PR DESCRIPTION
## PR summary
This commit introduces the new spectral-style
'request-body-name' rule, which replaces the
legacy 'no_request_body_name' rule.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [x] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [x] Removed or adjusted testcases (packages/validator/test)
- [x] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [x] Removed docs of old rule (docs/ibm-legacy-rules.md)

