### PR TITLE
fix(response-status-codes): add check for 201 response on 'create' operation

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -3495,10 +3495,13 @@ responses:
 <code>101 - Switching Protocols</code> status code is used, which should be extremely rare (it's normally used with websockets).</li>
 <li>A <code>204 - No Content</code> response should not include content.</li>
 <li>A non-204 success status code (e.g. <code>200 - OK</code>, <code>201 - Created</code>, etc.) should include content.</li>
+<li>A `create`-type operation (the method is POST or the operationId starts with <code>'create'</code>) must return either a <code>201 - Created</code>
+or a <code>202 - Accepted</code> status code.</li>
 </ul>
 <p>References: 
 <ul>
-<li><a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-status-codes">IBM Cloud API Handbook</a></li>
+<li><a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-status-codes">IBM Cloud API Handbook: Fundamentals/Status Codes</a></li>
+<li><a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-methods#post">IBM Cloud API Handbook: Fundamentals/Methods/POST</a></li>
 <li><a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6">RFC7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a></li>
 </ul>
 </td>

--- a/packages/ruleset/test/response-status-codes.test.js
+++ b/packages/ruleset/test/response-status-codes.test.js
@@ -15,11 +15,58 @@ describe('Spectral rule: response-status-codes', () => {
     it('101 with no 2xx codes', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks'].post.responses = {
+      testDocument.paths['/v1/drinks'].get.responses = {
         '101': {
           description: 'protocol-switching response'
         }
       };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('POST non-"create" w/201', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.operationId = 'pour_drink';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('POST non-"create" w/202', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.operationId = 'pour_drink';
+      testDocument.paths['/v1/drinks'].post.responses['202'] = {
+        description: 'Request to create new resource was accepted'
+      };
+      delete testDocument.paths['/v1/drinks'].post.responses['201'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('non-POST "create" w/201', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].get.operationId = 'create_drink';
+      testDocument.paths['/v1/drinks'].get.responses['201'] =
+        testDocument.paths['/v1/drinks'].get.responses['200'];
+      delete testDocument.paths['/v1/drinks'].get.responses['200'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('non-POST "create" w/202', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].get.operationId = 'create_drink';
+      testDocument.paths['/v1/drinks'].get.responses['202'] = {
+        description: 'Request to create new resource was accepted'
+      };
+      delete testDocument.paths['/v1/drinks'].get.responses['200'];
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
@@ -90,9 +137,9 @@ describe('Spectral rule: response-status-codes', () => {
     it('204 status code with response content', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks'].post.responses['204'] =
-        testDocument.paths['/v1/drinks'].post.responses['201'];
-      delete testDocument.paths['/v1/drinks'].post.responses['201'];
+      testDocument.paths['/v1/drinks'].get.responses['204'] =
+        testDocument.paths['/v1/drinks'].get.responses['200'];
+      delete testDocument.paths['/v1/drinks'].get.responses['200'];
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -103,14 +150,14 @@ describe('Spectral rule: response-status-codes', () => {
       );
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/drinks.post.responses.204.content'
+        'paths./v1/drinks.get.responses.204.content'
       );
     });
 
     it('No success status codes', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      delete testDocument.paths['/v1/drinks'].post.responses['201'];
+      delete testDocument.paths['/v1/drinks'].get.responses['200'];
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -118,6 +165,41 @@ describe('Spectral rule: response-status-codes', () => {
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(
         'Operation `responses` should include at least one success status code (2xx).'
+      );
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/drinks.get.responses');
+    });
+
+    it('non-POST "create" operation with no 201/202 status code', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].get.operationId = 'create_drink';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(
+        "A 201 or 202 status code should be returned by a 'create' operation."
+      );
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/drinks.get.responses');
+    });
+
+    it('POST non-"create" operation with no 201/202 status code', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.operationId = 'pour_drink';
+      testDocument.paths['/v1/drinks'].post.responses['200'] =
+        testDocument.paths['/v1/drinks'].post.responses['201'];
+      delete testDocument.paths['/v1/drinks'].post.responses['201'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(
+        "A 201 or 202 status code should be returned by a 'create' operation."
       );
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe('paths./v1/drinks.post.responses');

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
@@ -63,8 +63,12 @@ paths:
       tags:
         - pets
       responses:
-        '204':
-          description: Null response
+        '201':
+          description: success!
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
         default:
           description: unexpected error
           content:

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -367,7 +367,7 @@ describe('test expected output - OpenAPI 3', function() {
     const validationResults = await inCodeValidator(oas3Object, defaultMode);
 
     expect(validationResults.errors.length).toBe(3);
-    expect(validationResults.warnings.length).toBe(47);
+    expect(validationResults.warnings.length).toBe(48);
     expect(validationResults.infos).not.toBeDefined();
     expect(validationResults.hints).not.toBeDefined();
 


### PR DESCRIPTION
## PR summary

This commit updates the 'response-status-codes' rule so that it will
now check to make sure that an operation whose operationId starts with
the word "create" is returning a '201 - Created' status code.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

