### PR TITLE
feat(property-inconsistent-name-and-type): disable rule in default configuration

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -350,8 +350,8 @@ for any resources (paths) that support the <code>If-Match</code> and/or <code>If
 </tr>
 <tr>
 <td><a href="#rule-property-inconsistent-name-and-type">property-inconsistent-name-and-type</a></td>
-<td>warn</td>
-<td>Avoid using the same property name for properties of different types.</td>
+<td>off</td>
+<td>Avoid using the same property name for properties of different types. This rule is disabled by default.</td>
 <td>oas2, oas3</td>
 </tr>
 <tr>
@@ -3232,11 +3232,14 @@ components:
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>
-<td>Avoid using the same property name for properties of different types.</td>
+<td>Avoid using the same property name for properties of different types.
+<br><br>
+<b>This rule is disabled by default. Enable it in your Spectral config file to utilize this validation.</b>
+</td>
 </tr>
 <tr>
 <td><b>Severity:</b></td>
-<td>warn</td>
+<td>off</td>
 </tr>
 <tr>
 <td><b>OAS Versions:</b></td>

--- a/packages/ruleset/src/rules/property-inconsistent-name-and-type.js
+++ b/packages/ruleset/src/rules/property-inconsistent-name-and-type.js
@@ -8,7 +8,7 @@ module.exports = {
   message: '{{error}}',
   formats: [oas2, oas3],
   given: schemas,
-  severity: 'warn',
+  severity: 'off',
   resolved: true,
   then: {
     function: propertyInconsistentNameAndType,

--- a/packages/ruleset/test/property-inconsistent-name-and-type.test.js
+++ b/packages/ruleset/test/property-inconsistent-name-and-type.test.js
@@ -1,7 +1,12 @@
-let { propertyInconsistentNameAndType } = require('../src/rules');
+let rule = require('../src/rules').propertyInconsistentNameAndType;
 const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 
-const name = 'property-inconsistent-name-and-type';
+// this rule is turned off by default - enable it to run tests
+// but still verify it is defined in the rule as "off"
+const originalSeverity = makeCopy(rule.severity);
+rule.severity = 'warn';
+
+const ruleId = 'property-inconsistent-name-and-type';
 const expectedSeverity = severityCodes.warning;
 
 describe('Spectral rule: property-inconsistent-name-and-type', () => {
@@ -11,17 +16,17 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
   // isolation between the tests. this will reset that variable after each test
   afterEach(() => {
     jest.resetModules();
-    propertyInconsistentNameAndType = require('../src/rules')
-      .propertyInconsistentNameAndType;
+    rule = require('../src/rules').propertyInconsistentNameAndType;
+    rule.severity = 'warn';
+  });
+
+  it('Should originally be set to severity: "off"', () => {
+    expect(originalSeverity).toBe('off');
   });
 
   describe('Should not yield errors', () => {
     it('should not error with clean spec', async () => {
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        rootDocument
-      );
+      const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
     });
 
@@ -41,12 +46,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
         }
       };
 
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        testDocument
-      );
-
+      const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
 
@@ -94,11 +94,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
         }
       };
 
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        testDocument
-      );
+      const results = await testRule(ruleId, rule, testDocument);
 
       expect(results).toHaveLength(0);
     });
@@ -147,11 +143,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
         }
       };
 
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        testDocument
-      );
+      const results = await testRule(ruleId, rule, testDocument);
 
       expect(results).toHaveLength(0);
     });
@@ -200,11 +192,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
         }
       };
 
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        testDocument
-      );
+      const results = await testRule(ruleId, rule, testDocument);
 
       expect(results).toHaveLength(0);
     });
@@ -253,11 +241,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
         }
       };
 
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        testDocument
-      );
+      const results = await testRule(ruleId, rule, testDocument);
 
       expect(results).toHaveLength(0);
     });
@@ -287,16 +271,12 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
         }
       };
 
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        testDocument
-      );
+      const results = await testRule(ruleId, rule, testDocument);
 
       expect(results).toHaveLength(2);
 
       let validation = results[0];
-      expect(validation.code).toBe(name);
+      expect(validation.code).toBe(ruleId);
       expect(validation.message).toBe(
         'Properties with the same name have inconsistent types: running_time.'
       );
@@ -306,7 +286,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
       expect(validation.severity).toBe(expectedSeverity);
 
       validation = results[1];
-      expect(validation.code).toBe(name);
+      expect(validation.code).toBe(ruleId);
       expect(validation.message).toBe(
         'Properties with the same name have inconsistent types: running_time.'
       );
@@ -360,16 +340,12 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
         }
       };
 
-      const results = await testRule(
-        name,
-        propertyInconsistentNameAndType,
-        testDocument
-      );
+      const results = await testRule(ruleId, rule, testDocument);
 
       expect(results).toHaveLength(3);
 
       let validation = results[0];
-      expect(validation.code).toBe(name);
+      expect(validation.code).toBe(ruleId);
       expect(validation.message).toBe(
         'Properties with the same name have inconsistent types: running_time.'
       );
@@ -379,7 +355,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
       expect(validation.severity).toBe(expectedSeverity);
 
       validation = results[1];
-      expect(validation.code).toBe(name);
+      expect(validation.code).toBe(ruleId);
       expect(validation.message).toBe(
         'Properties with the same name have inconsistent types: running_time.'
       );
@@ -389,7 +365,7 @@ describe('Spectral rule: property-inconsistent-name-and-type', () => {
       expect(validation.severity).toBe(expectedSeverity);
 
       validation = results[2];
-      expect(validation.code).toBe(name);
+      expect(validation.code).toBe(ruleId);
       expect(validation.message).toBe(
         'Properties with the same name have inconsistent types: running_time.'
       );


### PR DESCRIPTION
## PR summary
This commit modifies the 'property-inconsistent-name-and-type' rule configuration
so that it is disabled by default.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

