### PR TITLE
New rule/array constraints

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -80,6 +80,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: string-boundary](#rule-string-boundary)
   * [Rule: unused-tag](#rule-unused-tag)
   * [Rule: valid-type-format](#rule-valid-type-format)
+  * [Rule: array-boundary](#rule-array-boundary)
 
 <!-- tocstop -->
 
@@ -398,6 +399,12 @@ has non-form content.</td>
 <td><a href="#rule-string-boundary">string-boundary</a></td>
 <td>warn</td>
 <td>String schema properties should define the <code>pattern</code>, <code>minLength</code> and <code>maxLength</code> fields</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-array-boundary">array-boundary</a></td>
+<td>warn</td>
+<td>Array schema properties should define the <code>minItems</code> and <code>maxItems</code> fields</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -4038,6 +4045,63 @@ components:
         thing_contents:
           type: string
           format: byte
+</pre>
+</td>
+</tr>
+</table>
+
+### Rule: array-boundary
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>array-boundary</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>Array schema properties should define the <code>minItems</code> and <code>maxItems</code> fields
+[<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#array">1</a>].</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Array:
+      description: An Array instance.
+      type: array
+      items:
+        type: string
+        pattern: '^[a-zA-Z0-9]*$'
+        minLength: 0
+        maxLength: 50
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Array:
+      description: An Array instance.
+      type: array
+      minItems: 0
+      maxItems: 16
+      items:
+        type: string
+        pattern: '^[a-zA-Z0-9]*$'
+        minLength: 0
+        maxLength: 50
 </pre>
 </td>
 </tr>

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -29,6 +29,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Spectral Overrides](#spectral-overrides)
 - [Reference](#reference)
   * [Rule: accept-parameter](#rule-accept-parameter)
+  * [Rule: array-boundary](#rule-array-boundary)
   * [Rule: array-items](#rule-array-items)
   * [Rule: array-of-arrays](#rule-array-of-arrays)
   * [Rule: array-responses](#rule-array-responses)
@@ -80,7 +81,6 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: string-boundary](#rule-string-boundary)
   * [Rule: unused-tag](#rule-unused-tag)
   * [Rule: valid-type-format](#rule-valid-type-format)
-  * [Rule: array-boundary](#rule-array-boundary)
 
 <!-- tocstop -->
 
@@ -105,6 +105,12 @@ is provided in the [Reference](#reference) section below.
 <td>warn</td>
 <td>Operations should not explicitly define the <code>Accept</code> header parameter</td>
 <td>oas2, oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-array-boundary">array-boundary</a></td>
+<td>warn</td>
+<td>Array schemas should define the <code>minItems</code> and <code>maxItems</code> fields</td>
+<td>oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-array-items">array-items</a></td>
@@ -402,12 +408,6 @@ has non-form content.</td>
 <td>oas3</td>
 </tr>
 <tr>
-<td><a href="#rule-array-boundary">array-boundary</a></td>
-<td>warn</td>
-<td>Array schema properties should define the <code>minItems</code> and <code>maxItems</code> fields</td>
-<td>oas3</td>
-</tr>
-<tr>
 <td><a href="#rule-unused-tag">unused-tag</a></td>
 <td>warn</td>
 <td>Verifies that each defined tag is referenced by at least one operation</td>
@@ -663,6 +663,64 @@ paths:
               schema:
                 $ref: '#/components/schemas/ThingCollection'
 
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: array-boundary
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>array-boundary</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>Array schemas should define the <code>minItems</code> and <code>maxItems</code> fields
+[<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#array">1</a>].</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Array:
+      description: An Array instance.
+      type: array
+      items:
+        type: string
+        pattern: '^[a-zA-Z0-9]*$'
+        minLength: 0
+        maxLength: 50
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Array:
+      description: An Array instance.
+      type: array
+      minItems: 0
+      maxItems: 16
+      items:
+        type: string
+        pattern: '^[a-zA-Z0-9]*$'
+        minLength: 0
+        maxLength: 50
 </pre>
 </td>
 </tr>
@@ -4045,63 +4103,6 @@ components:
         thing_contents:
           type: string
           format: byte
-</pre>
-</td>
-</tr>
-</table>
-
-### Rule: array-boundary
-<table>
-<tr>
-<td><b>Rule id:</b></td>
-<td><b>array-boundary</b></td>
-</tr>
-<tr>
-<td valign=top><b>Description:</b></td>
-<td>Array schema properties should define the <code>minItems</code> and <code>maxItems</code> fields
-[<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#array">1</a>].</td>
-</tr>
-<tr>
-<td><b>Severity:</b></td>
-<td>warn</td>
-</tr>
-<tr>
-<td><b>OAS Versions:</b></td>
-<td>oas3</td>
-</tr>
-<tr>
-<td valign=top><b>Non-compliant example:<b></td>
-<td>
-<pre>
-components:
-  schemas:
-    Array:
-      description: An Array instance.
-      type: array
-      items:
-        type: string
-        pattern: '^[a-zA-Z0-9]*$'
-        minLength: 0
-        maxLength: 50
-</pre>
-</td>
-</tr>
-<tr>
-<td valign=top><b>Compliant example:</b></td>
-<td>
-<pre>
-components:
-  schemas:
-    Array:
-      description: An Array instance.
-      type: array
-      minItems: 0
-      maxItems: 16
-      items:
-        type: string
-        pattern: '^[a-zA-Z0-9]*$'
-        minLength: 0
-        maxLength: 50
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/array-boundary.js
+++ b/packages/ruleset/src/functions/array-boundary.js
@@ -1,0 +1,55 @@
+const { validateSubschemas } = require('../utils');
+const { getSchemaType } = require('../utils');
+const { SchemaType } = require('../utils');
+
+module.exports = function(schema, _opts, { path }) {
+  return validateSubschemas(schema, path, arrayBoundaryErrors, true, false);
+};
+
+const debugEnabled = false;
+function debug(msg) {
+  if (debugEnabled) {
+    console.log(msg);
+  }
+}
+
+function arrayBoundaryErrors(schema, path) {
+  const errors = [];
+
+  if (getSchemaType(schema) === SchemaType.ARRAY) {
+    if (isUndefinedOrNull(schema.minItems)) {
+      errors.push({
+        message: 'Should define a minItems for a valid array',
+        path
+      });
+      debug('>>> minItems field missing for: ' + path.join('.'));
+    }
+    if (isUndefinedOrNull(schema.maxItems)) {
+      errors.push({
+        message: 'Should define a maxItems for a valid array',
+        path
+      });
+      debug('>>> maxItems field missing for: ' + path.join('.'));
+    }
+  } else {
+    if (schema.minItems) {
+      errors.push({
+        message: 'minItems should not be defined for a non-array schema',
+        path: [...path, 'minItems']
+      });
+      debug('>>> ' + schema.type + ' minItems should not be defined for a non-array schema for: ' + path.join('.'));
+    }
+    if (schema.maxItems) {
+      errors.push({
+        message: 'maxItems should not be defined for a non-array schema',
+        path: [...path, 'maxItems']
+      });
+      debug('>>> ' + schema.type + ' maxItems should not be defined for a non-array schema for: ' + path.join('.'));
+    }
+  }
+  return errors;
+}
+
+function isUndefinedOrNull(obj) {
+  return obj === undefined || obj === null;
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  arrayBoundary: require('./array-boundary'),
   arrayItems: require('./array-items'),
   arrayOfArrays: require('./array-of-arrays'),
   arrayResponses: require('./array-responses'),

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -90,7 +90,7 @@ module.exports = {
     'oas3-unused-component': true,
 
     // IBM Custom Rules
-
+    'array-boundary': ibmRules.arrayBoundary,
     'accept-parameter': ibmRules.acceptParameter,
     'array-items': ibmRules.arrayItems,
     'array-of-arrays': ibmRules.arrayOfArrays,

--- a/packages/ruleset/src/rules/array-boundary.js
+++ b/packages/ruleset/src/rules/array-boundary.js
@@ -1,0 +1,15 @@
+const { oas3 } = require('@stoplight/spectral-formats');
+const { arrayBoundary } = require('../functions');
+const { schemas } = require('../collections');
+
+module.exports = {
+  description: 'Array schemas should have explicit boundaries defined',
+  message: '{{error}}',
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  given: schemas,
+  then: {
+    function: arrayBoundary
+  }
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  arrayBoundary: require('./array-boundary'),
   acceptParameter: require('./accept-parameter'),
   arrayItems: require('./array-items'),
   arrayOfArrays: require('./array-of-arrays'),

--- a/packages/ruleset/test/array-boundary.test.js
+++ b/packages/ruleset/test/array-boundary.test.js
@@ -1,0 +1,388 @@
+const { arrayBoundary } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = arrayBoundary;
+const ruleId = 'array-boundary';
+const expectedSeverity = severityCodes.warning;
+const expectedMsgMin = 'Array schemas should define a numeric minItems field';
+const expectedMsgMax = 'Array schemas should define a numeric maxItems field';
+
+describe('Spectral rule: array-boundary', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Array property with min/maxItems in allOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'Drink response schema',
+        properties: {
+          main_prop: {
+            allOf: [
+              {
+                type: 'array',
+                description: 'a description',
+                items: {
+                  type: 'string'
+                }
+              },
+              {
+                type: 'array',
+                minItems: 12,
+                maxItems: 42
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Schema property uses nested allOf/oneOf with mix/maxItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'Drink response schema',
+        properties: {
+          main_prop: {
+            // At least one of the allOf schemas should have min/maxItems.
+            allOf: [
+              {
+                // Each of the oneOf schemas should have min/maxItems
+                oneOf: [
+                  {
+                    type: 'array',
+                    minItems: 45,
+                    maxItems: 100000
+                  },
+                  {
+                    type: 'array',
+                    minItems: 100001,
+                    maxItems: 100500
+                  }
+                ]
+              },
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Response schema array property with no min/maxItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Make a copy of Movie named Movie2, and make Movie2 the response schema
+      // for the create operation only.
+      const movie2 = makeCopy(testDocument.components.schemas['Movie']);
+      movie2.properties['production_crew'] = {
+        type: 'array',
+        items: {
+          type: 'string'
+        }
+      };
+      testDocument.components.schemas['Movie2'] = movie2;
+      testDocument.paths['/v1/movies'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        $ref: '#/components/schemas/Movie2'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgMin);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.201.content.application/json.schema.properties.production_crew'
+      );
+
+      expect(results[1].code).toBe(ruleId);
+      expect(results[1].message).toBe(expectedMsgMax);
+      expect(results[1].severity).toBe(expectedSeverity);
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.201.content.application/json.schema.properties.production_crew'
+      );
+    });
+
+    it('Inline response schema array property with only minItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post.responses['400'].content[
+        'application/json'
+      ].schema = {
+        description: 'An error response.',
+        type: 'object',
+        properties: {
+          trace: {
+            description: 'array containing each line of a stack trace',
+            type: 'array',
+            minItems: 1,
+            items: {
+              type: 'string',
+              format: 'uuid'
+            }
+          },
+          error: {
+            $ref: '#/components/schemas/RequestError'
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgMax);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.400.content.application/json.schema.properties.trace'
+      );
+    });
+
+    it('Schema property uses allOf without min/maxItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            allOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              },
+              {
+                type: 'array'
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgMin);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+
+      expect(results[1].code).toBe(ruleId);
+      expect(results[1].message).toBe(expectedMsgMax);
+      expect(results[1].severity).toBe(expectedSeverity);
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses oneOf without min/maxItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            oneOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                },
+                minItems: 0
+              },
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                },
+                maxItems: 5
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgMin);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+
+      expect(results[1].code).toBe(ruleId);
+      expect(results[1].message).toBe(expectedMsgMax);
+      expect(results[1].severity).toBe(expectedSeverity);
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses anyOf without min/maxItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            anyOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                },
+                minItems: 0
+              },
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                },
+                maxItems: 5
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgMin);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+
+      expect(results[1].code).toBe(ruleId);
+      expect(results[1].message).toBe(expectedMsgMax);
+      expect(results[1].severity).toBe(expectedSeverity);
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses nested allOf/oneOf without maxItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            oneOf: [
+              {
+                allOf: [
+                  {
+                    type: 'array',
+                    minItems: 0,
+                    maxItems: 4
+                  },
+                  {
+                    type: 'array',
+                    items: {
+                      type: 'string'
+                    }
+                  }
+                ]
+              },
+              {
+                type: 'array',
+                minItems: 0,
+                items: {
+                  type: 'string'
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgMax);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+
+    it('Schema property uses nested allOf/anyOf without minItems', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema = {
+        description: 'a description',
+        properties: {
+          main_prop: {
+            anyOf: [
+              {
+                allOf: [
+                  {
+                    type: 'array',
+                    minItems: 0,
+                    maxItems: 4
+                  },
+                  {
+                    type: 'array',
+                    items: {
+                      type: 'string'
+                    }
+                  }
+                ]
+              },
+              {
+                type: 'array',
+                maxItems: 1600,
+                items: {
+                  type: 'string'
+                }
+              }
+            ]
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgMin);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.properties.main_prop'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -610,6 +610,8 @@ module.exports = {
                 description:
                   'The set of Drink instances in this page of results.',
                 type: 'array',
+                minItems: 0,
+                maxItems: 50,
                 items: {
                   $ref: '#/components/schemas/Drink'
                 }
@@ -656,6 +658,8 @@ module.exports = {
                 description:
                   'The set of Movie instances in this page of results.',
                 type: 'array',
+                minItems: 0,
+                maxItems: 50,
                 items: {
                   $ref: '#/components/schemas/Movie'
                 }

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
@@ -142,6 +142,8 @@ components:
       properties:
         pets:
           type: array
+          minItems: 0
+          maxItems: 20
           description: "object containing a list of pets"
           items:
             $ref: "#/components/schemas/Pet"

--- a/packages/validator/test/cli-validator/mock-files/oas3/component-path-example.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/component-path-example.yaml
@@ -101,6 +101,8 @@ components:
       properties:
         chars:
           type: array
+          minItems: 0
+          maxItems: 200
           description: all the characters
           items:
             type: string

--- a/packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
@@ -79,6 +79,8 @@ paths:
           explode: true
           schema:
             type: array
+            minItems: 0
+            maxItems: 20
             items:
               type: string
               enum:
@@ -93,11 +95,15 @@ paths:
             application/xml:
               schema:
                 type: array
+                minItems: 0
+                maxItems: 20
                 items:
                   $ref: "#/components/schemas/Pet"
             application/json:
               schema:
                 type: array
+                minItems: 0
+                maxItems: 20
                 items:
                   $ref: "#/components/schemas/Pet"
         "400":
@@ -178,6 +184,8 @@ components:
         photo_urls:
           type: array
           description: string
+          minItems: 0
+          maxItems: 20
           xml:
             name: photoUrl
             wrapped: true
@@ -186,6 +194,8 @@ components:
         tags:
           type: array
           description: string
+          minItems: 0
+          maxItems: 20
           xml:
             name: tag
             wrapped: true


### PR DESCRIPTION
## PR summary
Adds a new rule to enforce constraints are set on array schemas. This is to enforce [the related guidance in the API Handbook](https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#array) and resolves #458.

One consideration is that the constraints are only required for request schemas and just recommended for response schemas. We could potentially only validate request schemas but the "SHOULD" in the handbook for response schemas seems enough motivation to me to add the warning. Happy to entertain other opinions on this. It is the kind of rule that may start adding lots of warnings in user's API Definitions.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

