### PR TITLE
refactor: move $ref check out of individual functions

### DIFF
--- a/packages/ruleset/src/functions/array-boundary.js
+++ b/packages/ruleset/src/functions/array-boundary.js
@@ -17,12 +17,6 @@ function debug(msg) {
 }
 
 function arrayBoundaryErrors(schema, path) {
-  // If "schema" is a $ref, that means it didn't get resolved
-  // properly (perhaps due to a circular ref), so just ignore it.
-  if (schema.$ref) {
-    return [];
-  }
-
   if (getSchemaType(schema) !== SchemaType.ARRAY) {
     return [];
   }

--- a/packages/ruleset/src/functions/property-description.js
+++ b/packages/ruleset/src/functions/property-description.js
@@ -9,11 +9,6 @@ module.exports = function(schema, _opts, { path }) {
 };
 
 function propertyDescription(schema, path) {
-  // If "schema" is a $ref, that means it didn't get resolved
-  // properly (perhaps due to a circular ref), so just ignore it.
-  if (schema.$ref) {
-    return [];
-  }
   // If "schema" is a schema property, then check for a description.
   const isSchemaProperty = pathMatchesRegexp(path, /^.*,properties,[^,]*$/);
   if (isSchemaProperty && !schemaHasDescription(schema)) {

--- a/packages/ruleset/src/functions/ref-sibling-duplicate-description.js
+++ b/packages/ruleset/src/functions/ref-sibling-duplicate-description.js
@@ -5,12 +5,6 @@ module.exports = function(schema, _opts, { path }) {
 };
 
 function checkDuplicateDescription(schema, path) {
-  // If "schema" is a $ref, that means it didn't get resolved
-  // properly (perhaps due to a circular ref), so just ignore it.
-  if (schema.$ref) {
-    return [];
-  }
-
   // We're only interested in a schema or schema property that has an allOf list.
   if (!Array.isArray(schema.allOf) || !schema.allOf.length) {
     return [];

--- a/packages/ruleset/src/functions/schema-description.js
+++ b/packages/ruleset/src/functions/schema-description.js
@@ -9,12 +9,6 @@ module.exports = function(schema, _opts, { path }) {
 };
 
 function schemaDescription(schema, path) {
-  // If "schema" is a $ref, that means it didn't get resolved
-  // properly (perhaps due to a circular ref), so just ignore it.
-  if (schema.$ref) {
-    return [];
-  }
-
   //
   // Check to see if "path" represents a primary schema (i.e. not a schema property).
   // Note: the regexp used below uses a "lookbehind assertion"

--- a/packages/ruleset/src/functions/schema-type.js
+++ b/packages/ruleset/src/functions/schema-type.js
@@ -12,12 +12,6 @@ function schemaType(schema, path) {
     return [];
   }
 
-  // If "schema" is a $ref, that means it didn't get resolved
-  // properly (perhaps due to a circular ref), so just ignore it.
-  if (schema.$ref) {
-    return [];
-  }
-
   const mergedSchema = mergeAllOfSchemaProperties(schema);
 
   if (!schemaHasType(mergedSchema)) {

--- a/packages/ruleset/src/utils/validate-composed-schemas.js
+++ b/packages/ruleset/src/utils/validate-composed-schemas.js
@@ -6,6 +6,9 @@
  *
  * Composed schemas DO NOT include nested schemas (property schemas, items schemas).
  *
+ * Note: it is only safe to use this method within functions operating on the "resolved" specification,
+ * which should always be the case.
+ *
  * @param {object} schema - Simple or composite OpenAPI 3.0 schema object.
  * @param {array} path - Path array for the provided schema.
  * @param {function} validate - Validate function.
@@ -20,6 +23,12 @@ const validateComposedSchemas = (
   includeSelf = true,
   includeNot = true
 ) => {
+  // If "schema" is a $ref, that means it didn't get resolved
+  // properly (perhaps due to a circular ref), so just ignore it.
+  if (schema.$ref) {
+    return [];
+  }
+
   const errors = [];
 
   if (includeSelf) {

--- a/packages/ruleset/src/utils/validate-nested-schemas.js
+++ b/packages/ruleset/src/utils/validate-nested-schemas.js
@@ -7,6 +7,9 @@
  * Nested schemas included via `allOf`, `oneOf`, and `anyOf` are validated, but composed schemas
  * are not themselves validated. Nested schemas included via `not` are not validated.
  *
+ * Note: it is only safe to use this method within functions operating on the "resolved" specification,
+ * which should always be the case.
+ *
  * @param {object} schema - Simple or composite OpenAPI 3.0 schema object.
  * @param {array} path - Path array for the provided schema.
  * @param {function} validate - Validate function.
@@ -21,6 +24,12 @@ const validateNestedSchemas = (
   includeSelf = true,
   includeNot = false
 ) => {
+  // If "schema" is a $ref, that means it didn't get resolved
+  // properly (perhaps due to a circular ref), so just ignore it.
+  if (schema.$ref) {
+    return [];
+  }
+
   const errors = [];
 
   if (includeSelf) {

--- a/packages/ruleset/src/utils/validate-subschemas.js
+++ b/packages/ruleset/src/utils/validate-subschemas.js
@@ -8,6 +8,9 @@ const validateNestedSchemas = require('./validate-nested-schemas');
  * and applicator schemas (such as those in an `allOf` or `oneOf` property), plus all subschemas
  * of those schemas.
  *
+ * Note: it is only safe to use this method within functions operating on the "resolved" specification,
+ * which should always be the case.
+ *
  * @param {object} schema - Simple or composite OpenAPI 3.0 schema object.
  * @param {array} path - Path array for the provided schema.
  * @param {function} validate - Validate function.

--- a/packages/ruleset/test/validate-composed-schemas.test.js
+++ b/packages/ruleset/test/validate-composed-schemas.test.js
@@ -188,4 +188,21 @@ describe('Utility function: validateComposedSchemas()', () => {
 
     expect(visitedPaths).toEqual(['']);
   });
+
+  it('should skip schemas defined by a $ref', async () => {
+    const schema = {
+      allOf: [
+        {
+          $ref: '#/components/schemas/SomeSchema'
+        },
+        {}
+      ]
+    };
+
+    const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
+      return [p.join('.')];
+    });
+
+    expect(visitedPaths.sort()).toEqual(['', 'allOf.1'].sort());
+  });
 });

--- a/packages/ruleset/test/validate-nested-schemas.test.js
+++ b/packages/ruleset/test/validate-nested-schemas.test.js
@@ -202,4 +202,24 @@ describe('Utility function: validateNestedSchemas()', () => {
       return [];
     });
   });
+
+  it('should skip schemas defined by a $ref', async () => {
+    const schema = {
+      properties: {
+        one: {},
+        two: {},
+        three: {
+          $ref: '#/components/schemas/Three'
+        }
+      }
+    };
+
+    const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
+      return [p.join('.')];
+    });
+
+    expect(visitedPaths.sort()).toEqual(
+      ['', 'properties.one', 'properties.two'].sort()
+    );
+  });
 });


### PR DESCRIPTION
When invoking a function on a rule with the resolved spec, it is prudent to
check for schemas defined by a $ref. In the resolved spec, schemas defined with
a $ref are the result of circular references being detected and it isn't
necessary to validate the schemas.

To avoid duplicating this check for each function and requiring manual
maintenance in all functions (many were missing the check), I moved it to the
validate functions that they all rely on to recursively check schemas.

The only potential downside here is that it would prevent us from writing a
function that recursively walks through the unresolved spec and that also
relies on the presence of $refs in the schemas. This feels extremely unlikely
to me so it seems a worthwhile optimization.

Happy to be corrected if I'm making a bad assumption here!