### PR TITLE
Addressing issues

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -176,15 +176,15 @@ is provided in the [Reference](#reference) section below.
 <td>oas2, oas3</td>
 </tr>
 <tr>
-<<<<<<< HEAD
 <td><a href="#rule-operation-id-case-convention">operation-id-case-convention</a></td>
 <td>warn</td>
 <td>Operation ids should follow a specific case convention</td>
-=======
+<td>oas2, oas3</td>
+</tr>
+<tr>
 <td><a href="#rule-operation-id-naming-convention">operation-id-naming-convention</a></td>
 <td>warn</td>
 <td>Operation ids should follow a naming convention</td>
->>>>>>> 9e1fb2d (feat(operation-id-naming-convention): add new operation-id-naming-convention rule)
 <td>oas2, oas3</td>
 </tr>
 <tr>

--- a/packages/ruleset/src/rules/content-entry-provided.js
+++ b/packages/ruleset/src/rules/content-entry-provided.js
@@ -5,7 +5,7 @@ module.exports = {
   description:
     'Request bodies and non-204 responses should define a content object',
   given: [
-    "$.paths[*][*].responses[?(@property != '204' && @property != '202' && @property != '101')]",
+    "$.paths[*][*].responses[?(@property != '204' && @property != '202' && @property != '101' && @property != '304')]",
     '$.paths[*][*].requestBody'
   ],
   severity: 'warn',

--- a/packages/ruleset/test/content-entry-provided.test.js
+++ b/packages/ruleset/test/content-entry-provided.test.js
@@ -55,6 +55,21 @@ describe('Spectral rule: content-entry-provided', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('should not error if 304 response is missing content', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['/v1/movies'].delete = {
+      responses: {
+        '304': {
+          description: 'No content'
+        }
+      }
+    };
+
+    const results = await testRule(name, contentEntryProvided, testDocument);
+
+    expect(results).toHaveLength(0);
+  });
+
   it('should error if 201 response is missing content', async () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].post = {


### PR DESCRIPTION
This PR includes two commits, each addressing a recent issue.

The first commit resolves #425 - it removes some merge conflict artifacts that were left in the docs.

The second commit resolves #426 - it adds `304` to the list of status code we don't require a content entry for, a decision supported by the API Handbook:

> Responses with a `304` status MUST NOT have a response body.