### PR TITLE
feat(no-etag-header): add new 'no-etag-header' spectral-style rule

### DIFF
--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -15,6 +15,7 @@ module.exports = {
   enumCaseConvention: require('./enum-case-convention'),
   errorResponseSchema: require('./error-response-schema'),
   inlineResponseSchema: require('./inline-response-schema'),
+  noEtagHeader: require('./no-etag-header'),
   operationIdCaseConvention: require('./operation-id-case-convention'),
   operationIdNamingConvention: require('./operation-id-naming-convention'),
   operationSummary: require('./operation-summary'),

--- a/packages/ruleset/src/functions/no-etag-header.js
+++ b/packages/ruleset/src/functions/no-etag-header.js
@@ -1,0 +1,126 @@
+module.exports = function(pathItem, options, { path }) {
+  return etagHeaderCheck(pathItem, path);
+};
+
+/**
+ * This function checks a path item (object containing operations) to make sure that
+ * the path's GET operation defines the ETag response header if needed.
+ * An ETag response header is needed if there are other operations within the same
+ * path that support the If-Match or If-Not-Match header parameters.
+ *
+ * @param {*} pathItem the object containing the set of operations for a given path string
+ * @param {*} path the array of path segments indicating the "location" of a
+ * pathItem within the API definition (e.g. ['paths','/v1/clouds/{id}'])
+ * @returns an array containing the violations found or [] if no violations
+ */
+function etagHeaderCheck(pathItem, path) {
+  // If no operations define the If-Match/If-None-Match header params, then bail out now.
+  if (!isETagNeeded(pathItem)) {
+    return [];
+  }
+
+  // Make sure there is an ETag response header defined within the pathItem's GET operation.
+
+  // 1. Make sure there is a GET operation.
+  const getOperation = pathItem['get'];
+  if (!getOperation) {
+    return [
+      {
+        message:
+          'ETag response header is required, but no "get" operation is defined',
+        path
+      }
+    ];
+  }
+
+  // 2. Make sure that EACH success response entry defines the ETag response header.
+  const errors = [];
+  let numSuccessResponses = 0;
+  const responses = getOperation.responses;
+  if (responses) {
+    for (const statusCode in responses) {
+      // Only interested in "success" response entries.
+      if (/2[0-9][0-9]/.test(statusCode)) {
+        numSuccessResponses++;
+
+        let etagHeader;
+        const response = responses[statusCode];
+        if (response && response.headers) {
+          for (const headerName of Object.keys(response.headers)) {
+            if (headerName.toLowerCase() === 'etag') {
+              etagHeader = response.headers[headerName];
+            }
+          }
+        }
+
+        if (!etagHeader) {
+          let errorPath = [...path, 'get', 'responses', statusCode];
+          if (response && response.headers) {
+            errorPath = [...errorPath, 'headers'];
+          }
+          errors.push({
+            message: 'ETag response header is required',
+            path: errorPath
+          });
+        }
+      }
+    }
+  }
+
+  // Finally, make sure that we found at least one success response entry.
+  if (!numSuccessResponses) {
+    errors.push({
+      message:
+        'ETag response header is required, but "get" operation defines no success responses',
+      path: [...path, 'get']
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Returns true iff an ETag response header should be defined within
+ * the specified pathItem's "get" operation.
+ * @param {*} pathItem the object containing the operations for a given path string
+ * @returns boolean
+ */
+function isETagNeeded(pathItem) {
+  // An ETag response header is needed if any of the pathItem's operations
+  // define an 'If-Match' or 'If-None-Match' header parameter.
+  const headersToCheck = ['If-Match', 'If-None-Match'];
+
+  // Check to see if either of the headers are defined in the pathItem's parameter list.
+  // If so, then no need to check the individual operations.
+  if (headerParamsPresent(pathItem.parameters, headersToCheck)) {
+    return true;
+  }
+
+  // Next, visit the operations and check their parameter lists.
+  for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+    const operation = pathItem[method];
+    if (operation) {
+      if (headerParamsPresent(operation.parameters, headersToCheck)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Checks to see if any of the names within "headerNames" match the name
+// of a header param defined within "paramList".
+function headerParamsPresent(paramList, headerNames) {
+  if (Array.isArray(paramList)) {
+    for (const p of paramList) {
+      if (p.in.toLowerCase() === 'header') {
+        for (const headerName of headerNames) {
+          if (headerName.toLowerCase() === p.name.toLowerCase()) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -114,6 +114,7 @@ module.exports = {
     'inline-response-schema': ibmRules.inlineResponseSchema,
     'major-version-in-path': ibmRules.majorVersionInPath,
     'missing-required-property': ibmRules.missingRequiredProperty,
+    'no-etag-header': ibmRules.noEtagHeader,
     'operation-id-case-convention': ibmRules.operationIdCaseConvention,
     'operation-id-naming-convention': ibmRules.operationIdNamingConvention,
     'operation-summary': ibmRules.operationSummary,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -23,6 +23,7 @@ module.exports = {
   inlineResponseSchema: require('./inline-response-schema'),
   majorVersionInPath: require('./major-version-in-path'),
   missingRequiredProperty: require('./missing-required-property'),
+  noEtagHeader: require('./no-etag-header'),
   operationIdCaseConvention: require('./operation-id-case-convention'),
   operationIdNamingConvention: require('./operation-id-naming-convention'),
   operationSummary: require('./operation-summary'),

--- a/packages/ruleset/src/rules/no-etag-header.js
+++ b/packages/ruleset/src/rules/no-etag-header.js
@@ -1,0 +1,16 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { noEtagHeader } = require('../functions');
+const { paths } = require('../collections');
+
+module.exports = {
+  description:
+    'ETag response header should be defined in GET operation for resources that support If-Match or If-None-Match header parameters',
+  message: '{{error}}',
+  given: paths,
+  severity: 'error',
+  formats: [oas2, oas3],
+  resolved: true,
+  then: {
+    function: noEtagHeader
+  }
+};

--- a/packages/ruleset/test/array-items.test.js
+++ b/packages/ruleset/test/array-items.test.js
@@ -121,7 +121,7 @@ describe('Spectral rule: array-items', () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(3);
+      expect(results).toHaveLength(5);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMessage);
@@ -162,6 +162,27 @@ describe('Spectral rule: array-items', () => {
         'properties',
         'movies',
         'items',
+        'additionalProperties'
+      ]);
+      expect(results[3].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'additionalProperties'
+      ]);
+      expect(results[4].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'put',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
         'additionalProperties'
       ]);
     });

--- a/packages/ruleset/test/array-of-arrays.test.js
+++ b/packages/ruleset/test/array-of-arrays.test.js
@@ -140,7 +140,7 @@ describe('Spectral rule: array-of-arrays', () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(3);
+      expect(results).toHaveLength(5);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMessage);
@@ -186,6 +186,31 @@ describe('Spectral rule: array-of-arrays', () => {
         'properties',
         'movies',
         'items',
+        'properties',
+        'array_prop'
+      ]);
+
+      expect(results[3].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'array_prop'
+      ]);
+
+      expect(results[4].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'put',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
         'properties',
         'array_prop'
       ]);

--- a/packages/ruleset/test/description-mentions-json.test.js
+++ b/packages/ruleset/test/description-mentions-json.test.js
@@ -220,7 +220,7 @@ describe('Spectral rule: description-mentions-json', () => {
         'This is NOT a JSON object!';
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(3);
+      expect(results).toHaveLength(5);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMsg);
@@ -263,6 +263,29 @@ describe('Spectral rule: description-mentions-json', () => {
         'properties',
         'movies',
         'items',
+        'properties',
+        'id'
+      ]);
+      expect(results[3].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'id'
+      ]);
+      expect(results[4].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'put',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
         'properties',
         'id'
       ]);
@@ -285,7 +308,7 @@ describe('Spectral rule: description-mentions-json', () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(3);
+      expect(results).toHaveLength(5);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMsg);
@@ -328,6 +351,29 @@ describe('Spectral rule: description-mentions-json', () => {
         'properties',
         'movies',
         'items',
+        'properties',
+        'x-not-an-extension'
+      ]);
+      expect(results[3].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'x-not-an-extension'
+      ]);
+      expect(results[4].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'put',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
         'properties',
         'x-not-an-extension'
       ]);

--- a/packages/ruleset/test/no-etag-header.test.js
+++ b/packages/ruleset/test/no-etag-header.test.js
@@ -1,0 +1,109 @@
+const { noEtagHeader } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = noEtagHeader;
+const ruleId = 'no-etag-header';
+const expectedSeverity = severityCodes.error;
+
+describe('Spectral rule: no-etag-header', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('No need for ETag', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Remove the If-Match header param and the ETag response header.
+      delete testDocument.paths['/v1/movies/{movie_id}'].put.parameters;
+      delete testDocument.components.responses.MovieWithETag.headers;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('No GET operation', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/movies/{movie_id}'].get;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.message).toBe(
+        'ETag response header is required, but no "get" operation is defined'
+      );
+      expect(result.path.join('.')).toBe('paths./v1/movies/{movie_id}');
+    });
+
+    it('No responses', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/movies/{movie_id}'].get.responses;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.message).toBe(
+        'ETag response header is required, but "get" operation defines no success responses'
+      );
+      expect(result.path.join('.')).toBe('paths./v1/movies/{movie_id}.get');
+    });
+
+    it('No success responses', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/movies/{movie_id}'].get.responses['200'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.message).toBe(
+        'ETag response header is required, but "get" operation defines no success responses'
+      );
+      expect(result.path.join('.')).toBe('paths./v1/movies/{movie_id}.get');
+    });
+
+    it('No response headers', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.components.responses.MovieWithETag.headers;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.message).toBe('ETag response header is required');
+      expect(result.path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.get.responses.200'
+      );
+    });
+
+    it('No ETag response header', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.responses.MovieWithETag.headers['NOT-ETAG'] =
+        testDocument.components.responses.MovieWithETag.headers['ETag'];
+      delete testDocument.components.responses.MovieWithETag.headers['ETag'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.message).toBe('ETag response header is required');
+      expect(result.path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.get.responses.200.headers'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/property-case-collision.test.js
+++ b/packages/ruleset/test/property-case-collision.test.js
@@ -38,7 +38,7 @@ describe('Spectral rule: property-case-collision', () => {
 
     const results = await testRule(name, propertyCaseCollision, testDocument);
 
-    expect(results).toHaveLength(3);
+    expect(results).toHaveLength(5);
 
     const validation = results[0];
     expect(validation.code).toBe(name);

--- a/packages/ruleset/test/property-description.test.js
+++ b/packages/ruleset/test/property-description.test.js
@@ -164,7 +164,7 @@ describe('Spectral rule: property-description', () => {
       testDocument.components.schemas['IdString'].description = '';
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(3);
+      expect(results).toHaveLength(5);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMsg);
@@ -178,6 +178,12 @@ describe('Spectral rule: property-description', () => {
       );
       expect(results[2].path.join('.')).toBe(
         'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.properties.id'
+      );
+      expect(results[3].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.properties.id'
+      );
+      expect(results[4].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.properties.id'
       );
     });
 

--- a/packages/ruleset/test/security-schemes.test.js
+++ b/packages/ruleset/test/security-schemes.test.js
@@ -28,6 +28,8 @@ describe('Spectral rule: security-schemes', () => {
       delete testDocument.paths['/v1/drinks/{drink_id}'].get.security;
       delete testDocument.paths['/v1/movies'].post.security;
       delete testDocument.paths['/v1/movies'].get.security;
+      delete testDocument.paths['/v1/movies/{movie_id}'].get.security;
+      delete testDocument.paths['/v1/movies/{movie_id}'].put.security;
       delete testDocument.paths['/v1/cars'].post.security;
       delete testDocument.paths['/v1/cars/{car_id}'].get.security;
 
@@ -45,7 +47,7 @@ describe('Spectral rule: security-schemes', () => {
 
       // All references to security schemes should now be flagged as undefined.
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(10);
+      expect(results).toHaveLength(12);
       for (const r of results) {
         expect(r.code).toBe(ruleId);
         expect(r.message).toBe(expectedMsgUndefinedScheme);
@@ -73,9 +75,15 @@ describe('Spectral rule: security-schemes', () => {
         'paths./v1/movies.get.security.0.MovieScheme'
       );
       expect(results[8].path.join('.')).toBe(
-        'paths./v1/cars.post.security.0.IAM'
+        'paths./v1/movies/{movie_id}.get.security.0.MovieScheme'
       );
       expect(results[9].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.put.security.0.MovieScheme'
+      );
+      expect(results[10].path.join('.')).toBe(
+        'paths./v1/cars.post.security.0.IAM'
+      );
+      expect(results[11].path.join('.')).toBe(
         'paths./v1/cars/{car_id}.get.security.0.IAM'
       );
     });

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -367,6 +367,90 @@ module.exports = {
         }
       }
     },
+    '/v1/movies/{movie_id}': {
+      parameters: [
+        {
+          $ref: '#/components/parameters/MovieIdParam'
+        }
+      ],
+      get: {
+        operationId: 'get_movie',
+        summary: 'Get a movie',
+        description: 'Retrieve the movie and return it in the response.',
+        tags: ['TestTag'],
+        security: [
+          {
+            MovieScheme: ['moviegoer']
+          }
+        ],
+        responses: {
+          '200': {
+            $ref: '#/components/responses/MovieWithETag'
+          },
+          '400': {
+            description: 'Didnt work!',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Error'
+                }
+              }
+            }
+          }
+        }
+      },
+      put: {
+        operationId: 'replace_movie',
+        summary: 'Replace movie',
+        description: 'Replace a movie with updated state information.',
+        tags: ['TestTag'],
+        parameters: [
+          {
+            $ref: '#/components/parameters/IfMatchParam'
+          }
+        ],
+        security: [
+          {
+            MovieScheme: ['director']
+          }
+        ],
+        'x-codegen-request-body-name': 'movie',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Movie'
+              }
+            }
+          }
+        },
+        responses: {
+          '204': {
+            description: 'The movie was successfully updated.'
+          },
+          '400': {
+            description: 'Didnt work!',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Error'
+                }
+              }
+            }
+          },
+          '409': {
+            description: 'Resource conflict!',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Error'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     '/v1/cars': {
       post: {
         operationId: 'create_car',
@@ -455,6 +539,18 @@ module.exports = {
           maxLength: 30
         }
       },
+      MovieIdParam: {
+        name: 'movie_id',
+        description: 'The id of the movie resource.',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          pattern: '[a-zA-Z0-9 ]+',
+          minLength: 1,
+          maxLength: 30
+        }
+      },
       VerboseParam: {
         description: 'An optional verbose parameter.',
         name: 'verbose',
@@ -484,6 +580,18 @@ module.exports = {
           pattern: '[a-zA-Z0-9 ]+',
           minLength: 1,
           maxLength: 30
+        }
+      },
+      IfMatchParam: {
+        description: 'The If-Match header param.',
+        name: 'If-Match',
+        required: true,
+        in: 'header',
+        schema: {
+          type: 'string',
+          pattern: '[a-zA-Z0-9 ]+',
+          minLength: 1,
+          maxLength: 64
         }
       }
     },
@@ -923,6 +1031,24 @@ module.exports = {
           'application/json': {
             schema: {
               $ref: '#/components/schemas/Drink'
+            }
+          }
+        }
+      },
+      MovieWithETag: {
+        description: 'Success, we retrieved a movie!',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Movie'
+            }
+          }
+        },
+        headers: {
+          ETag: {
+            description: 'The unique version identifier of the movie.',
+            schema: {
+              $ref: '#/components/schemas/IdString'
             }
           }
         }

--- a/packages/ruleset/test/valid-type-format.test.js
+++ b/packages/ruleset/test/valid-type-format.test.js
@@ -468,7 +468,7 @@ describe('Spectral rule: valid-type-format', () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(3);
+      expect(results).toHaveLength(5);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toMatch(errorMsgIntegerFormat);
@@ -511,6 +511,29 @@ describe('Spectral rule: valid-type-format', () => {
         'properties',
         'movies',
         'items',
+        'properties',
+        'bad_int_prop'
+      ]);
+      expect(results[3].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'bad_int_prop'
+      ]);
+      expect(results[4].path).toStrictEqual([
+        'paths',
+        '/v1/movies/{movie_id}',
+        'put',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
         'properties',
         'bad_int_prop'
       ]);


### PR DESCRIPTION
## PR summary
This commit introduces a new spectral-style rule with
id 'no-etag-header'.  This rule will check to make sure that
a path's GET operation defines the ETag response
header if any of the path's operations support header parameters
named If-Match or If-None-Match.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

