### PR TITLE
fix(string-boundary): improve handling of composed schemas

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -3974,8 +3974,23 @@ servers:
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>
-<td>String schema properties should define the <code>pattern</code>, <code>minLength</code> and <code>maxLength</code> fields
-[<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#string">1</a>].</td>
+<td>This rule checks to make sure that string schema properties define the <code>pattern</code>, <code>minLength</code> and <code>maxLength</code>
+fields in order to clearly define the set of valid values for the property.
+[<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#string">1</a>].
+<p>Note that these checks are bypassed for the following scenarios:
+<ul>
+<li>All checks are bypassed for string schemas that are used only within an operation response.
+<li>All checks are bypassed for string schemas that contain an <code>enum</code> field.</li>
+<li>The check for the <code>pattern</code> field is bypassed if <code>format</code> is set to 
+<code>binary</code>, <code>byte</code>, <code>date</code>, <code>date-time</code>, or <code>url</code>.</li>
+<li>The check for the <code>minLength</code> field is bypassed if <code>format</code> is set to
+<code>date</code>, <code>identifier</code>, or <code>url</code>.</li>
+<li>The check for the <code>maxLength</code> field is bypassed if <code>format</code> is set to <code>date</code>.</li>
+</ul>
+<p>This rule also checks non-string schema properties to make sure they do not define the
+code>pattern</code>, <code>minLength</code> and <code>maxLength</code> fields since these fields are applicable
+only for string schemas.
+</td>
 </tr>
 <tr>
 <td><b>Severity:</b></td>

--- a/packages/ruleset/src/utils/get-composite-schema-attribute.js
+++ b/packages/ruleset/src/utils/get-composite-schema-attribute.js
@@ -1,0 +1,25 @@
+const checkCompositeSchemaForConstraint = require('./check-composite-schema-for-constraint');
+
+/**
+ * Retrieves the value of "schema"'s attribute named "attrName" either directly from "schema"
+ * or from one of its composition "children".
+ *
+ * This function can be used in scenarios where you need to retrieve a particular schema's
+ * field (e.g. the pattern field), but the field might exist either in "schema" itself,
+ * or within one or more allOf/anyOf/oneOf list element schemas.
+ * @param {*} schema the schema to retrieve the attribute from
+ * @param {*} attrName the name of the attribute to retrieve
+ * @returns the value of the attribute or undefined if not present
+ */
+function getCompositeSchemaAttribute(schema, attrName) {
+  let value = undefined;
+  const foundConstraint = checkCompositeSchemaForConstraint(schema, s => {
+    if (attrName in s && s[attrName] !== undefined && s[attrName] !== null) {
+      value = s[attrName];
+      return true;
+    }
+  });
+  return foundConstraint ? value : undefined;
+}
+
+module.exports = getCompositeSchemaAttribute;

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   checkCompositeSchemaForConstraint: require('./check-composite-schema-for-constraint'),
   checkCompositeSchemaForProperty: require('./check-composite-schema-for-property'),
+  getCompositeSchemaAttribute: require('./get-composite-schema-attribute'),
   getPropertyNamesForSchema: require('./get-property-names-for-schema'),
   isDeprecated: require('./is-deprecated'),
   isFormMimeType: require('./is-form-mimetype'),

--- a/packages/ruleset/test/get-composite-schema-attribute.test.js
+++ b/packages/ruleset/test/get-composite-schema-attribute.test.js
@@ -1,0 +1,126 @@
+const { getCompositeSchemaAttribute } = require('../src/utils');
+
+describe('Utility function: getCompositeSchemaAttribute()', () => {
+  it('Boundary conditions', async () => {
+    expect(getCompositeSchemaAttribute(undefined, undefined)).toBe(undefined);
+    expect(getCompositeSchemaAttribute(undefined, null)).toBe(undefined);
+    expect(getCompositeSchemaAttribute(null, undefined)).toBe(undefined);
+    expect(getCompositeSchemaAttribute(null, null)).toBe(undefined);
+  });
+
+  it('Should return attribute within non-composed schema', async () => {
+    const schema = {
+      type: 'string',
+      format: 'date-time'
+    };
+    expect(getCompositeSchemaAttribute(schema, 'format')).toBe('date-time');
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
+  });
+
+  it('Should return `undefined` for a schema with empty `allOf`', async () => {
+    const schema = { allOf: [] };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe(undefined);
+  });
+
+  it('Should return `undefined` for a schema with empty `anyOf`', async () => {
+    const schema = { anyOf: [] };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe(undefined);
+  });
+
+  it('Should return `undefined` for a schema with empty `oneOf`', async () => {
+    const schema = { oneOf: [] };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe(undefined);
+  });
+
+  it('Should return attribute if present in one of the allOf schemas', async () => {
+    const schema = {
+      allOf: [
+        {
+          type: 'string'
+        },
+        {
+          format: 'byte'
+        }
+      ]
+    };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
+    expect(getCompositeSchemaAttribute(schema, 'format')).toBe('byte');
+  });
+
+  it('Should return attribute if present in each of the anyOf schemas', async () => {
+    const schema = {
+      anyOf: [
+        {
+          type: 'string',
+          format: 'byte'
+        },
+        {
+          type: 'string'
+        }
+      ]
+    };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
+    expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
+  });
+
+  it('Should return attribute if present in each of the oneOf schemas', async () => {
+    const schema = {
+      oneOf: [
+        {
+          type: 'string',
+          format: 'byte'
+        },
+        {
+          type: 'string'
+        }
+      ]
+    };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
+    expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
+  });
+
+  it('Should recurse through `oneOf` and `allOf`', async () => {
+    const schema = {
+      oneOf: [
+        {
+          allOf: [{ type: 'string' }, { format: 'byte' }]
+        },
+        {
+          type: 'string'
+        }
+      ]
+    };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
+    expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
+  });
+
+  it('Should recurse through `anyOf` and `allOf`', async () => {
+    const schema = {
+      anyOf: [
+        {
+          allOf: [{ type: 'string' }, { format: 'byte' }]
+        },
+        {
+          type: 'string'
+        }
+      ]
+    };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
+    expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
+  });
+
+  it('Should recurse through `allOf` and `oneOf`', async () => {
+    const schema = {
+      allOf: [
+        {
+          oneOf: [{ type: 'string', format: 'uri' }, { type: 'string' }]
+        },
+        {
+          format: 'byte'
+        }
+      ]
+    };
+    expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
+    expect(getCompositeSchemaAttribute(schema, 'format')).toBe('byte');
+  });
+});

--- a/packages/ruleset/test/string-boundary.test.js
+++ b/packages/ruleset/test/string-boundary.test.js
@@ -4,451 +4,516 @@ const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 const name = 'string-boundary';
 
 describe('Spectral rule: string-boundary', () => {
-  it('should not error with a clean spec', async () => {
-    const results = await testRule(name, stringBoundary, rootDocument);
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(name, stringBoundary, rootDocument);
+      expect(results).toHaveLength(0);
+    });
 
-    expect(results).toHaveLength(0);
-  });
-
-  it('should not error when string schema has only an enum', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.parameters = [
-      {
-        name: 'filter',
-        in: 'query',
-        schema: {
-          type: 'string',
-          enum: ['fiction', 'nonfiction']
-        }
-      }
-    ];
-
-    const results = await testRule(name, stringBoundary, testDocument);
-
-    expect(results).toHaveLength(0);
-  });
-
-  it('should not error when string schema is in a not', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.parameters = [
-      {
-        name: 'filter',
-        in: 'query',
-        schema: {
-          type: 'integer',
-          not: {
-            type: 'string'
+    it('String schema has only an enum', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: 'string',
+            enum: ['fiction', 'nonfiction']
           }
         }
-      }
-    ];
+      ];
 
-    const results = await testRule(name, stringBoundary, testDocument);
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(0);
+    });
 
-    expect(results).toHaveLength(0);
-  });
-
-  it('should not error for missing pattern when format is binary, byte, date, date-time, or url', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.parameters = [
-      {
-        name: 'hash',
-        in: 'query',
-        schema: {
-          type: 'string',
-          format: 'binary',
-          minLength: 0,
-          maxLength: 15
-        }
-      },
-      {
-        name: 'trailer',
-        in: 'query',
-        schema: {
-          type: 'string',
-          format: 'byte',
-          minLength: 0,
-          maxLength: 1024
-        }
-      },
-      {
-        name: 'before_date',
-        in: 'query',
-        schema: {
-          type: 'string',
-          format: 'date'
-        }
-      },
-      {
-        name: 'after_date',
-        in: 'query',
-        schema: {
-          type: 'string',
-          format: 'date-time',
-          minLength: 1,
-          maxLength: 15
-        }
-      },
-      {
-        name: 'imdb_url',
-        in: 'query',
-        schema: {
-          type: 'string',
-          format: 'url',
-          maxLength: 1024
-        }
-      }
-    ];
-
-    const results = await testRule(name, stringBoundary, testDocument);
-    expect(results).toHaveLength(0);
-  });
-
-  it('should error if string schema is missing a `pattern` field', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.parameters = [
-      {
-        name: 'filter',
-        in: 'query',
-        schema: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 15
-        }
-      }
-    ];
-
-    const results = await testRule(name, stringBoundary, testDocument);
-
-    expect(results).toHaveLength(1);
-
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'Should define a pattern for a valid string'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'parameters',
-      '0',
-      'schema'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
-  });
-
-  it('should error if string schema is missing a `minLength` field', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.parameters = [
-      {
-        name: 'metadata',
-        in: 'header',
-        content: {
-          'text/plain': {
-            schema: {
-              type: 'string',
-              pattern: '[a-zA-Z0-9]+',
-              maxLength: 15
+    it('String schema is in a not', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: 'integer',
+            not: {
+              type: 'string'
             }
           }
         }
-      }
-    ];
+      ];
 
-    const results = await testRule(name, stringBoundary, testDocument);
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(0);
+    });
 
-    expect(results).toHaveLength(1);
+    it('Missing pattern when format is binary, byte, date, date-time, or url', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'hash',
+          in: 'query',
+          schema: {
+            type: 'string',
+            format: 'binary',
+            minLength: 0,
+            maxLength: 15
+          }
+        },
+        {
+          name: 'trailer',
+          in: 'query',
+          schema: {
+            type: 'string',
+            format: 'byte',
+            minLength: 0,
+            maxLength: 1024
+          }
+        },
+        {
+          name: 'before_date',
+          in: 'query',
+          schema: {
+            type: 'string',
+            format: 'date'
+          }
+        },
+        {
+          name: 'after_date',
+          in: 'query',
+          schema: {
+            type: 'string',
+            format: 'date-time',
+            minLength: 1,
+            maxLength: 15
+          }
+        },
+        {
+          name: 'imdb_url',
+          in: 'query',
+          schema: {
+            type: 'string',
+            format: 'url',
+            maxLength: 1024
+          }
+        }
+      ];
 
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'Should define a minLength for a valid string'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'parameters',
-      '0',
-      'content',
-      'text/plain',
-      'schema'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
-  });
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(0);
+    });
 
-  it('should error if string schema is missing a `maxLength` field', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] = {
-      schema: {
+    it('String schema specifies pattern in oneOf schemas', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'ruleTester',
+          in: 'query',
+          schema: {
+            $ref: '#/components/schemas/RuleTester'
+          }
+        }
+      ];
+
+      testDocument.components.schemas['RuleTester'] = {
+        description: 'Tests pattern field within oneOf',
         type: 'string',
-        pattern: '[a-zA-Z0-9]+',
-        minLength: 15
-      }
-    };
+        minLength: 1,
+        maxLength: 38,
+        oneOf: [
+          {
+            pattern: 'pattern1'
+          },
+          {
+            pattern: 'pattern2'
+          },
+          {
+            pattern: 'pattern3'
+          }
+        ],
+        example: 'example string'
+      };
 
-    const results = await testRule(name, stringBoundary, testDocument);
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(0);
+    });
 
-    expect(results).toHaveLength(1);
+    it('String schema specifies fields in allOf schemas', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'ruleTester',
+          in: 'query',
+          schema: {
+            $ref: '#/components/schemas/RuleTester'
+          }
+        }
+      ];
 
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'Should define a maxLength for a valid string'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
-  });
-
-  it('should error if non-string schema defines a `pattern` field', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] = {
-      schema: {
-        type: 'integer',
-        pattern: '.*'
-      }
-    };
-
-    const results = await testRule(name, stringBoundary, testDocument);
-
-    expect(results).toHaveLength(1);
-
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'pattern should not be defined for a non-string schema'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema',
-      'pattern'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
-  });
-
-  it('should error if non-string schema defines a `minLength` field', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] = {
-      schema: {
-        type: 'integer',
-        minLength: 15
-      }
-    };
-
-    const results = await testRule(name, stringBoundary, testDocument);
-
-    expect(results).toHaveLength(1);
-
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'minLength should not be defined for a non-string schema'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema',
-      'minLength'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
-  });
-
-  it('should error if non-string schema defines a `maxLength` field', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] = {
-      schema: {
-        type: 'integer',
-        maxLength: 15
-      }
-    };
-
-    const results = await testRule(name, stringBoundary, testDocument);
-
-    expect(results).toHaveLength(1);
-
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'maxLength should not be defined for a non-string schema'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema',
-      'maxLength'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
-  });
-
-  it('should error if string schema has a `minLength` value greater than the `maxLength` value', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] = {
-      schema: {
+      testDocument.components.schemas['RuleTester'] = {
+        description: 'Tests string fields within allOf',
         type: 'string',
-        pattern: '[a-zA-Z0-9]+',
-        maxLength: 10,
-        minLength: 15
-      }
-    };
-
-    const results = await testRule(name, stringBoundary, testDocument);
-
-    expect(results).toHaveLength(1);
-
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'minLength cannot be greater than maxLength'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
-  });
-
-  it('should error if faulty string schema is part of a composed schema', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] = {
-      schema: {
+        minLength: 1,
+        maxLength: 38,
         allOf: [
           {
-            type: 'string',
-            maxLength: 10,
             minLength: 1
           },
           {
-            anyOf: [
-              {
-                type: 'string',
-                maxLength: 10,
-                minLength: 1
-              },
-              {
-                oneOf: [
-                  {
-                    type: 'string',
-                    maxLength: 10,
-                    minLength: 1
-                  }
-                ]
-              }
-            ]
+            maxLength: 38
+          },
+          {
+            pattern: 'id:.*'
           }
-        ]
-      }
-    };
+        ],
+        example: 'example string'
+      };
 
-    const results = await testRule(name, stringBoundary, testDocument);
-
-    expect(results).toHaveLength(3);
-
-    results.forEach(r => {
-      expect(r.code).toBe(name);
-      expect(r.message).toBe('Should define a pattern for a valid string');
-      expect(r.severity).toBe(severityCodes.warning);
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(0);
     });
-
-    expect(results[0].path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema',
-      'allOf',
-      '0'
-    ]);
-
-    expect(results[1].path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema',
-      'allOf',
-      '1',
-      'anyOf',
-      '0'
-    ]);
-
-    expect(results[2].path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'post',
-      'requestBody',
-      'content',
-      'text/plain',
-      'schema',
-      'allOf',
-      '1',
-      'anyOf',
-      '1',
-      'oneOf',
-      '0'
-    ]);
   });
 
-  it('should error if faulty string schema is defined at path level', async () => {
-    const testDocument = makeCopy(rootDocument);
-    testDocument.paths['/v1/movies'].parameters = [
-      {
-        name: 'filter',
-        in: 'query',
+  describe('Should yield errors', () => {
+    it('String schema is missing a `pattern` field', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 15
+          }
+        }
+      ];
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'Should define a pattern for a valid string'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.parameters.0.schema'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('String schema is missing a `minLength` field', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'metadata',
+          in: 'header',
+          content: {
+            'text/plain': {
+              schema: {
+                type: 'string',
+                pattern: '[a-zA-Z0-9]+',
+                maxLength: 15
+              }
+            }
+          }
+        }
+      ];
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'Should define a minLength for a valid string'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.parameters.0.content.text/plain.schema'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('String schema is missing a `maxLength` field', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'text/plain'
+      ] = {
         schema: {
           type: 'string',
-          minLength: 1,
+          pattern: '[a-zA-Z0-9]+',
+          minLength: 15
+        }
+      };
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'Should define a maxLength for a valid string'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.text/plain.schema'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('Non-string schema defines a `pattern` field', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'text/plain'
+      ] = {
+        schema: {
+          type: 'integer',
+          pattern: '.*'
+        }
+      };
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'pattern should not be defined for a non-string schema'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.text/plain.schema.pattern'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('Non-string schema defines a `minLength` field', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'text/plain'
+      ] = {
+        schema: {
+          type: 'integer',
+          minLength: 15
+        }
+      };
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'minLength should not be defined for a non-string schema'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.text/plain.schema.minLength'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('Non-string schema defines a `maxLength` field', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'text/plain'
+      ] = {
+        schema: {
+          type: 'integer',
           maxLength: 15
         }
-      }
-    ];
+      };
 
-    const results = await testRule(name, stringBoundary, testDocument);
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'maxLength should not be defined for a non-string schema'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.text/plain.schema.maxLength'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
 
-    expect(results).toHaveLength(1);
+    it('String schema has a `minLength` value greater than the `maxLength` value', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'text/plain'
+      ] = {
+        schema: {
+          type: 'string',
+          pattern: '[a-zA-Z0-9]+',
+          maxLength: 10,
+          minLength: 15
+        }
+      };
 
-    const validation = results[0];
-    expect(validation.code).toBe(name);
-    expect(validation.message).toBe(
-      'Should define a pattern for a valid string'
-    );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      '/v1/movies',
-      'parameters',
-      '0',
-      'schema'
-    ]);
-    expect(validation.severity).toBe(severityCodes.warning);
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'minLength cannot be greater than maxLength'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.text/plain.schema'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('Invalid string schema is part of a composed schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'text/plain'
+      ] = {
+        schema: {
+          allOf: [
+            {
+              type: 'string',
+              maxLength: 10,
+              minLength: 1
+            },
+            {
+              anyOf: [
+                {
+                  type: 'string',
+                  maxLength: 10,
+                  minLength: 1
+                },
+                {
+                  oneOf: [
+                    {
+                      type: 'string',
+                      maxLength: 10,
+                      minLength: 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      };
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(name);
+      expect(results[0].message).toBe(
+        'Should define a pattern for a valid string'
+      );
+      expect(results[0].severity).toBe(severityCodes.warning);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.text/plain.schema'
+      );
+    });
+
+    it('Invalid string schema is defined at path level', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 15
+          }
+        }
+      ];
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'Should define a pattern for a valid string'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.parameters.0.schema'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('String schema specifies maxLength in only SOME oneOf schemas', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'ruleTester',
+          in: 'query',
+          schema: {
+            $ref: '#/components/schemas/RuleTester'
+          }
+        }
+      ];
+
+      testDocument.components.schemas['RuleTester'] = {
+        description: 'Tests maxLength field within oneOf',
+        type: 'string',
+        minLength: 1,
+        pattern: '.*',
+        oneOf: [
+          {
+            maxLength: 38
+          },
+          {
+            maxLength: 74
+          },
+          {
+            description: 'No maxLength field in this schema'
+          }
+        ],
+        example: 'example string'
+      };
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'Should define a maxLength for a valid string'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.parameters.0.schema'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
+
+    it('String schema specifies pattern in only SOME anyOf schemas', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'ruleTester',
+          in: 'query',
+          schema: {
+            $ref: '#/components/schemas/RuleTester'
+          }
+        }
+      ];
+
+      testDocument.components.schemas['RuleTester'] = {
+        description: 'Tests pattern field within anyOf',
+        type: 'string',
+        minLength: 1,
+        maxLength: 38,
+        oneOf: [
+          {
+            pattern: '.*'
+          },
+          {
+            pattern: 'id-[0-9]+.*'
+          },
+          {
+            description: 'No pattern field in this schema'
+          }
+        ],
+        example: 'example string'
+      };
+
+      const results = await testRule(name, stringBoundary, testDocument);
+      expect(results).toHaveLength(1);
+      const validation = results[0];
+      expect(validation.code).toBe(name);
+      expect(validation.message).toBe(
+        'Should define a pattern for a valid string'
+      );
+      expect(validation.path.join('.')).toBe(
+        'paths./v1/movies.post.parameters.0.schema'
+      );
+      expect(validation.severity).toBe(severityCodes.warning);
+    });
   });
 });


### PR DESCRIPTION
## PR summary
This commit modifies the "string-boundary" rule so that it
more accurately performs the checks for the various schema
attributes within composed schemas.
For example, if a string schema contains an allOf, then the
"pattern" field could be specified in any of the allOf
list element schemas instead of the main schema itself.
In contrast, for a string schema containing a oneOf or anyOf,
the "pattern" field would need to be specified in either
the main schema itself OR within EACH of the oneOf/anyOf
list element schemas.

Previously, the rule was not accurate enough with its
checks within composed schemas.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

