### PR TITLE
fix(pagination-style): fix issues in 'pagination-style' rule

### DIFF
--- a/packages/ruleset/src/functions/pagination-style.js
+++ b/packages/ruleset/src/functions/pagination-style.js
@@ -334,18 +334,24 @@ function paginationStyle(pathItem, path) {
   // Reference: https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-pagination#pagination-links
 
   // Check #9: The response body should contain a "first" property which links to the first page of results.
-  results.push(...checkPageLink(responseSchemaPath, responseSchema, 'first'));
+  results.push(
+    ...checkPageLink(responseSchemaPath, responseSchema, 'first', true)
+  );
 
   // Check #10: The response body should contain a "last" property which links to the last page of results.
-  results.push(...checkPageLink(responseSchemaPath, responseSchema, 'last'));
+  results.push(
+    ...checkPageLink(responseSchemaPath, responseSchema, 'last', false)
+  );
 
   // Check #11: The response body should contain a "previous" property which links to the previous page of results.
   results.push(
-    ...checkPageLink(responseSchemaPath, responseSchema, 'previous')
+    ...checkPageLink(responseSchemaPath, responseSchema, 'previous', false)
   );
 
   // Check #12: The response body should contain a "next" property which links to the next page of results.
-  results.push(...checkPageLink(responseSchemaPath, responseSchema, 'next'));
+  results.push(
+    ...checkPageLink(responseSchemaPath, responseSchema, 'next', true)
+  );
 
   if (results.length > 0) {
     debug('Results: ' + JSON.stringify(results, null, 2));
@@ -358,16 +364,13 @@ function paginationStyle(pathItem, path) {
 
 // Verify that the '<name>' property exists within 'responseSchema'
 // and represents a valid "page link" value (an object with an "href" field).
-function checkPageLink(path, responseSchema, name) {
+// The 'isRequired' flag indicates whether the specified property is required
+// to be present or not.
+function checkPageLink(path, responseSchema, name, isRequired) {
   const results = [];
 
   const pageLinkProp = responseSchema.properties[name];
-  if (!pageLinkProp) {
-    results.push({
-      message: `A paginated list operation should include a "${name}" property in the response body schema`,
-      path
-    });
-  } else {
+  if (pageLinkProp) {
     const pageLinkSchema = mergeAllOfSchemaProperties(pageLinkProp);
     if (
       !pageLinkSchema ||
@@ -380,6 +383,11 @@ function checkPageLink(path, responseSchema, name) {
         path: [...path, 'properties', name]
       });
     }
+  } else if (isRequired) {
+    results.push({
+      message: `A paginated list operation should include a "${name}" property in the response body schema`,
+      path
+    });
   }
 
   return results;

--- a/packages/ruleset/src/utils/merge-allof-schema-properties.js
+++ b/packages/ruleset/src/utils/merge-allof-schema-properties.js
@@ -3,28 +3,52 @@ const { isObject, mergeWith } = require('lodash');
 // Takes a schema, and if an allOf field is provided,
 // merges all allOf schema properties to create one schema
 module.exports = function(schema) {
-  const mergedSchema = Object.assign({}, schema);
-  const allOfArr = mergedSchema['allOf'];
-  // delete now, so it is not merged back into the final result
-  delete mergedSchema['allOf'];
+  // Our merge target is initially an empty object.
+  const targetSchema = {};
+
+  // Make a copy of the source schema so that we can delete
+  // the allOf field later.
+  const sourceSchema = JSON.parse(JSON.stringify(schema));
+
+  // Grab the allOf list from the source schema (if present)
+  // and then delete it from the source schema so that
+  // only the other fields are left (we'll merge those last).
+  const allOfArr = sourceSchema['allOf'];
+  delete sourceSchema['allOf'];
+
   if (allOfArr && Array.isArray(allOfArr)) {
+    // Merge each of the allOf list element schemas into the
+    // target schema, one at a time.
+    // The 'customizer' function will contatenate arrays
+    // instead of overwriting.
     allOfArr.forEach(function(allOfSchema) {
-      // deep merges the allOf schema into the aggregate schema
-      // uses a function to concatenate arrays instead of overwriting
-      mergeWith(mergedSchema, allOfSchema, customizer);
+      mergeWith(targetSchema, allOfSchema, customizer);
     });
   }
-  return mergedSchema;
+
+  // Finally, merge the remaining fields from our source schema into the target.
+  mergeWith(targetSchema, sourceSchema, customizer);
+
+  return targetSchema;
 };
 
-function customizer(objValue, srcValue) {
-  // keep the original values for non-object fields instead of overwriting
-  // will maintain the `type`, `description`, `summary`, etc. fields
-  if (!isObject(objValue)) {
-    return objValue;
+/**
+ * This function is used as the customizer function passed to the mergeWith()
+ * function to do a deep merge of a source schema into a target schema.
+ * @param {*} targetValue a field from the merge target (might be undefined)
+ * @param {*} sourceValue a field from the merge source
+ * @returns the "merged" value
+ */
+function customizer(targetValue, sourceValue) {
+  // Allow non-object fields from the merge source to be overwritten in the target.
+  if (!isObject(sourceValue)) {
+    return sourceValue;
   }
-  // if the object is an array combine the arrays
-  // otherwise, not an array, so return undefined and
-  // mergeWith will do default object deep merging
-  return Array.isArray(objValue) ? objValue.concat(srcValue) : undefined;
+
+  // If the object is an array combine the arrays.
+  // Otherwise, not an array, so return undefined and
+  // mergeWith will do default object deep merging.
+  return Array.isArray(targetValue)
+    ? targetValue.concat(sourceValue)
+    : undefined;
 }

--- a/packages/ruleset/test/merge-allof-schema-properties.test.js
+++ b/packages/ruleset/test/merge-allof-schema-properties.test.js
@@ -69,7 +69,7 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
     const expectedResult = {
       description: 'the description',
       type: 'object',
-      required: ['prop1', 'prop2'],
+      required: ['prop2', 'prop1'],
       properties: {
         prop1: {
           type: 'string'
@@ -86,9 +86,48 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
     expect(mergeAllOfSchemaProperties(schema)).toStrictEqual(expectedResult);
   });
 
+  it('should return correct page-link schema', async () => {
+    const schema = {
+      allOf: [
+        {
+          type: 'object',
+          description: 'pagelink schema',
+          required: ['href'],
+          properties: {
+            href: {
+              type: 'string',
+              description: 'the href property',
+              example: 'the wrong href example'
+            }
+          }
+        }
+      ],
+      description: 'a link to the first page of results',
+      properties: {
+        href: {
+          example: 'the correct href example'
+        }
+      }
+    };
+
+    const expectedResult = {
+      description: 'a link to the first page of results',
+      type: 'object',
+      required: ['href'],
+      properties: {
+        href: {
+          type: 'string',
+          description: 'the href property',
+          example: 'the correct href example'
+        }
+      }
+    };
+
+    expect(mergeAllOfSchemaProperties(schema)).toStrictEqual(expectedResult);
+  });
+
   it('should return correct merged paginated response schema', async () => {
     const schema = {
-      description: 'A paginated response schema',
       allOf: [
         {
           description: 'Pagination base properties',
@@ -113,6 +152,7 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
         {
           type: 'object',
           required: ['resources'],
+          description: 'A paginated response schema',
           properties: {
             resources: {
               description: 'The resources contained in a page of list results.',

--- a/packages/ruleset/test/pagination-style.test.js
+++ b/packages/ruleset/test/pagination-style.test.js
@@ -11,6 +11,22 @@ describe('Spectral rule: pagination-style', () => {
       const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
     });
+    it('Valid pagination with no "previous" or "last" properties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Delete the "previous" and "last" properties from our two pagination base schemas.
+      delete testDocument.components.schemas.OffsetPaginationBase.properties
+        .previous;
+      delete testDocument.components.schemas.OffsetPaginationBase.properties
+        .last;
+      delete testDocument.components.schemas.TokenPaginationBase.properties
+        .previous;
+      delete testDocument.components.schemas.TokenPaginationBase.properties
+        .last;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
     it('Invalid pagination on non-get operation', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -582,7 +598,7 @@ describe('Spectral rule: pagination-style', () => {
           .properties.next;
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(4);
+        expect(results).toHaveLength(2);
         for (const r of results) {
           expect(r.code).toBe(ruleId);
           expect(r.message).toMatch(expectedMsgPagelinkRE);

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -167,11 +167,11 @@ describe('cli tool - test expected output - Swagger 2', function() {
 
     // This can be uncommented to display the output when adjustments to
     // the expect statements below are needed.
-    let textOutput = '';
-    capturedText.forEach((elem, index) => {
-      textOutput += `[${index}]: ${elem}\n`;
-    });
-    console.warn(textOutput);
+    // let textOutput = '';
+    // capturedText.forEach((elem, index) => {
+    //   textOutput += `[${index}]: ${elem}\n`;
+    // });
+    // console.warn(textOutput);
 
     expect(exitCode).toEqual(1);
 


### PR DESCRIPTION
This commit fixes two issues in the 'pagination-style' rule:
1. The "previous" and "last" properties are no longer required
to be defined in a paginated response schema.  This change
brings the rule more in sync with the API handbook guidance.

2. The rule previously did not correctly process an allOf list
while performing checks on the "first", "next", "previous" or
"last" response schema properties.  This is now fixed.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

