### PR TITLE
feat: add 2 new rules related to path segments

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -35,6 +35,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: array-responses](#rule-array-responses)
   * [Rule: authorization-parameter](#rule-authorization-parameter)
   * [Rule: binary-schemas](#rule-binary-schemas)
+  * [Rule: consecutive-path-param-segments](#rule-consecutive-path-param-segments)
   * [Rule: circular-refs](#rule-circular-refs)
   * [Rule: content-entry-contains-schema](#rule-content-entry-contains-schema)
   * [Rule: content-entry-provided](#rule-content-entry-provided)
@@ -81,6 +82,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: server-variable-default-value](#rule-server-variable-default-value)
   * [Rule: string-boundary](#rule-string-boundary)
   * [Rule: unused-tag](#rule-unused-tag)
+  * [Rule: valid-path-segments](#rule-valid-path-segments)
   * [Rule: valid-type-format](#rule-valid-type-format)
 
 <!-- tocstop -->
@@ -142,6 +144,14 @@ is provided in the [Reference](#reference) section below.
 <td>warn</td>
 <td>Makes sure that binary schemas are used only in proper locations within the API definition</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-consecutive-path-param-segments">consecutive-path-param-segments</a></td>
+<td>error</td>
+<td>Checks each path string in the API definition to detect the presence of two or more consecutive
+path segments that contain a path parameter reference (e.g. <code>/v1/foos/{foo_id}/{bar_id}</code>), 
+which is not allowed.</td>
+<td>oas2, oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-circular-refs">circular-refs</a></td>
@@ -419,6 +429,12 @@ has non-form content.</td>
 <td>warn</td>
 <td>Verifies that each defined tag is referenced by at least one operation</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-valid-path-segments">valid-path-segments</a></td>
+<td>error</td>
+<td>Checks each path string in the API to make sure path parameter references are valid within path segments</td>
+<td>oas2, oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-valid-type-format">valid-type-format</a></td>
@@ -1060,6 +1076,60 @@ paths:
               schema:
                 type: string
                 format: binary
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: consecutive-path-param-segments
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>consecutive-path-param-segments</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule checks each path string in the API to detect the presence of two or more path segments that contain
+a parameter reference, which is not allowed.
+For example, the path <code>/v1/foos/{foo_id}/{bar_id}</code> is invalid and should probably be <code>/v1/foos/{foo_id}/bars/{bar_id}</code>.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas2, oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/foos/{foo_id}/{bar_id}':
+    parameters:
+      - $ref: '#/components/parameters/FooIdParam'
+      - $ref: '#/components/parameters/BarIdParam'
+  get:
+    operationId: get_foobar
+    ...
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/foos/{foo_id}/bars/{bar_id}':
+    parameters:
+      - $ref: '#/components/parameters/FooIdParam'
+      - $ref: '#/components/parameters/BarIdParam'
+  get:
+    operationId: get_foobar
+    ...
 </pre>
 </td>
 </tr>
@@ -4094,6 +4164,59 @@ paths:
       summary: Create a Thing
       tags:
         - Things
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: valid-path-segments
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>valid-path-segments</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule validates the path segments within each path string found in the API.
+Specifically, the rule makes sure that any path segment containing a path parameter reference contains
+only that parameter reference and nothing more.
+For example, the path <code>/v1/foos/_{foo_id}_</code> is invalid and should probably be <code>/v1/foos/{foo_id}</code>.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas2, oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/foos/_{foo_id}_':
+    parameters:
+      - $ref: '#/components/parameters/FooIdParam'
+  get:
+    operationId: get_foo
+    ...
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/foos/{foo_id}':
+    parameters:
+      - $ref: '#/components/parameters/FooIdParam'
+  get:
+    operationId: get_foo
+    ...
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/consecutive-path-param-segments.js
+++ b/packages/ruleset/src/functions/consecutive-path-param-segments.js
@@ -1,0 +1,28 @@
+module.exports = function(pathItem, options, { path }) {
+  return consecutivePathParamSegments(path);
+};
+
+/**
+ * This function detects the presence of two or more consecutive path segments
+ * containing path parameter references (e.g. '/v1/clouds/{cloud_id}/{region_id}').
+ * @param {*} path the array of path segments indicating the "location" of a
+ * pathItem within the API definition (e.g. ['paths','/v1/clouds/{id}'])
+ * @returns an array containing the violations found or [] if no violations
+ */
+function consecutivePathParamSegments(path) {
+  // The path string itself (e.g. '/v1/clouds/{id}') will be the last element in 'path'.
+  const pathStr = path[path.length - 1].toString();
+
+  // Check to see if the path string has two or more consecutive path segments
+  // containing a path parameter reference (e.g. '/v1/clouds/{cloud_id}/{region_id}').
+  if (/{[^/]+}\/{[^/]+}/.test(pathStr)) {
+    return [
+      {
+        message: `Path contains two or more consecutive path parameter references: ${pathStr}`,
+        path
+      }
+    ];
+  }
+
+  return [];
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -6,6 +6,7 @@ module.exports = {
   binarySchemas: require('./binary-schemas'),
   checkMajorVersion: require('./check-major-version'),
   circularRefs: require('./circular-refs'),
+  consecutivePathParamSegments: require('./consecutive-path-param-segments'),
   deleteBody: require('./delete-body'),
   descriptionMentionsJSON: require('./description-mentions-json'),
   disallowedHeaderParameter: require('./disallowed-header-parameter'),
@@ -41,5 +42,6 @@ module.exports = {
   securitySchemes: require('./security-schemes').securitySchemes,
   stringBoundary: require('./string-boundary'),
   unusedTag: require('./unused-tag').unusedTag,
+  validatePathSegments: require('./valid-path-segments'),
   validTypeFormat: require('./valid-type-format')
 };

--- a/packages/ruleset/src/functions/path-segment-case-convention.js
+++ b/packages/ruleset/src/functions/path-segment-case-convention.js
@@ -1,15 +1,15 @@
 const { casing } = require('@stoplight/spectral-functions');
 let casingConfig;
 
-module.exports = function(operation, options, { path }) {
+module.exports = function(pathItem, options, { path }) {
   // Save this rule's "functionOptions" value since we need
   // to pass it on to Spectral's "casing" function.
   casingConfig = options;
 
-  return pathSegmentCaseConvention(operation, path);
+  return pathSegmentCaseConvention(path);
 };
 
-function pathSegmentCaseConvention(pathItem, path) {
+function pathSegmentCaseConvention(path) {
   // The path string (e.g. '/v1/resources/{resource_id}') will be the last element in 'path'.
   const pathStr = path[path.length - 1];
 
@@ -19,7 +19,9 @@ function pathSegmentCaseConvention(pathItem, path) {
   // Filter out the path segments that are either "" (the first one due to the
   // path string starting with "/") or a path param reference,
   // since we don't want to raise errors for those.
-  pathSegments = pathSegments.filter(s => s !== '' && !s.match(/^{.*}$/));
+  pathSegments = pathSegments.filter(
+    s => s !== '' && s.indexOf('{') < 0 && s.indexOf('}') < 0
+  );
 
   const errors = [];
   for (const segment of pathSegments) {

--- a/packages/ruleset/src/functions/valid-path-segments.js
+++ b/packages/ruleset/src/functions/valid-path-segments.js
@@ -1,0 +1,39 @@
+module.exports = function(pathItem, options, { path }) {
+  return validatePathSegments(path);
+};
+
+/**
+ * This function validates individual path segments within a path string.
+ * Specifically, we'll check to make sure that a path segment that contains
+ * a parameter reference (or at least appears to) actually contains only that
+ * parameter reference and nothing more.
+ * @param {*} path the array of path segments indicating the "location" of a
+ * pathItem within the API definition (e.g. ['paths','/v1/clouds/{id}'])
+ * @returns an array containing the violations found or [] if no violations
+ */
+function validatePathSegments(path) {
+  // The path string itself (e.g. '/v1/clouds/{id}') will be the last element in 'path'.
+  const pathStr = path[path.length - 1].toString();
+
+  // Parse the path string into the individual path segments.
+  const segments = pathStr.split('/');
+
+  // Validate each path segment.
+  const errors = [];
+  for (const segment of segments) {
+    // If it looks like the user intended to define a path param reference
+    // (i.e. if we find either '{' or '}' within the path segment),
+    // then check to make sure the segment only contains a single
+    // path param reference.
+    if (segment.indexOf('{') >= 0 || segment.indexOf('}') >= 0) {
+      if (!/^{[^}]*}$/.test(segment)) {
+        errors.push({
+          message: `Invalid path parameter reference within path segment: ${segment}`,
+          path
+        });
+      }
+    }
+  }
+
+  return errors;
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -98,6 +98,7 @@ module.exports = {
     'authorization-parameter': ibmRules.authorizationParameter,
     'binary-schemas': ibmRules.binarySchemas,
     'circular-refs': ibmRules.circularRefs,
+    'consecutive-path-param-segments': ibmRules.consecutivePathParamSegments,
     'content-entry-contains-schema': ibmRules.contentEntryContainsSchema,
     'content-entry-provided': ibmRules.contentEntryProvided,
     'content-type-parameter': ibmRules.contentTypeParameter,
@@ -145,6 +146,7 @@ module.exports = {
     'server-variable-default-value': ibmRules.serverVariableDefaultValue,
     'string-boundary': ibmRules.stringBoundary,
     'unused-tag': ibmRules.unusedTag,
+    'valid-path-segments': ibmRules.validPathSegments,
     'valid-type-format': ibmRules.validTypeFormat
   }
 };

--- a/packages/ruleset/src/rules/consecutive-path-param-segments.js
+++ b/packages/ruleset/src/rules/consecutive-path-param-segments.js
@@ -1,0 +1,16 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { consecutivePathParamSegments } = require('../functions');
+const { paths } = require('../collections');
+
+module.exports = {
+  description:
+    'Path strings should not contain two or more consecutive path parameter references',
+  message: '{{error}}',
+  formats: [oas2, oas3],
+  given: paths,
+  severity: 'error',
+  resolved: true,
+  then: {
+    function: consecutivePathParamSegments
+  }
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -7,6 +7,7 @@ module.exports = {
   authorizationParameter: require('./authorization-parameter'),
   binarySchemas: require('./binary-schemas'),
   circularRefs: require('./circular-refs'),
+  consecutivePathParamSegments: require('./consecutive-path-param-segments'),
   contentEntryContainsSchema: require('./content-entry-contains-schema'),
   contentEntryProvided: require('./content-entry-provided'),
   contentTypeParameter: require('./content-type-parameter'),
@@ -52,5 +53,6 @@ module.exports = {
   serverVariableDefaultValue: require('./server-variable-default-value'),
   stringBoundary: require('./string-boundary'),
   unusedTag: require('./unused-tag'),
+  validPathSegments: require('./valid-path-segments'),
   validTypeFormat: require('./valid-type-format')
 };

--- a/packages/ruleset/src/rules/valid-path-segments.js
+++ b/packages/ruleset/src/rules/valid-path-segments.js
@@ -1,0 +1,15 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { validatePathSegments } = require('../functions');
+const { paths } = require('../collections');
+
+module.exports = {
+  description: 'Validates individual path segments within a path string',
+  message: '{{error}}',
+  formats: [oas2, oas3],
+  given: paths,
+  severity: 'error',
+  resolved: true,
+  then: {
+    function: validatePathSegments
+  }
+};

--- a/packages/ruleset/test/consecutive-path-param-segments.test.js
+++ b/packages/ruleset/test/consecutive-path-param-segments.test.js
@@ -1,0 +1,37 @@
+const { consecutivePathParamSegments } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = consecutivePathParamSegments;
+const ruleId = 'consecutive-path-param-segments';
+const expectedSeverity = severityCodes.error;
+
+describe('Spectral rule: consecutive-path-param-segments', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Path has two consecutive param references', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/{swig_id}'] =
+        testDocument.paths['/v1/drinks/{drink_id}'];
+      delete testDocument.paths['/v1/drinks/{drink_id}'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}/{swig_id}'
+      );
+      expect(results[0].message).toBe(
+        'Path contains two or more consecutive path parameter references: /v1/drinks/{drink_id}/{swig_id}'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/valid-path-segments.test.js
+++ b/packages/ruleset/test/valid-path-segments.test.js
@@ -1,0 +1,75 @@
+const { validPathSegments } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = validPathSegments;
+const ruleId = 'valid-path-segments';
+const expectedSeverity = severityCodes.error;
+
+describe('Spectral rule: valid-path-segments', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Multiple parameter references', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}{swig_id}/foo'] =
+        testDocument.paths['/v1/drinks/{drink_id}'];
+      delete testDocument.paths['/v1/drinks/{drink_id}'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}{swig_id}/foo'
+      );
+      expect(results[0].message).toBe(
+        'Invalid path parameter reference within path segment: {drink_id}{swig_id}'
+      );
+    });
+
+    it('Extra characters #1', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/_{drink_id}_/foo'] =
+        testDocument.paths['/v1/drinks/{drink_id}'];
+      delete testDocument.paths['/v1/drinks/{drink_id}'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.path.join('.')).toBe('paths./v1/drinks/_{drink_id}_/foo');
+      expect(results[0].message).toBe(
+        'Invalid path parameter reference within path segment: _{drink_id}_'
+      );
+    });
+
+    it('Extra characters #2', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}:{swig_id}/foo'] =
+        testDocument.paths['/v1/drinks/{drink_id}'];
+      delete testDocument.paths['/v1/drinks/{drink_id}'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}:{swig_id}/foo'
+      );
+      expect(results[0].message).toBe(
+        'Invalid path parameter reference within path segment: {drink_id}:{swig_id}'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
This commit introduces the following new spectral-style rules:
1. consecutive-path-param-segments: detects presence of
two or more consecutive path segments containing param
references within a path string.
2. valid-path-segments: checks path segments within each
path string to ensure parameter references are well-formed.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

