### PR TITLE
fix: allow relative urls in security schemes

### DIFF
--- a/packages/ruleset/test/security-scheme-attributes.test.js
+++ b/packages/ruleset/test/security-scheme-attributes.test.js
@@ -28,6 +28,28 @@ describe('Spectral rule: security-scheme-attributes', () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+
+    it('Relative URLs within security schemes', async () => {
+      const testDocument = makeCopy(rootDocument);
+      const flows = testDocument.components.securitySchemes.DrinkScheme.flows;
+      flows.implicit.authorizationUrl = '/relative/url';
+      flows.authorizationCode.tokenUrl = '/relative/url';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Relative URLs with base url that ends in backslash', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.servers[0].url = 'https://some-madeup-url.com/api/';
+
+      const flows = testDocument.components.securitySchemes.DrinkScheme.flows;
+      flows.implicit.authorizationUrl = '/relative/url';
+      flows.authorizationCode.tokenUrl = '/relative/url';
+
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {


### PR DESCRIPTION
The OpenAPI specification [allows for relative references](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#relativeReferences) in URL properties
throughout an API document. We were not considering this in the
`security-scheme-attributes` rule. This commit adjusts the logic to allow
for relative URLs.

Resolves #466

Signed-off-by: Dustin Popp <dpopp07@gmail.com>