### PR TITLE
fix: update spectral version to resolve path mapping bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,9 +1549,9 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.4.1.tgz",
-      "integrity": "sha512-l5nWXy/6YEyk51VVrOurhupVScIqfK0ra8yIRSli+gnW5Kf5Nfw5PLci5GceQGaM5WE+wmqZ/iY95yOVFwHc+A==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.4.2.tgz",
+      "integrity": "sha512-pVj/BApBC/29URqLZ05nsYxvkzni4tu71jFA1Sv7hvZeX11KStMgYWVAfLRmOswMJ5rGK6UFRJA1GRSBw1Dtqw==",
       "dependencies": {
         "@rollup/plugin-commonjs": "^20.0.0",
         "@stoplight/json": "3.17.0",
@@ -1596,9 +1596,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.12.2.tgz",
-      "integrity": "sha512-g2Nfvqr3m+hl7goB1VzAd7700xkrhReiQY+mb45NMzORKxy4JJfWdb23d8egdb/djyVOZ5QsFxQToGsCLVHu/w==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.12.4.tgz",
+      "integrity": "sha512-LArBw61vR3vvMN+QDxIP5Hq+Ms5YB0spoJyutVjOkrLpEvuObIODmU3eMTJ54+TjZ+4R+MbyzxpjqEYXif5pQw==",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.1",
         "@stoplight/json": "~3.18.1",
@@ -1607,8 +1607,8 @@
         "@stoplight/spectral-parsers": "^1.0.0",
         "@stoplight/spectral-ref-resolver": "^1.0.0",
         "@stoplight/spectral-runtime": "^1.0.0",
-        "@stoplight/types": "13.1.0",
-        "@types/json-schema": "^7.0.7",
+        "@stoplight/types": "~13.2.0",
+        "@types/json-schema": "^7.0.11",
         "ajv": "^8.6.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
@@ -1616,8 +1616,8 @@
         "jsonpath-plus": "6.0.1",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
-        "minimatch": "3.0.4",
-        "nimma": "0.2.1",
+        "minimatch": "3.1.2",
+        "nimma": "0.2.2",
         "pony-cause": "^1.0.0",
         "simple-eval": "1.0.0",
         "tslib": "^2.3.0"
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/@stoplight/types": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.1.0.tgz",
-      "integrity": "sha512-ese47WaU0Jepai7ZzCs1uy5UqpoFZ9a9rDNPHQMBIGAq/dfMPWHK5rbpOiSzBGtysyley4tzx7hjjpYkfvB3HQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.2.0.tgz",
+      "integrity": "sha512-V3BRfzWEAcCpICGQh/WW2LX4rcB2KagQ7/msf0BDTCF5qpFMSwOxcjv25k1NUMVQSh3qwGfGoka/gYGA5m+NQA==",
       "dependencies": {
         "@types/json-schema": "^7.0.4",
         "utility-types": "^3.10.0"
@@ -4580,17 +4580,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -6596,9 +6585,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6741,9 +6730,9 @@
       "dev": true
     },
     "node_modules/nimma": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.1.tgz",
-      "integrity": "sha512-z3QgbdfhBRUBIJX6eRgNyu5z3KE7AEHYPBvIcsmEsS7hO7TdNaaXHiz21FNEVIVuhH6QsvFGw/4vGmRpDrz+HA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
+      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
       "dependencies": {
         "@jsep-plugin/regex": "^1.0.1",
         "@jsep-plugin/ternary": "^1.0.2",
@@ -12136,7 +12125,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "0.30.0",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/spectral-formats": "^1.1.0",
@@ -12145,7 +12134,7 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@stoplight/spectral-core": "^1.11.0",
+        "@stoplight/spectral-core": "^1.12.4",
         "jest": "^27.4.5"
       },
       "engines": {
@@ -12154,12 +12143,12 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "0.81.0",
+      "version": "0.83.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "0.30.0",
-        "@stoplight/spectral-cli": "^6.3.0",
-        "@stoplight/spectral-core": "^1.11.0",
+        "@ibm-cloud/openapi-ruleset": "0.32.0",
+        "@stoplight/spectral-cli": "^6.4.2",
+        "@stoplight/spectral-core": "^1.12.4",
         "@stoplight/spectral-parsers": "^1.0.1",
         "chalk": "^4.1.1",
         "commander": "^2.20.3",
@@ -12642,7 +12631,7 @@
     "@ibm-cloud/openapi-ruleset": {
       "version": "file:packages/ruleset",
       "requires": {
-        "@stoplight/spectral-core": "^1.11.0",
+        "@stoplight/spectral-core": "^1.12.4",
         "@stoplight/spectral-formats": "^1.1.0",
         "@stoplight/spectral-functions": "^1.6.1",
         "@stoplight/spectral-rulesets": "^1.6.0",
@@ -13404,9 +13393,9 @@
       "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
     },
     "@stoplight/spectral-cli": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.4.1.tgz",
-      "integrity": "sha512-l5nWXy/6YEyk51VVrOurhupVScIqfK0ra8yIRSli+gnW5Kf5Nfw5PLci5GceQGaM5WE+wmqZ/iY95yOVFwHc+A==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.4.2.tgz",
+      "integrity": "sha512-pVj/BApBC/29URqLZ05nsYxvkzni4tu71jFA1Sv7hvZeX11KStMgYWVAfLRmOswMJ5rGK6UFRJA1GRSBw1Dtqw==",
       "requires": {
         "@rollup/plugin-commonjs": "^20.0.0",
         "@stoplight/json": "3.17.0",
@@ -13444,9 +13433,9 @@
       }
     },
     "@stoplight/spectral-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.12.2.tgz",
-      "integrity": "sha512-g2Nfvqr3m+hl7goB1VzAd7700xkrhReiQY+mb45NMzORKxy4JJfWdb23d8egdb/djyVOZ5QsFxQToGsCLVHu/w==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.12.4.tgz",
+      "integrity": "sha512-LArBw61vR3vvMN+QDxIP5Hq+Ms5YB0spoJyutVjOkrLpEvuObIODmU3eMTJ54+TjZ+4R+MbyzxpjqEYXif5pQw==",
       "requires": {
         "@stoplight/better-ajv-errors": "1.0.1",
         "@stoplight/json": "~3.18.1",
@@ -13455,8 +13444,8 @@
         "@stoplight/spectral-parsers": "^1.0.0",
         "@stoplight/spectral-ref-resolver": "^1.0.0",
         "@stoplight/spectral-runtime": "^1.0.0",
-        "@stoplight/types": "13.1.0",
-        "@types/json-schema": "^7.0.7",
+        "@stoplight/types": "~13.2.0",
+        "@types/json-schema": "^7.0.11",
         "ajv": "^8.6.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
@@ -13464,8 +13453,8 @@
         "jsonpath-plus": "6.0.1",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
-        "minimatch": "3.0.4",
-        "nimma": "0.2.1",
+        "minimatch": "3.1.2",
+        "nimma": "0.2.2",
         "pony-cause": "^1.0.0",
         "simple-eval": "1.0.0",
         "tslib": "^2.3.0"
@@ -13484,9 +13473,9 @@
           }
         },
         "@stoplight/types": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.1.0.tgz",
-          "integrity": "sha512-ese47WaU0Jepai7ZzCs1uy5UqpoFZ9a9rDNPHQMBIGAq/dfMPWHK5rbpOiSzBGtysyley4tzx7hjjpYkfvB3HQ==",
+          "version": "13.2.0",
+          "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.2.0.tgz",
+          "integrity": "sha512-V3BRfzWEAcCpICGQh/WW2LX4rcB2KagQ7/msf0BDTCF5qpFMSwOxcjv25k1NUMVQSh3qwGfGoka/gYGA5m+NQA==",
           "requires": {
             "@types/json-schema": "^7.0.4",
             "utility-types": "^3.10.0"
@@ -15772,16 +15761,6 @@
         "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -15940,9 +15919,9 @@
     "ibm-openapi-validator": {
       "version": "file:packages/validator",
       "requires": {
-        "@ibm-cloud/openapi-ruleset": "0.30.0",
-        "@stoplight/spectral-cli": "^6.3.0",
-        "@stoplight/spectral-core": "^1.11.0",
+        "@ibm-cloud/openapi-ruleset": "0.32.0",
+        "@stoplight/spectral-cli": "^6.4.2",
+        "@stoplight/spectral-core": "^1.12.4",
         "@stoplight/spectral-parsers": "^1.0.1",
         "chalk": "^4.1.1",
         "commander": "^2.20.3",
@@ -17352,9 +17331,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -17467,9 +17446,9 @@
       "dev": true
     },
     "nimma": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.1.tgz",
-      "integrity": "sha512-z3QgbdfhBRUBIJX6eRgNyu5z3KE7AEHYPBvIcsmEsS7hO7TdNaaXHiz21FNEVIVuhH6QsvFGw/4vGmRpDrz+HA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
+      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
       "requires": {
         "@jsep-plugin/regex": "^1.0.1",
         "@jsep-plugin/ternary": "^1.0.2",

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@stoplight/spectral-core": "^1.11.0",
+    "@stoplight/spectral-core": "^1.12.4",
     "jest": "^27.4.5"
   },
   "engines": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@ibm-cloud/openapi-ruleset": "0.32.0",
-    "@stoplight/spectral-cli": "^6.3.0",
-    "@stoplight/spectral-core": "^1.11.0",
+    "@stoplight/spectral-cli": "^6.4.2",
+    "@stoplight/spectral-core": "^1.12.4",
     "@stoplight/spectral-parsers": "^1.0.1",
     "chalk": "^4.1.1",
     "commander": "^2.20.3",

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -183,8 +183,9 @@ describe('cli tool - test expected output - Swagger 2', function() {
     expect(capturedText[8].match(/\S+/g)[2]).toEqual('172');
     // warnings
     expect(capturedText[13].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[17].match(/\S+/g)[2]).toEqual('166');
-    expect(capturedText[21].match(/\S+/g)[2]).toEqual('197');
+    expect(capturedText[17].match(/\S+/g)[2]).toEqual('131');
+    expect(capturedText[21].match(/\S+/g)[2]).toEqual('134');
+    expect(capturedText[25].match(/\S+/g)[2]).toEqual('197');
   });
 
   it('should return exit code of 0 if there are only warnings', async function() {
@@ -412,8 +413,8 @@ describe('test expected output - OpenAPI 3', function() {
 
     expect(warningToCheck.rule).toEqual('pagination-style');
     expect(warningToCheck.path.join('.')).toBe(
-      'components.responses.StringsResponse.content.application/json.schema'
+      'components.schemas.ListOfCharacters'
     );
-    expect(warningToCheck.line).toEqual(91);
+    expect(warningToCheck.line).toEqual(94);
   });
 });

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -129,7 +129,7 @@ describe('cli tool - test option handling', function() {
 
     // totals
     expect(capturedText[statsSection + 1].match(/\S+/g)[5]).toEqual('2');
-    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('3');
+    expect(capturedText[statsSection + 2].match(/\S+/g)[5]).toEqual('4');
 
     // errors
     expect(capturedText[statsSection + 5].match(/\S+/g)[0]).toEqual('1');
@@ -140,10 +140,13 @@ describe('cli tool - test option handling', function() {
 
     // warnings
     expect(capturedText[statsSection + 9].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 9].match(/\S+/g)[1]).toEqual('(33%)');
+    expect(capturedText[statsSection + 9].match(/\S+/g)[1]).toEqual('(25%)');
 
-    expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('1');
-    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(33%)');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[0]).toEqual('2');
+    expect(capturedText[statsSection + 10].match(/\S+/g)[1]).toEqual('(50%)');
+
+    expect(capturedText[statsSection + 11].match(/\S+/g)[0]).toEqual('1');
+    expect(capturedText[statsSection + 11].match(/\S+/g)[1]).toEqual('(25%)');
   });
 
   it('should not print statistics report by default', async function() {


### PR DESCRIPTION
This resolves an issue in which users would see validations with
paths that did not point to the correct location in the API definition.
This was caused by a bug in Spectral that has now been fixed.
