### PR TITLE
feat(delete-body): add new spectral-style 'delete-body' rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -39,6 +39,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: content-entry-contains-schema](#rule-content-entry-contains-schema)
   * [Rule: content-entry-provided](#rule-content-entry-provided)
   * [Rule: content-type-parameter](#rule-content-type-parameter)
+  * [Rule: delete-body](#rule-delete-body)
   * [Rule: description-mentions-json](#rule-description-mentions-json)
   * [Rule: discriminator](#rule-discriminator)
   * [Rule: duplicate-path-parameter](#rule-duplicate-path-parameter)
@@ -165,6 +166,12 @@ is provided in the [Reference](#reference) section below.
 <td>warn</td>
 <td>Operations should not explicitly define the <code>Content-Type</code> header parameter</td>
 <td>oas2, oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-delete-body">delete-body</a></td>
+<td>warn</td>
+<td>"delete" operations should not contain a requestBody.</td>
+<td>oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-description-mentions-json">description-mentions-json</a></td>
@@ -1289,6 +1296,65 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Thing'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: delete-body
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>delete-body</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule checks each "delete" operation and will return a warning if the operation contains a <code>requestBody</code>.</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#/components/parameters/ThingIdParam'
+    delete:
+      operationId: delete_thing
+      requestBody:
+          description: 'The Thing instance to be deleted.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+      responses:
+        '204':
+          description: 'The thing was deleted'
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#/components/parameters/ThingIdParam'
+    delete:
+      operationId: delete_thing
+      responses:
+        '204':
+          description: 'The thing was deleted'
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/delete-body.js
+++ b/packages/ruleset/src/functions/delete-body.js
@@ -1,0 +1,21 @@
+module.exports = function(operation, _opts, { path }) {
+  return deleteBody(operation, path);
+};
+
+// This rule warns about a delete operation if it has a requestBody.
+function deleteBody(operation, path) {
+  // Grab the http method from the end of the path.
+  const method = path[path.length - 1].trim().toLowerCase();
+
+  // Return a warning if we're looking at a "delete" that has a requestBody.
+  if (method === 'delete' && 'requestBody' in operation) {
+    return [
+      {
+        message: '"delete" operation should not contain a requestBody.',
+        path: [...path, 'requestBody']
+      }
+    ];
+  }
+
+  return [];
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -6,6 +6,7 @@ module.exports = {
   binarySchemas: require('./binary-schemas'),
   checkMajorVersion: require('./check-major-version'),
   circularRefs: require('./circular-refs'),
+  deleteBody: require('./delete-body'),
   descriptionMentionsJSON: require('./description-mentions-json'),
   disallowedHeaderParameter: require('./disallowed-header-parameter'),
   discriminator: require('./discriminator'),

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -101,6 +101,7 @@ module.exports = {
     'content-entry-contains-schema': ibmRules.contentEntryContainsSchema,
     'content-entry-provided': ibmRules.contentEntryProvided,
     'content-type-parameter': ibmRules.contentTypeParameter,
+    'delete-body': ibmRules.deleteBody,
     'description-mentions-json': ibmRules.descriptionMentionsJSON,
     discriminator: ibmRules.discriminator,
     'duplicate-path-parameter': ibmRules.duplicatePathParameter,

--- a/packages/ruleset/src/rules/delete-body.js
+++ b/packages/ruleset/src/rules/delete-body.js
@@ -1,0 +1,15 @@
+const { oas3 } = require('@stoplight/spectral-formats');
+const { deleteBody } = require('../functions');
+const { operations } = require('../collections');
+
+module.exports = {
+  description: '"delete" operation should not contain a requestBody.',
+  message: '{{error}}',
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  given: operations,
+  then: {
+    function: deleteBody
+  }
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -10,6 +10,7 @@ module.exports = {
   contentEntryContainsSchema: require('./content-entry-contains-schema'),
   contentEntryProvided: require('./content-entry-provided'),
   contentTypeParameter: require('./content-type-parameter'),
+  deleteBody: require('./delete-body'),
   descriptionMentionsJSON: require('./description-mentions-json'),
   discriminator: require('./discriminator'),
   duplicatePathParameter: require('./duplicate-path-parameter'),

--- a/packages/ruleset/test/delete-body.test.js
+++ b/packages/ruleset/test/delete-body.test.js
@@ -1,0 +1,56 @@
+const { deleteBody } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = deleteBody;
+const ruleId = 'delete-body';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg = '"delete" operation should not contain a requestBody.';
+
+describe('Spectral rule: delete-body', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Delete operation w/a requestBody', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].delete = {
+        operationId: 'delete_drink',
+        summary: 'Pour a drink down the drain',
+        description: 'Pour a drink down the drain',
+        tags: ['TestTag'],
+        requestBody: {
+          content: {
+            'text/html': {
+              schema: {
+                type: 'string'
+              }
+            }
+          }
+        },
+        responses: {
+          '204': {
+            description: 'Drink successfully poured!'
+          },
+          '400': {
+            $ref: '#/components/responses/BarIsClosed'
+          }
+        }
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      for (const r of results) {
+        expect(r.code).toBe(ruleId);
+        expect(r.message).toBe(expectedMsg);
+        expect(r.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.delete.requestBody'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
This commit adds a new spectral-style rule with id 'delete-body',
which will warn about any "delete" operations that contain
a requestBody field.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

