### PR TITLE
fix(response-error-response-schema): bring rule in sync with API Handbook

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -404,7 +404,7 @@ has non-form content.</td>
 <tr>
 <td><a href="#rule-response-error-response-schema">response-error-response-schema</a></td>
 <td>warn</td>
-<td>Error response should follow API Handbook guidelines</td>
+<td>Error response schemas should comply with API Handbook guidance</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -3895,12 +3895,19 @@ requestBody:
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>
-<td><code>4xx</code> and <code>5xx</code> error responses should provide sufficient information
-to help the user resolve the error
-[<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors">1</a>].
-This rule is more lenient than the guidance outlined in the API Handbook.
-Specifically, the rule does not require an "Error Container Model"
-and allows for a single "Error Model" to be provided at the top level of the error response schema or in an <code>error</code> field.
+<td>This rule implements the guidance related to error response schemas found in the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors">API Handbook</a>.
+<p>Specifically, the following checks are performed against each schema associated with an error response:
+<ul>
+<li>The error response schema should form a valid
+<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors#error-container-model">error container model</a> as
+described by the API Handbook.</li>
+<li>The <code>errors</code> property must be an array whose <code>items</code> field is a schema that forms a valid
+<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors#error-model">error model</a>
+as described in the API Handbook.</li>
+<li>If present, the <code>target</code> property must contain a valid
+<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors#error-target-model">error target model</a>
+as described in the API Handbook.</li>
+</ul>
 </td>
 </tr>
 <tr>
@@ -3914,13 +3921,130 @@ and allows for a single "Error Model" to be provided at the top level of the err
 <tr>
 <td valign=top><b>Non-compliant example:<b></td>
 <td>
-n/a
+<pre>
+paths:
+  '/v1/things':
+    post:
+      operationId: create_thing
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Thing'
+    responses:
+      '201':
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Thing'
+      '400':
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorContainer'
+components:
+  schemas:
+    ErrorContainer: {
+      description: 'An error response for an operation.',
+      type: 'object',
+      properties: {
+        error: {
+          $ref: '#/components/schemas/Error'
+        },
+        trace: {
+          description: 'The error trace information.',
+          type: 'string',
+          format: 'uuid'
+        }
+      }
+    },
+    Error: {
+      description: 'An error response entry.',
+      type: 'object',
+      properties: {
+        code: {
+          description: 'The error code.',
+          type: 'integer'
+        },
+        message: {
+          description: 'The error message.',
+          type: 'string'
+        },
+        more_info: {
+          description: 'Additional info about the error.',
+          type: 'string'
+        },
+      }
+    }
+</pre>
 </td>
 </tr>
 <tr>
 <td valign=top><b>Compliant example:</b></td>
 <td>
-n/a
+<pre>
+paths:
+  '/v1/things':
+    post:
+      operationId: create_thing
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Thing'
+    responses:
+      '201':
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Thing'
+      '400':
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorContainer'
+components:
+  schemas:
+    ErrorContainer: {
+      description: 'An error response for an operation.',
+      type: 'object',
+      properties: {
+        errors: {
+          type: 'array',
+          minItems: 0,
+          maxItems: 100,
+          description: 'The array of error entries associated with the error response',
+          items: {
+            $ref: '#/components/schemas/Error'
+          }
+        },
+        trace: {
+          description: 'The error trace information.',
+          type: 'string',
+          format: 'uuid'
+        }
+      }
+    },
+    Error: {
+      description: 'An error response entry.',
+      type: 'object',
+      properties: {
+        code: {
+          description: 'The error code.',
+          type: 'string',
+          enum: ['bad_request', 'not_authorized', 'no_need_to_know']
+        },
+        message: {
+          description: 'The error message.',
+          type: 'string'
+        },
+        more_info: {
+          description: 'Additional info about the error.',
+          type: 'string'
+        },
+      }
+    }
+</pre>
 </td>
 </tr>
 </table>

--- a/packages/ruleset/src/functions/error-response-schema.js
+++ b/packages/ruleset/src/functions/error-response-schema.js
@@ -1,136 +1,312 @@
-module.exports = function(errorResponseSchema, _opts, { path }) {
-  const errors = [];
-  if (!schemaIsObjectWithProperties(errorResponseSchema)) {
-    return [
-      {
-        message: 'Error response should be an object with properties',
-        path: path
-      }
-    ];
-  } else {
-    errors.push(...validateErrorResponseProperties(errorResponseSchema, path));
-  }
-  return errors;
+const {
+  isArraySchema,
+  isIntegerSchema,
+  isObject,
+  isStringSchema
+} = require('../utils');
+
+module.exports = function(schema, _opts, { path }) {
+  return checkErrorContainerModelSchema(schema, path);
 };
 
-function validateErrorResponseProperties(errorResponseSchema, pathToSchema) {
+/**
+ * This function will verify that "schema" complies with the API Handbook's
+ * "Errors" section (https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-errors), specifically
+ * that it complies with the "Error container model" design requirements.
+ * Here are the specific checks that are performed:
+ * 1. "schema" contains the "trace" property (a string)
+ * 2. "schema" contains the "errors" property (an array)
+ * 3. if "schema" contains the "status_code" property it must be an integer
+ * 4. the "errors" property's "items" field must be a valid "error model"
+ * 5. the error model schema (i.e. errors.items) contains the "code" string property
+ * which must have an enum identifying the valid error codes that could be returned by
+ * the server.
+ * 6. the error model schema contains the "message" property (a string)
+ * 7. the error model schema contains the "more_info" property (a string)
+ * 8. if the error model schema contains the "target" property, it must be a valid
+ * error target model with string properties "type" and "name" present
+ * @param {*} schema the schema to be verified as an "Error container model" schema
+ * @param {*} path the array of path segments indicating the "location" of the schema within the API definition
+ * (e.g. ['paths','/v1/clouds/{id}', 'get', 'responses', '400', 'content', 'application/json', 'schema'])
+ * @returns an array containing the violations found or [] if no violations
+ */
+function checkErrorContainerModelSchema(schema, path) {
+  if (!schemaIsObjectWithProperties(schema)) {
+    return [
+      {
+        message: 'Error container model must be an object with properties',
+        path
+      }
+    ];
+  }
+
+  const properties = schema.properties;
+  path = [...path, 'properties'];
+
   const errors = [];
-  const errorResponseProperties = errorResponseSchema.properties;
-  const pathToProperties = [...pathToSchema, 'properties'];
-  if (!hasTraceField(errorResponseProperties)) {
-    errors.push({
-      message: 'Error response should have a uuid `trace` field',
-      path: [...pathToProperties, 'trace']
-    });
+  errors.push(...checkTraceProperty(properties, path));
+  errors.push(...checkStatusCodeProperty(properties, path));
+  errors.push(...checkErrorsProperty(properties, path));
+  return errors;
+}
+
+function checkTraceProperty(properties, path) {
+  const prop = properties.trace;
+  if (prop) {
+    path = [...path, 'trace'];
   }
-  if (!validStatusCodeField(errorResponseProperties)) {
-    errors.push({
-      message: '`status_code` field must be an integer',
-      path: [...pathToProperties, 'status_code']
-    });
+  if (!isObject(prop) || !isStringSchema(prop)) {
+    return [
+      {
+        message:
+          'Error container model should contain property `trace` of type string',
+        path
+      }
+    ];
   }
-  if (errorResponseProperties.errors) {
-    // validate `errors` is error model container
-    if (errorResponseProperties.errors.type !== 'array') {
+  return [];
+}
+
+function checkStatusCodeProperty(properties, path) {
+  // It's ok to omit the status_code property.  But if present, it MUST be an integer.
+  const prop = properties.status_code;
+  if (!prop) {
+    return [];
+  }
+
+  if (!isObject(prop) || !isIntegerSchema(prop)) {
+    return [
+      {
+        message:
+          'Error container model property `status_code` must be of type integer',
+        path: [...path, 'status_code']
+      }
+    ];
+  }
+  return [];
+}
+
+function checkErrorsProperty(properties, path) {
+  path = [...path];
+
+  const prop = properties.errors;
+  if (prop) {
+    path.push('errors');
+  }
+  if (!isObject(prop) || !isArraySchema(prop)) {
+    return [
+      {
+        message:
+          'Error container model must contain property `errors` which must be an array of error models',
+        path
+      }
+    ];
+  }
+
+  const items = prop.items;
+  if (items) {
+    path.push('items');
+  }
+  if (!schemaIsObjectWithProperties(items)) {
+    return [
+      {
+        message:
+          'Error container model `errors.items` field must be an object with properties',
+        path
+      }
+    ];
+  }
+
+  return validateErrorModelSchema(items, path);
+}
+
+function validateErrorModelSchema(schema, path) {
+  path = [...path, 'properties'];
+  const properties = schema.properties;
+
+  const errors = [];
+  errors.push(...checkCodeProperty(properties, path));
+  errors.push(...checkMessageProperty(properties, path));
+  errors.push(...checkMoreInfoProperty(properties, path));
+  errors.push(...checkTargetProperty(properties, path));
+  return errors;
+}
+
+function checkCodeProperty(properties, path) {
+  path = [...path];
+
+  const prop = properties.code;
+  if (!prop) {
+    return [
+      {
+        message: 'Error model must contain property `code` of type string',
+        path
+      }
+    ];
+  }
+
+  path.push('code');
+
+  if (!isStringSchema(prop)) {
+    return [
+      {
+        message: 'Error model must contain property `code` of type string',
+        path
+      }
+    ];
+  }
+
+  if (!prop.enum) {
+    return [
+      {
+        message:
+          'Error model property `code` must include an enumeration of the valid error codes',
+        path
+      }
+    ];
+  }
+
+  path.push('enum');
+
+  if (!Array.isArray(prop.enum)) {
+    return [
+      {
+        message:
+          'Error model property `code` must include an enumeration of the valid error codes',
+        path
+      }
+    ];
+  }
+
+  return [];
+}
+
+function checkMessageProperty(properties, path) {
+  const prop = properties.message;
+  if (prop) {
+    path = [...path, 'message'];
+  }
+  if (!isObject(prop) || !isStringSchema(prop)) {
+    return [
+      {
+        message: 'Error model must contain property `message` of type string',
+        path
+      }
+    ];
+  }
+  return [];
+}
+
+function checkMoreInfoProperty(properties, path) {
+  const prop = properties.more_info;
+  if (prop) {
+    path = [...path, 'more_info'];
+  }
+  if (!isObject(prop) || !isStringSchema(prop)) {
+    return [
+      {
+        message:
+          'Error model should contain property `more_info` of type string',
+        path
+      }
+    ];
+  }
+  return [];
+}
+
+function checkTargetProperty(properties, path) {
+  // It's ok to omit the target property.
+  const target = properties.target;
+  if (!target) {
+    return [];
+  }
+
+  path = [...path, 'target'];
+
+  // If target is defined, it must comply with the API Handbook.
+  if (!schemaIsObjectWithProperties(target)) {
+    return [
+      {
+        message:
+          'Error model property `target` must be a valid error target model object',
+        path
+      }
+    ];
+  }
+
+  const targetModelProps = target.properties;
+  path.push('properties');
+
+  const errors = [];
+
+  // 1. The 'type' property must be defined as an enumeration: ['field', 'header', 'parameter'].
+  const typeProp = targetModelProps.type;
+  if (!typeProp) {
+    errors.push({
+      message: 'Error target model must contain property `type` of type string',
+      path
+    });
+  } else if (!isStringSchema(typeProp)) {
+    errors.push({
+      message: 'Error target model must contain property `type` of type string',
+      path: [...path, 'type']
+    });
+  } else {
+    // We know that 'type' is a string property. Now make sure its enum complies.
+    const enumValue = typeProp.enum;
+    const message =
+      "Error target model property `type` must define an enumeration containing ['field', 'header', 'parameter']";
+    if (!enumValue) {
       errors.push({
-        message: '`errors` field should be an array of error models',
-        path: [...pathToProperties, 'errors']
+        message,
+        path: [...path, 'type']
+      });
+    } else if (!Array.isArray(enumValue)) {
+      errors.push({
+        message,
+        path: [...path, 'type', 'enum']
       });
     } else {
-      // `errors` is error model container, so validate the items
-      // are valid error models
-      errors.push(
-        ...validateErrorModelSchema(errorResponseProperties.errors.items, [
-          ...pathToProperties,
-          'errors',
-          'items'
-        ])
-      );
+      const validEnum = ['field', 'parameter', 'header'];
+      if (!listsEqual(validEnum, enumValue)) {
+        errors.push({
+          message,
+          path: [...path, 'type', 'enum']
+        });
+      }
     }
-  } else if (errorResponseProperties.error) {
-    // expect a single error model, validate error model schema
-    errors.push(
-      ...validateErrorModelSchema(errorResponseProperties.error, [
-        ...pathToProperties,
-        'error'
-      ])
-    );
-  } else {
-    // no `errors` or `error` field, so expect error model at top level of schema
-    errors.push(...validateErrorModelSchema(errorResponseSchema, pathToSchema));
   }
-  return errors;
-}
 
-function validateErrorModelSchema(errorModelSchema, pathToSchema) {
-  const errors = [];
-  if (!schemaIsObjectWithProperties(errorModelSchema)) {
+  // 2. The 'name' property must be of type string.
+  const nameProp = targetModelProps.name;
+  if (!nameProp) {
     errors.push({
-      message: 'Error Model should be an object with properties',
-      path: pathToSchema
+      message: 'Error target model must contain property `name` of type string',
+      path
     });
-  } else {
-    // error model has properties, validate the properties
-    if (!hasCodeField(errorModelSchema.properties)) {
-      errors.push({
-        message:
-          'Error Model should contain `code` field, a snake-case, string error code',
-        path: [...pathToSchema, 'properties', 'code']
-      });
-    }
-    if (!hasMessageField(errorModelSchema.properties)) {
-      errors.push({
-        message: 'Error Model should contain a string, `message`, field',
-        path: [...pathToSchema, 'properties', 'message']
-      });
-    }
-    if (!hasMoreInfoField(errorModelSchema.properties)) {
-      errors.push({
-        message:
-          'Error Model should contain `more_info` field that contains a URL with more info about the error',
-        path: [...pathToSchema, 'properties', 'more_info']
-      });
-    }
+  } else if (!isStringSchema(nameProp)) {
+    errors.push({
+      message: 'Error target model must contain property `name` of type string',
+      path: [...path, 'name']
+    });
   }
+
   return errors;
 }
 
-function validStatusCodeField(errorResponseProperties) {
-  // valid if no status_code provided or if the provided status_code is an integer
-  return (
-    !errorResponseProperties.status_code ||
-    errorResponseProperties.status_code.type === 'integer'
-  );
+/**
+ * Returns true iff "list1" equals "list2" without regard to the order of elements.
+ * @param {*} list1 the first list to compare
+ * @param {*} list2 the second list to compare
+ * @returns boolean true iff the lists contain the same elements even if in a different order
+ */
+function listsEqual(list1, list2) {
+  if (list1.length != list2.length) {
+    return false;
+  }
+  return list1.every(x => list2.includes(x));
 }
 
-function hasCodeField(errorModelSchemaProperties) {
-  return (
-    errorModelSchemaProperties.code &&
-    errorModelSchemaProperties.code.type === 'string'
-  );
-}
-
-function hasMessageField(errorModelSchemaProperties) {
-  return (
-    errorModelSchemaProperties.message &&
-    errorModelSchemaProperties.message.type === 'string'
-  );
-}
-
-function hasMoreInfoField(errorModelSchemaProperties) {
-  return (
-    errorModelSchemaProperties.more_info &&
-    errorModelSchemaProperties.more_info.type === 'string'
-  );
-}
-
-function hasTraceField(errorResponseProperties) {
-  return (
-    errorResponseProperties.trace &&
-    errorResponseProperties.trace.type === 'string'
-  );
-}
-
-function schemaIsObjectWithProperties(errorResponseSchema) {
-  return !!errorResponseSchema.properties;
+function schemaIsObjectWithProperties(s) {
+  return s && isObject(s) && isObject(s.properties);
 }

--- a/packages/ruleset/src/rules/response-error-response-schema.js
+++ b/packages/ruleset/src/rules/response-error-response-schema.js
@@ -2,7 +2,8 @@ const { oas3 } = require('@stoplight/spectral-formats');
 const { errorResponseSchema } = require('../functions');
 
 module.exports = {
-  description: 'Error response should follow design guidelines',
+  description:
+    'Error response schemas should comply with API Handbook guidance',
   message: '{{error}}',
   given:
     '$.paths[*][*].responses[?(@property >= 400 && @property < 600)].content[*].schema',

--- a/packages/ruleset/test/array-boundary.test.js
+++ b/packages/ruleset/test/array-boundary.test.js
@@ -133,17 +133,19 @@ describe('Spectral rule: array-boundary', () => {
         description: 'An error response.',
         type: 'object',
         properties: {
-          trace: {
-            description: 'array containing each line of a stack trace',
+          errors: {
             type: 'array',
-            minItems: 1,
+            minItems: 0,
+            description:
+              'The array of error entries associated with the error response',
             items: {
-              type: 'string',
-              format: 'uuid'
+              $ref: '#/components/schemas/Error'
             }
           },
-          error: {
-            $ref: '#/components/schemas/RequestError'
+          trace: {
+            description: 'The error trace information.',
+            type: 'string',
+            format: 'uuid'
           }
         }
       };
@@ -154,7 +156,7 @@ describe('Spectral rule: array-boundary', () => {
       expect(results[0].message).toBe(expectedMsgMax);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/movies.post.responses.400.content.application/json.schema.properties.trace'
+        'paths./v1/movies.post.responses.400.content.application/json.schema.properties.errors'
       );
     });
 

--- a/packages/ruleset/test/description-mentions-json.test.js
+++ b/packages/ruleset/test/description-mentions-json.test.js
@@ -111,13 +111,20 @@ describe('Spectral rule: description-mentions-json', () => {
         description: 'A JSON object containing the error details.',
         type: 'object',
         properties: {
+          errors: {
+            type: 'array',
+            minItems: 0,
+            maxItems: 100,
+            description:
+              'The array of error entries associated with the error response',
+            items: {
+              $ref: '#/components/schemas/Error'
+            }
+          },
           trace: {
             description: 'The error trace information.',
             type: 'string',
             format: 'uuid'
-          },
-          error: {
-            $ref: '#/components/schemas/RequestError'
           }
         }
       };

--- a/packages/ruleset/test/inline-response-schema.test.js
+++ b/packages/ruleset/test/inline-response-schema.test.js
@@ -108,13 +108,20 @@ describe('Spectral rule: inline-response-schema', () => {
         description: 'An error response.',
         type: 'object',
         properties: {
+          errors: {
+            type: 'array',
+            minItems: 0,
+            maxItems: 100,
+            description:
+              'The array of error entries associated with the error response',
+            items: {
+              $ref: '#/components/schemas/Error'
+            }
+          },
           trace: {
             description: 'The error trace information.',
             type: 'string',
             format: 'uuid'
-          },
-          error: {
-            $ref: '#/components/schemas/RequestError'
           }
         }
       };

--- a/packages/ruleset/test/property-description.test.js
+++ b/packages/ruleset/test/property-description.test.js
@@ -137,13 +137,20 @@ describe('Spectral rule: property-description', () => {
         description: 'An error response.',
         type: 'object',
         properties: {
+          errors: {
+            type: 'array',
+            minItems: 0,
+            maxItems: 100,
+            description:
+              'The array of error entries associated with the error response',
+            items: {
+              $ref: '#/components/schemas/Error'
+            }
+          },
           trace: {
-            description: '        ',
+            description: '   ',
             type: 'string',
             format: 'uuid'
-          },
-          error: {
-            $ref: '#/components/schemas/RequestError'
           }
         }
       };

--- a/packages/ruleset/test/schema-description.test.js
+++ b/packages/ruleset/test/schema-description.test.js
@@ -119,13 +119,20 @@ describe('Spectral rule: schema-description', () => {
         description: '      ',
         type: 'object',
         properties: {
+          errors: {
+            type: 'array',
+            minItems: 0,
+            maxItems: 100,
+            description:
+              'The array of error entries associated with the error response',
+            items: {
+              $ref: '#/components/schemas/Error'
+            }
+          },
           trace: {
             description: 'The error trace information.',
             type: 'string',
             format: 'uuid'
-          },
-          error: {
-            $ref: '#/components/schemas/RequestError'
           }
         }
       };

--- a/packages/ruleset/test/schema-type.test.js
+++ b/packages/ruleset/test/schema-type.test.js
@@ -83,15 +83,22 @@ describe('Spectral rule: schema-type', () => {
       testDocument.paths['/v1/movies'].post.responses['400'].content[
         'application/json'
       ].schema = {
+        type: '  ',
         description: 'an object schema',
         properties: {
+          errors: {
+            type: 'array',
+            minItems: 0,
+            description:
+              'The array of error entries associated with the error response',
+            items: {
+              $ref: '#/components/schemas/Error'
+            }
+          },
           trace: {
             description: 'The error trace information.',
             type: 'string',
             format: 'uuid'
-          },
-          error: {
-            $ref: '#/components/schemas/RequestError'
           }
         }
       };

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -62,7 +62,7 @@ module.exports = {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Error'
+                  $ref: '#/components/schemas/ErrorContainer'
                 }
               }
             }
@@ -122,7 +122,7 @@ module.exports = {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Error'
+                  $ref: '#/components/schemas/ErrorContainer'
                 }
               }
             }
@@ -283,7 +283,7 @@ module.exports = {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Error'
+                  $ref: '#/components/schemas/ErrorContainer'
                 }
               }
             }
@@ -392,7 +392,7 @@ module.exports = {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Error'
+                  $ref: '#/components/schemas/ErrorContainer'
                 }
               }
             }
@@ -433,7 +433,7 @@ module.exports = {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Error'
+                  $ref: '#/components/schemas/ErrorContainer'
                 }
               }
             }
@@ -443,7 +443,7 @@ module.exports = {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Error'
+                  $ref: '#/components/schemas/ErrorContainer'
                 }
               }
             }
@@ -952,13 +952,39 @@ module.exports = {
           }
         }
       },
-      RequestError: {
-        description: 'This schema describes an error response.',
+      ErrorContainer: {
+        description: 'An error response for an operation.',
+        type: 'object',
+        properties: {
+          errors: {
+            type: 'array',
+            minItems: 0,
+            maxItems: 100,
+            description:
+              'The array of error entries associated with the error response',
+            items: {
+              $ref: '#/components/schemas/Error'
+            }
+          },
+          status_code: {
+            type: 'integer',
+            description: 'The HTTP status code.'
+          },
+          trace: {
+            description: 'The error trace information.',
+            type: 'string',
+            format: 'uuid'
+          }
+        }
+      },
+      Error: {
+        description: 'An error response entry.',
         type: 'object',
         properties: {
           code: {
             description: 'The error code.',
-            type: 'string'
+            type: 'string',
+            enum: ['bad_request', 'not_authorized', 'no_need_to_know']
           },
           message: {
             description: 'The error message.',
@@ -967,20 +993,25 @@ module.exports = {
           more_info: {
             description: 'Additional info about the error.',
             type: 'string'
+          },
+          target: {
+            $ref: '#/components/schemas/ErrorTarget'
           }
         }
       },
-      Error: {
-        description: 'An error response.',
+      ErrorTarget: {
+        description: 'An error target (a field, header or query parameter).',
         type: 'object',
         properties: {
-          trace: {
-            description: 'The error trace information.',
+          type: {
+            description: 'The error target type.',
             type: 'string',
-            format: 'uuid'
+            enum: ['field', 'header', 'parameter']
           },
-          error: {
-            $ref: '#/components/schemas/RequestError'
+          name: {
+            description:
+              'The name of the field/header/query parameter associated with the error.',
+            type: 'string'
           }
         }
       }
@@ -1093,7 +1124,7 @@ module.exports = {
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/Error'
+              $ref: '#/components/schemas/ErrorContainer'
             }
           }
         }
@@ -1118,7 +1149,7 @@ module.exports = {
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/Error'
+              $ref: '#/components/schemas/ErrorContainer'
             }
           }
         }


### PR DESCRIPTION
## PR summary
This commit updates the implementation, tests and documentation
associated with the 'response-error-response-schema' validation rule
so that it more accurately implements the API Handbook guidance
related to error response schemas.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

