### PR TITLE
Correct array-responses severity in documentation

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -117,7 +117,7 @@ is provided in the [Reference](#reference) section below.
 </tr>
 <tr>
 <td><a href="#rule-array-responses">array-responses</a></td>
-<td>warn</td>
+<td>error</td>
 <td>Operations should not return an array as the top-level structure of a response.</td>
 <td>oas3</td>
 </tr>


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

Code flags `array-responses` violations as `error` yet it's documented as `warn`. This change aligns documentation with implementation.

Code: https://github.com/IBM/openapi-validator/blob/main/packages/ruleset/src/rules/array-responses.js#L10

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

