### PR TITLE
fix(operation-id-naming-convention): update rule with latest guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -956,33 +956,33 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
-      "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
-      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.11.tgz",
+      "integrity": "sha512-RllI476aSMsxzeI9TtlSMoNTgHDxEmnl6GkkHwhr0vdL8W+0WuesyI8Vd3rBOfrwtPXbPxdT9ADJdiOKgzxPQA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/@stoplight/spectral-formats": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.1.0.tgz",
-      "integrity": "sha512-ZpEHNkS30qfPbxHJAf3OwZ7g0LkSG2UZXhl3/Jsf6WGivVcuQUY+ZK4c1ZJqBNct1JF1ujP3FgF26xDdTrOtDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.2.0.tgz",
+      "integrity": "sha512-idvn7r8fvQjY/KeJpKgXQ5eJhce6N6/KoKWMPSh5yyvYDpn+bkU4pxAD79jOJaDnIyKJd1jjTPEJWnxbS0jj6A==",
       "dependencies": {
         "@stoplight/json": "^3.17.0",
         "@stoplight/spectral-core": "^1.8.0",
@@ -1827,18 +1827,18 @@
       }
     },
     "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.7.0.tgz",
-      "integrity": "sha512-QXnidFatoBQVBv4iHtJyg46zjEeyooTVOgfmsc+UHwAPu0u0YNF7DW52wZCwBU0RMknExDRbopc/QGvO7srmCg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.8.0.tgz",
+      "integrity": "sha512-xFeTYnkeLgZt6sJi53BjUv9mYxW5OuZ4LT4gwIsZopmsVX3ZBl73H8t2XzH9eIGhSqDPX8A426Rg5EDkwBcsoA==",
       "dependencies": {
-        "@asyncapi/specs": "^2.13.0",
+        "@asyncapi/specs": "^2.14.0",
         "@stoplight/better-ajv-errors": "1.0.1",
         "@stoplight/json": "^3.17.0",
         "@stoplight/spectral-core": "^1.8.1",
-        "@stoplight/spectral-formats": "^1.1.0",
+        "@stoplight/spectral-formats": "^1.2.0",
         "@stoplight/spectral-functions": "^1.5.1",
         "@stoplight/spectral-runtime": "^1.1.1",
-        "@stoplight/types": "^12.3.0",
+        "@stoplight/types": "^12.5.0",
         "@types/json-schema": "^7.0.7",
         "ajv": "^8.8.2",
         "ajv-formats": "~2.1.0",
@@ -1848,6 +1848,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-rulesets/node_modules/@stoplight/types": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.5.0.tgz",
+      "integrity": "sha512-dwqYcDrGmEyUv5TWrDam5TGOxU72ufyQ7hnOIIDdmW5ezOwZaBFoR5XQ9AsH49w7wgvOqB2Bmo799pJPWnpCbg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@stoplight/spectral-runtime": {
@@ -2008,9 +2020,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.30.tgz",
-      "integrity": "sha512-oNBIZjIqyHYP8VCNAV9uEytXVeXG2oR0w9lgAXro20eugRQfY002qr3CUl6BAe+Yf/z3CRjPdz27Pu6WWtuSRw=="
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2783,9 +2795,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001334",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
-      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
+      "version": "1.0.30001339",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
+      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
       "dev": true,
       "funding": [
         {
@@ -3615,9 +3627,9 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.127",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.127.tgz",
-      "integrity": "sha512-nhD6S8nKI0O2MueC6blNOEZio+/PWppE/pevnf3LOlQA/fKPCrDp2Ao4wx4LFwmIkJpVdFdn2763YWLy9ENIZg==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5205,9 +5217,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.7.tgz",
+      "integrity": "sha512-SLm2ERgmBGag79RfrIknk+40ZOJCgUBpCQTl3WE2YER21VR0W3Vt/OAXXaYLSU0AIcBqWnytoTwk2ZcTbxH0xg=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -6644,9 +6656,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
-      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.15.tgz",
+      "integrity": "sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -7178,9 +7190,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.8.0.tgz",
-      "integrity": "sha512-MDHVaj0zrinLkshylII8pT46VCkAUqQfYRS+pyuuZZtBZRRphH/IG5HC1YbIc77AX5FmLUWGvu23Kah5fscIbw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.9.0.tgz",
+      "integrity": "sha512-4mhU5nEv7ktvHmJnM2nmWP2Zk4cCsD26imX+dvZ76HOuFUnIpU6+i1MWuoMg8N/xWHQgB0d2/ybWEGgJR9M/pw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7265,7 +7277,7 @@
         "@npmcli/run-script": "^3.0.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.0.6",
+        "cacache": "^16.0.7",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
@@ -7307,7 +7319,7 @@
         "npm-user-validate": "^1.0.1",
         "npmlog": "^6.0.2",
         "opener": "^1.5.2",
-        "pacote": "^13.1.1",
+        "pacote": "^13.3.0",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
@@ -7771,7 +7783,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.0.6",
+      "version": "16.0.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9031,7 +9043,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "13.1.1",
+      "version": "13.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10808,9 +10820,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.70.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
-      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
+      "version": "2.72.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.72.1.tgz",
+      "integrity": "sha512-NTc5UGy/NWFGpSqF1lFY8z9Adri6uhyMLI6LvPAXdBKoPRFhIIiBUpt+Qg2awixqO3xvzSijjhnb4+QEZwJmxA==",
       "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -12589,7 +12601,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/spectral-formats": "^1.1.0",
@@ -12607,10 +12619,10 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "0.75.0",
+      "version": "0.76.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "0.24.0",
+        "@ibm-cloud/openapi-ruleset": "0.25.0",
         "@stoplight/spectral-cli": "^6.3.0",
         "@stoplight/spectral-core": "^1.11.0",
         "@stoplight/spectral-parsers": "^1.0.1",
@@ -13378,27 +13390,27 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
-      "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
       "dev": true
     },
     "@jridgewell/set-array": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
-      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.11.tgz",
+      "integrity": "sha512-RllI476aSMsxzeI9TtlSMoNTgHDxEmnl6GkkHwhr0vdL8W+0WuesyI8Vd3rBOfrwtPXbPxdT9ADJdiOKgzxPQA==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -13955,9 +13967,9 @@
       }
     },
     "@stoplight/spectral-formats": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.1.0.tgz",
-      "integrity": "sha512-ZpEHNkS30qfPbxHJAf3OwZ7g0LkSG2UZXhl3/Jsf6WGivVcuQUY+ZK4c1ZJqBNct1JF1ujP3FgF26xDdTrOtDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.2.0.tgz",
+      "integrity": "sha512-idvn7r8fvQjY/KeJpKgXQ5eJhce6N6/KoKWMPSh5yyvYDpn+bkU4pxAD79jOJaDnIyKJd1jjTPEJWnxbS0jj6A==",
       "requires": {
         "@stoplight/json": "^3.17.0",
         "@stoplight/spectral-core": "^1.8.0",
@@ -14090,24 +14102,35 @@
       }
     },
     "@stoplight/spectral-rulesets": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.7.0.tgz",
-      "integrity": "sha512-QXnidFatoBQVBv4iHtJyg46zjEeyooTVOgfmsc+UHwAPu0u0YNF7DW52wZCwBU0RMknExDRbopc/QGvO7srmCg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.8.0.tgz",
+      "integrity": "sha512-xFeTYnkeLgZt6sJi53BjUv9mYxW5OuZ4LT4gwIsZopmsVX3ZBl73H8t2XzH9eIGhSqDPX8A426Rg5EDkwBcsoA==",
       "requires": {
-        "@asyncapi/specs": "^2.13.0",
+        "@asyncapi/specs": "^2.14.0",
         "@stoplight/better-ajv-errors": "1.0.1",
         "@stoplight/json": "^3.17.0",
         "@stoplight/spectral-core": "^1.8.1",
-        "@stoplight/spectral-formats": "^1.1.0",
+        "@stoplight/spectral-formats": "^1.2.0",
         "@stoplight/spectral-functions": "^1.5.1",
         "@stoplight/spectral-runtime": "^1.1.1",
-        "@stoplight/types": "^12.3.0",
+        "@stoplight/types": "^12.5.0",
         "@types/json-schema": "^7.0.7",
         "ajv": "^8.8.2",
         "ajv-formats": "~2.1.0",
         "json-schema-traverse": "^1.0.0",
         "lodash": "~4.17.21",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@stoplight/types": {
+          "version": "12.5.0",
+          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-12.5.0.tgz",
+          "integrity": "sha512-dwqYcDrGmEyUv5TWrDam5TGOxU72ufyQ7hnOIIDdmW5ezOwZaBFoR5XQ9AsH49w7wgvOqB2Bmo799pJPWnpCbg==",
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "utility-types": "^3.10.0"
+          }
+        }
       }
     },
     "@stoplight/spectral-runtime": {
@@ -14253,9 +14276,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.30.tgz",
-      "integrity": "sha512-oNBIZjIqyHYP8VCNAV9uEytXVeXG2oR0w9lgAXro20eugRQfY002qr3CUl6BAe+Yf/z3CRjPdz27Pu6WWtuSRw=="
+      "version": "17.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -14837,9 +14860,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001334",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
-      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
+      "version": "1.0.30001339",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
+      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
       "dev": true
     },
     "cardinal": {
@@ -15480,9 +15503,9 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "electron-to-chromium": {
-      "version": "1.4.127",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.127.tgz",
-      "integrity": "sha512-nhD6S8nKI0O2MueC6blNOEZio+/PWppE/pevnf3LOlQA/fKPCrDp2Ao4wx4LFwmIkJpVdFdn2763YWLy9ENIZg==",
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
     },
     "emittery": {
@@ -16562,7 +16585,7 @@
     "ibm-openapi-validator": {
       "version": "file:packages/validator",
       "requires": {
-        "@ibm-cloud/openapi-ruleset": "0.24.0",
+        "@ibm-cloud/openapi-ruleset": "0.25.0",
         "@stoplight/spectral-cli": "^6.3.0",
         "@stoplight/spectral-core": "^1.11.0",
         "@stoplight/spectral-parsers": "^1.0.1",
@@ -16724,9 +16747,9 @@
       }
     },
     "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.7.tgz",
+      "integrity": "sha512-SLm2ERgmBGag79RfrIknk+40ZOJCgUBpCQTl3WE2YER21VR0W3Vt/OAXXaYLSU0AIcBqWnytoTwk2ZcTbxH0xg=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -17860,9 +17883,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
-      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.15.tgz",
+      "integrity": "sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==",
       "dev": true
     },
     "marked-terminal": {
@@ -18259,9 +18282,9 @@
       "dev": true
     },
     "npm": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.8.0.tgz",
-      "integrity": "sha512-MDHVaj0zrinLkshylII8pT46VCkAUqQfYRS+pyuuZZtBZRRphH/IG5HC1YbIc77AX5FmLUWGvu23Kah5fscIbw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.9.0.tgz",
+      "integrity": "sha512-4mhU5nEv7ktvHmJnM2nmWP2Zk4cCsD26imX+dvZ76HOuFUnIpU6+i1MWuoMg8N/xWHQgB0d2/ybWEGgJR9M/pw==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
@@ -18274,7 +18297,7 @@
         "@npmcli/run-script": "^3.0.1",
         "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^16.0.6",
+        "cacache": "^16.0.7",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
@@ -18316,7 +18339,7 @@
         "npm-user-validate": "^1.0.1",
         "npmlog": "^6.0.2",
         "opener": "^1.5.2",
-        "pacote": "^13.1.1",
+        "pacote": "^13.3.0",
         "parse-conflict-json": "^2.0.2",
         "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
@@ -18637,7 +18660,7 @@
           }
         },
         "cacache": {
-          "version": "16.0.6",
+          "version": "16.0.7",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19529,7 +19552,7 @@
           }
         },
         "pacote": {
-          "version": "13.1.1",
+          "version": "13.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20850,9 +20873,9 @@
       }
     },
     "rollup": {
-      "version": "2.70.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
-      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
+      "version": "2.72.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.72.1.tgz",
+      "integrity": "sha512-NTc5UGy/NWFGpSqF1lFY8z9Adri6uhyMLI6LvPAXdBKoPRFhIIiBUpt+Qg2awixqO3xvzSijjhnb4+QEZwJmxA==",
       "peer": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/packages/ruleset/test/binary-schemas.test.js
+++ b/packages/ruleset/test/binary-schemas.test.js
@@ -13,7 +13,7 @@ const expectedMsgResponse =
 
 describe('Spectral rule: binary-schemas', () => {
   describe('Should not yield errors', () => {
-    it.only('Clean spec', async () => {
+    it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
     });

--- a/packages/ruleset/test/operation-id-naming-convention.test.js
+++ b/packages/ruleset/test/operation-id-naming-convention.test.js
@@ -12,24 +12,178 @@ describe('Spectral rule: operation-id-naming-convention', () => {
       const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
     });
+
+    it('path has multiple path params, get', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
+      newGet.operationId = 'check_glass';
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        get: newGet
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has multiple path params, get', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
+      newGet.operationId = 'get_glass';
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        get: newGet
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has single path param not at end, get', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
+      newGet.operationId = 'anything_goes';
+      testDocument.paths['/v1/drinks/{drink_id}/glass'] = {
+        get: newGet
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path ends with path param, post', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].post = {
+        operationId: 'create_drink'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('no path param, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].put = {
+        operationId: 'replace_drinks'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path ends with path param, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].put = {
+        operationId: 'replace_drink'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has single path param not at end, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // This should not fail as it is not considered to be "resource-oriented".
+      testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
+        put: {
+          operationId: 'replace_glasses'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has single path param not at end, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
+        put: {
+          operationId: 'set_drink_glass'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has multiple path params, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        put: {
+          operationId: 'add_drink_glass'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path ends with path param, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].delete = {
+        operationId: 'delete_drink'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has single path param not at end, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
+        delete: {
+          operationId: 'unset_glasses'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has single path param not at end, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
+        delete: {
+          operationId: 'delete_drink_glasses'
+        }
+      };
+
+      // Add another path so this API will be resource-oriented.
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        get: {
+          operationId: 'get_drink_glass'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('path has multiple path params, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        delete: {
+          operationId: 'remove_drink_glass'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {
-    it('no path param, post', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks'].post.operationId = 'mix_drink';
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      const r = results[0];
-      expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*add or create$/);
-      expect(r.severity).toBe(expectedSeverity);
-      expect(r.path.join('.')).toBe('paths./v1/drinks.post.operationId');
-    });
-
     it('no path param, get', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -63,11 +217,13 @@ describe('Spectral rule: operation-id-naming-convention', () => {
       );
     });
 
-    it('path ends with path param, delete', async () => {
+    it('path has multiple path params, get', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/{drink_id}'].delete = {
-        operationId: 'eliminate_drink'
+      const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
+      newGet.operationId = 'empty_glass';
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        get: newGet
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -75,10 +231,43 @@ describe('Spectral rule: operation-id-naming-convention', () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*delete$/);
+      expect(r.message).toMatch(/^.*get or check$/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
-        'paths./v1/drinks/{drink_id}.delete.operationId'
+        'paths./v1/drinks/{drink_id}/glasses/{glass_id}.get.operationId'
+      );
+    });
+    it('no path param, post', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.operationId = 'mix_drink';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*create$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe('paths./v1/drinks.post.operationId');
+    });
+
+    it('path ends with path param, post', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].post = {
+        operationId: 'top_off_drink'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*create$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.post.operationId'
       );
     });
 
@@ -101,25 +290,6 @@ describe('Spectral rule: operation-id-naming-convention', () => {
       );
     });
 
-    it('path ends with path param, post', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.paths['/v1/drinks/{drink_id}'].post = {
-        operationId: 'top_off_drink'
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      const r = results[0];
-      expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*update$/);
-      expect(r.severity).toBe(expectedSeverity);
-      expect(r.path.join('.')).toBe(
-        'paths./v1/drinks/{drink_id}.post.operationId'
-      );
-    });
-
     it('path ends with path param, put', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -136,6 +306,145 @@ describe('Spectral rule: operation-id-naming-convention', () => {
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.put.operationId'
+      );
+    });
+
+    it('no path param, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].put = {
+        operationId: 'move_drinks'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*replace$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe('paths./v1/drinks.put.operationId');
+    });
+
+    it('path ends with path param, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].put = {
+        operationId: 'take_a_drink'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*replace$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.put.operationId'
+      );
+    });
+
+    it('path has single path param not at end, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
+        put: {
+          operationId: 'smash_drink_glasses'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*replace or set$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}/glasses.put.operationId'
+      );
+    });
+
+    it('path has multiple path params, put', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        put: {
+          operationId: 'smash_drink_glass'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*replace or add$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}/glasses/{glass_id}.put.operationId'
+      );
+    });
+
+    it('path ends with path param, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].delete = {
+        operationId: 'eliminate_drink'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*delete$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.delete.operationId'
+      );
+    });
+
+    it('path has single path param not at end, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
+        delete: {
+          operationId: 'remove_drink_glass'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*delete or unset$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}/glasses.delete.operationId'
+      );
+    });
+
+    it('path has multiple path params, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        delete: {
+          operationId: 'smash_drink_glass'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(/^.*delete or remove$/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'
       );
     });
   });

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -184,7 +184,7 @@ module.exports = {
         }
       },
       put: {
-        operationId: 'upload_menu',
+        operationId: 'replace_menu',
         summary: 'Upload Drinks Menu',
         description: 'Publish a new Drinks Menu for public viewing.',
         tags: ['TestTag'],

--- a/packages/validator/test/cli-validator/mock-files/clean-with-tabs.yml
+++ b/packages/validator/test/cli-validator/mock-files/clean-with-tabs.yml
@@ -50,9 +50,9 @@ paths:
 		put:
 			tags:
 			- "pet"
-			summary: "Update an existing pet"
+			summary: "Replace an existing pet"
 			description: "put new data for existing pet"
-			operationId: "update_pet"
+			operationId: "replace_pet"
 			consumes:
 			- "application/json"
 			- "application/xml"

--- a/packages/validator/test/cli-validator/mock-files/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/clean.yml
@@ -50,9 +50,9 @@ paths:
     put:
       tags:
       - "pet"
-      summary: "Update an existing pet"
+      summary: "Replace an existing pet"
       description: "put new data for existing pet"
-      operationId: "update_pet"
+      operationId: "replace_pet"
       consumes:
       - "application/json"
       - "application/xml"

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -147,7 +147,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
     // console.warn(JSON.stringify(validationResults, null, 2));
 
     expect(validationResults.errors.length).toBe(3);
-    expect(validationResults.warnings.length).toBe(5);
+    expect(validationResults.warnings.length).toBe(6);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 
@@ -167,11 +167,11 @@ describe('cli tool - test expected output - Swagger 2', function() {
 
     // This can be uncommented to display the output when adjustments to
     // the expect statements below are needed.
-    // let textOutput = "";
-    // capturedText.forEach((elem, index) => {
-    //   textOutput += `[${index}]: ${elem}\n`;
-    // });
-    // console.warn(textOutput);
+    let textOutput = '';
+    capturedText.forEach((elem, index) => {
+      textOutput += `[${index}]: ${elem}\n`;
+    });
+    console.warn(textOutput);
 
     expect(exitCode).toEqual(1);
 
@@ -182,8 +182,9 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(capturedText[4].match(/\S+/g)[2]).toEqual('59');
     expect(capturedText[8].match(/\S+/g)[2]).toEqual('172');
     // warnings
-    expect(capturedText[13].match(/\S+/g)[2]).toEqual('166');
-    expect(capturedText[17].match(/\S+/g)[2]).toEqual('197');
+    expect(capturedText[13].match(/\S+/g)[2]).toEqual('59');
+    expect(capturedText[17].match(/\S+/g)[2]).toEqual('166');
+    expect(capturedText[21].match(/\S+/g)[2]).toEqual('197');
   });
 
   it('should return exit code of 0 if there are only warnings', async function() {
@@ -366,7 +367,7 @@ describe('test expected output - OpenAPI 3', function() {
     const validationResults = await inCodeValidator(oas3Object, defaultMode);
 
     expect(validationResults.errors.length).toBe(3);
-    expect(validationResults.warnings.length).toBe(46);
+    expect(validationResults.warnings.length).toBe(47);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -129,7 +129,7 @@ describe('cli tool - test option handling', function() {
 
     // totals
     expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('2');
-    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('2');
+    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('3');
 
     // errors
     expect(capturedText[statsSection + 5].match(/\S+/g)[0]).toEqual('1');
@@ -140,10 +140,10 @@ describe('cli tool - test option handling', function() {
 
     // warnings
     expect(capturedText[statsSection + 9].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 9].match(/\S+/g)[1]).toEqual('(50%)');
+    expect(capturedText[statsSection + 9].match(/\S+/g)[1]).toEqual('(33%)');
 
     expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(50%)');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(33%)');
   });
 
   it('should not print statistics report by default', async function() {
@@ -233,7 +233,7 @@ describe('cli tool - test option handling', function() {
         }
       }
     });
-    expect(warningCount).toEqual(1); // without the config this value is 4
+    expect(warningCount).toEqual(2); // without the config this value is 4
     expect(errorCount).toEqual(0);
   });
 


### PR DESCRIPTION
## PR summary
This PR updates the `operation-id-naming-convention` rule so that it more closely tracks the current API Handbook guidance around operation id's.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

