### PR TITLE
 Exclude inapplicable validation from `not` schemas

### DIFF
--- a/packages/ruleset/src/functions/array-of-arrays.js
+++ b/packages/ruleset/src/functions/array-of-arrays.js
@@ -1,7 +1,7 @@
 const { validateSubschemas } = require('../utils');
 
 module.exports = function(schema, _opts, { path }) {
-  return validateSubschemas(schema, path, arrayOfArrays);
+  return validateSubschemas(schema, path, arrayOfArrays, true, false);
 };
 
 function arrayOfArrays(schema, path) {

--- a/packages/ruleset/src/functions/required-property.js
+++ b/packages/ruleset/src/functions/required-property.js
@@ -4,7 +4,7 @@ const {
 } = require('../utils');
 
 module.exports = function(schema, _opts, { path }) {
-  return validateSubschemas(schema, path, checkRequiredProperties);
+  return validateSubschemas(schema, path, checkRequiredProperties, true, false);
 };
 
 function checkRequiredProperties(schema, path) {

--- a/packages/ruleset/src/functions/string-boundary.js
+++ b/packages/ruleset/src/functions/string-boundary.js
@@ -1,7 +1,7 @@
 const { validateSubschemas } = require('../utils');
 
 module.exports = function(schema, _opts, { path }) {
-  return validateSubschemas(schema, path, stringBoundaryErrors);
+  return validateSubschemas(schema, path, stringBoundaryErrors, true, false);
 };
 
 // Rudimentary debug logging that is useful in debugging this rule.

--- a/packages/ruleset/src/utils/validate-subschemas.js
+++ b/packages/ruleset/src/utils/validate-subschemas.js
@@ -11,15 +11,23 @@ const validateNestedSchemas = require('./validate-nested-schemas');
  * @param {object} schema - Simple or composite OpenAPI 3.0 schema object.
  * @param {array} path - Path array for the provided schema.
  * @param {function} validate - Validate function.
+ * @param {boolean} includeSelf - Whether to validate the provided schema (or just its composed schemas).
+ * @param {boolean} includeNot - Whether to validate schemas composed with `not`.
  * @returns {array} - Array of validation errors.
  */
-const validateSubschemas = (schema, path, validate) => {
+const validateSubschemas = (
+  schema,
+  path,
+  validate,
+  includeSelf = true,
+  includeNot = true
+) => {
   return validateNestedSchemas(
     schema,
     path,
-    (s, p) => validateComposedSchemas(s, p, validate, true, true),
-    true,
-    true
+    (s, p) => validateComposedSchemas(s, p, validate, true, includeNot),
+    includeSelf,
+    includeNot
   );
 };
 

--- a/packages/ruleset/test/array-of-arrays.test.js
+++ b/packages/ruleset/test/array-of-arrays.test.js
@@ -96,6 +96,15 @@ describe('Spectral rule: array-of-arrays', () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+
+    it('Array of array of strings used in not for schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Drink.not = arrayOfArrayOfString;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {

--- a/packages/ruleset/test/missing-required-property.test.js
+++ b/packages/ruleset/test/missing-required-property.test.js
@@ -124,6 +124,40 @@ describe('Spectral rule: missing-required-property', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('should not error if not schema is missing a required property', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['v1/books'] = {
+      post: {
+        parameters: [
+          {
+            name: 'metadata',
+            in: 'header',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  not: {
+                    type: 'object',
+                    required: ['foo'],
+                    properties: {
+                      baz: {
+                        type: 'string'
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    };
+
+    const results = await testRule(name, missingRequiredProperty, testDocument);
+
+    expect(results).toHaveLength(0);
+  });
+
   it('should error if allOf schema is missing a required property', async () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['v1/books'] = {

--- a/packages/ruleset/test/string-boundary.test.js
+++ b/packages/ruleset/test/string-boundary.test.js
@@ -28,6 +28,26 @@ describe('Spectral rule: string-boundary', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('should not error when string schema is in a not', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['/v1/movies'].post.parameters = [
+      {
+        name: 'filter',
+        in: 'query',
+        schema: {
+          type: 'integer',
+          not: {
+            type: 'string'
+          }
+        }
+      }
+    ];
+
+    const results = await testRule(name, stringBoundary, testDocument);
+
+    expect(results).toHaveLength(0);
+  });
+
   it('should not error for missing pattern when format is binary, byte, date, date-time, or url', async () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].post.parameters = [


### PR DESCRIPTION
## PR summary
We've been validating some constraints for `not` schemas that probably don't really apply in scenarios where a `not` schema would be used. This PR backs off validation of some rules from `not` schemas.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

