### PR TITLE
feat: add new rules 'if-modified-since-parameter' and if-unmodified-since-parameter

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -49,6 +49,8 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: ibm-content-type-is-specific](#rule-ibm-content-type-is-specific)
   * [Rule: ibm-error-content-type-is-json](#rule-ibm-error-content-type-is-json)
   * [Rule: ibm-sdk-operations](#rule-ibm-sdk-operations)
+  * [Rule: if-modified-since-parameter](#rule-if-modified-since-parameter)
+  * [Rule: if-unmodified-since-parameter](#rule-if-unmodified-since-parameter)
   * [Rule: inline-response-schema](#rule-inline-response-schema)
   * [Rule: major-version-in-path](#rule-major-version-in-path)
   * [Rule: missing-required-property](#rule-missing-required-property)
@@ -231,6 +233,18 @@ which is not allowed.</td>
 <td>warn</td>
 <td>Validates the structure of the <code>x-sdk-operations</code> object </td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-if-modified-since-parameter">if-modified-since-parameter</a></td>
+<td>warn</td>
+<td>Operations should avoid supporting the <code>If-Modified-Since</code> header parameter</td>
+<td>oas2, oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-if-unmodified-since-parameter">if-unmodified-since-parameter</a></td>
+<td>warn</td>
+<td>Operations should avoid supporting the <code>If-Unmodified-Since</code> header parameter</td>
+<td>oas2, oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-inline-response-schema">inline-response-schema</a></td>
@@ -635,6 +649,7 @@ For details on how to add overrides to your custom ruleset, please read the
 ## Reference
 This section provides reference documentation about the IBM Cloud Validation Rules contained
 in the `@ibm-cloud/openapi-ruleset` package.
+
 
 ### Rule: accept-parameter
 <table>
@@ -1904,6 +1919,166 @@ n/a
 <td valign=top><b>Compliant example:</b></td>
 <td>
 n/a
+</td>
+</tr>
+</table>
+
+
+### Rule: if-modified-since-parameter
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>if-modified-since-parameter</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>The <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-headers#conditional-headers">API Handbook</a>
+recommends against the use of the <code>If-Modified-Since</code> and <code>If-Unmodified-Since</code> header parameters.
+Operations should support <code>If-Match</code> and <code>If-None-Match</code> headers instead.
+<p>This rule warns about operations that support the <code>If-Modified-Since</code> header parameter.
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas2, oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#components/parameters/ThingIdParam'
+    get:
+      operationId: get_thing
+      parameters:
+        - name: If-Modified-Since
+          in: header
+          description: |-
+            The operation will succeed only if the resource has been last modified 
+            after the date specified for this header parameter.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Resource was retrieved successfully!'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+        '412':
+          description: 'Resource has not been modified after If-Modified-Since date.'
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#components/parameters/ThingIdParam'
+    get:
+      operationId: get_thing
+      parameters:
+        - name: If-None-Match
+          in: header
+          description: |-
+            The operation will succeed only if the resource's current ETag value 
+            does not match the value specified for this header parameter.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Resource was retrieved successfully!'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+        '412':
+          description: 'Resource current ETag matches If-None-Match value.'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: if-unmodified-since-parameter
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>if-unmodified-since-parameter</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>The <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-headers#conditional-headers">API Handbook</a>
+recommends against the use of the <code>If-Modified-Since</code> and <code>If-Unmodified-Since</code> header parameters.
+Operations should support <code>If-Match</code> and <code>If-None-Match</code> headers instead.
+<p>This rule warns about operations that support the <code>If-Unmodified-Since</code> header parameter.
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas2, oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#components/parameters/ThingIdParam'
+    delete:
+      operationId: delete_thing
+      parameters:
+        - name: If-Unmodified-Since
+          in: header
+          description: |-
+            The operation will succeed only if the resource has not been modified 
+            after the date specified for this header parameter.
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'Resource was deleted successfully!'
+        '412':
+          description: 'Resource was last modified after the If-Unmodified-Since date.'
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#components/parameters/ThingIdParam'
+    delete:
+      operationId: delete_thing
+      parameters:
+        - name: If-Match
+          in: header
+           description: |-
+            The operation will succeed only if the resource's current ETag value
+            matches the value specified for this header parameter.
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'Resource was deleted successfully!'
+        '412':
+          description: 'Resource current ETag value does not match the If-Match value.'
+</pre>
 </td>
 </tr>
 </table>

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -111,6 +111,8 @@ module.exports = {
     'ibm-content-type-is-specific': ibmRules.ibmContentTypeIsSpecific,
     'ibm-error-content-type-is-json': ibmRules.ibmErrorContentTypeIsJson,
     'ibm-sdk-operations': ibmRules.ibmSdkOperations,
+    'if-modified-since-parameter': ibmRules.ifModifiedSinceParameter,
+    'if-unmodified-since-parameter': ibmRules.ifUnmodifiedSinceParameter,
     'inline-response-schema': ibmRules.inlineResponseSchema,
     'major-version-in-path': ibmRules.majorVersionInPath,
     'missing-required-property': ibmRules.missingRequiredProperty,

--- a/packages/ruleset/src/rules/if-modified-since-parameter.js
+++ b/packages/ruleset/src/rules/if-modified-since-parameter.js
@@ -1,0 +1,19 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { disallowedHeaderParameter } = require('../functions');
+const { parameters } = require('../collections');
+
+module.exports = {
+  description:
+    'Operations should support the If-None-Match header parameter instead of If-Modified-Since',
+  message: '{{description}}',
+  formats: [oas2, oas3],
+  given: parameters,
+  severity: 'warn',
+  resolved: true,
+  then: {
+    function: disallowedHeaderParameter,
+    functionOptions: {
+      headerName: 'If-Modified-Since'
+    }
+  }
+};

--- a/packages/ruleset/src/rules/if-unmodified-since-parameter.js
+++ b/packages/ruleset/src/rules/if-unmodified-since-parameter.js
@@ -1,0 +1,19 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { disallowedHeaderParameter } = require('../functions');
+const { parameters } = require('../collections');
+
+module.exports = {
+  description:
+    'Operations should support the If-Match header parameter instead of If-Unmodified-Since',
+  message: '{{description}}',
+  formats: [oas2, oas3],
+  given: parameters,
+  severity: 'warn',
+  resolved: true,
+  then: {
+    function: disallowedHeaderParameter,
+    functionOptions: {
+      headerName: 'If-Unmodified-Since'
+    }
+  }
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -20,6 +20,8 @@ module.exports = {
   ibmContentTypeIsSpecific: require('./ibm-content-type-is-specific'),
   ibmErrorContentTypeIsJson: require('./ibm-error-content-type-is-json'),
   ibmSdkOperations: require('./ibm-sdk-operations'),
+  ifModifiedSinceParameter: require('./if-modified-since-parameter'),
+  ifUnmodifiedSinceParameter: require('./if-unmodified-since-parameter'),
   inlineResponseSchema: require('./inline-response-schema'),
   majorVersionInPath: require('./major-version-in-path'),
   missingRequiredProperty: require('./missing-required-property'),

--- a/packages/ruleset/test/if-modified-since-parameter.test.js
+++ b/packages/ruleset/test/if-modified-since-parameter.test.js
@@ -1,0 +1,80 @@
+const { ifModifiedSinceParameter } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = ifModifiedSinceParameter;
+const ruleId = 'if-modified-since-parameter';
+const expectedSeverity = severityCodes.warning;
+const expectedErrorMsg =
+  'Operations should support the If-None-Match header parameter instead of If-Modified-Since';
+
+describe('Spectral rule: if-modified-since-parameter', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Query parameter named If-Modified-Since', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].parameters = [
+        {
+          description: 'A query param.',
+          name: 'If-Modified-Since',
+          required: true,
+          in: 'query',
+          schema: {
+            type: 'string'
+          }
+        }
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Path parameter named If-Modified-Since', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].parameters = [
+        {
+          description: 'A path param.',
+          name: 'If-Modified-Since',
+          required: true,
+          in: 'path',
+          schema: {
+            type: 'string'
+          }
+        }
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Header parameter named If-Modified-Since', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].parameters = [
+        {
+          description: 'Used for synchronization of resource updates.',
+          name: 'If-Modified-Since',
+          required: true,
+          in: 'header',
+          schema: {
+            type: 'string'
+          }
+        }
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedErrorMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/drinks.parameters.0');
+    });
+  });
+});

--- a/packages/ruleset/test/if-unmodified-since-parameter.test.js
+++ b/packages/ruleset/test/if-unmodified-since-parameter.test.js
@@ -1,0 +1,80 @@
+const { ifUnmodifiedSinceParameter } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = ifUnmodifiedSinceParameter;
+const ruleId = 'if-unmodified-since-parameter';
+const expectedSeverity = severityCodes.warning;
+const expectedErrorMsg =
+  'Operations should support the If-Match header parameter instead of If-Unmodified-Since';
+
+describe('Spectral rule: if-unmodified-since-parameter', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Query parameter named If-Unmodified-Since', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].parameters = [
+        {
+          description: 'A query param.',
+          name: 'If-Unmodified-Since',
+          required: true,
+          in: 'query',
+          schema: {
+            type: 'string'
+          }
+        }
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Path parameter named If-Unmodified-Since', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].parameters = [
+        {
+          description: 'A path param.',
+          name: 'If-Unmodified-Since',
+          required: true,
+          in: 'path',
+          schema: {
+            type: 'string'
+          }
+        }
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Header parameter named If-Unmodified-Since', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].parameters = [
+        {
+          description: 'Used for synchronization of resource updates.',
+          name: 'If-Unmodified-Since',
+          required: true,
+          in: 'header',
+          schema: {
+            type: 'string'
+          }
+        }
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedErrorMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe('paths./v1/drinks.parameters.0');
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
This commit introduces two new rules that warn about the use of
specific header parameters that are discouraged by the API Handbook:
1. if-modified-since-parameter - warns about operations that support the
   If-Modified-Since header parameter.
2. if-unmodified-since-parameter - warns about operations that support the
   If-Unmodified-Since header parameter.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

