### PR TITLE
fix(request-body-name): support json-patch/merge-patch operations

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -3643,7 +3643,7 @@ specific description. Here is an example (a swagger 2.0 fragment):
 <pre>
 definitions:
   PageLink:
-    description: 'A link to a page of results'        <<< general description
+    description: 'A link to a page of results'        &lt;&lt;&lt; general description
     type: object
     properties:
       href:
@@ -3655,10 +3655,10 @@ definitions:
     properties:
       first:
         $ref: '#/definitions/PageLink'
-        description: 'A link to the first page of results'     <<< more specific description
+        description: 'A link to the first page of results'     &lt;&lt;&lt; more specific description
       next:
         $ref: '#/definitions/PageLink'
-        description: 'A link to the next page of results'      <<< more specific description
+        description: 'A link to the next page of results'      &lt;&lt;&lt; more specific description
 </pre>
 In this example, the "first" and "next" properties are given specific descriptions that indicate they point to
 the first and next page of results, respectively.
@@ -3669,7 +3669,7 @@ API authors typically use the "ref sibling" allOf pattern.   The above example m
 components:
   schemas:
     PageLink:
-      description: 'A link to a page of results'        <<< general description
+      description: 'A link to a page of results'        &lt;&lt;&lt; general description
       type: object
       properties:
         href:
@@ -3682,9 +3682,9 @@ components:
         first:
           allOf:
             - $ref: '#/components/schemas/PageLink'
-            - description: 'A link to the first page of results'     <<< more specific description
+            - description: 'A link to the first page of results'     &lt;&lt;&lt; more specific description
         next:
-          description: 'A link to the next page of results'      <<< more specific description
+          description: 'A link to the next page of results'      &lt;&lt;&lt; more specific description
           allOf:
             - $ref: '#/components/schemas/PageLink'
 </pre>
@@ -3700,7 +3700,7 @@ Here is an example of this:
 components:
   schemas:
     PageLink:
-      description: 'A link to a page of results'        <<< general description
+      description: 'A link to a page of results'        &lt;&lt;&lt; general description
       type: object
       properties:
         href:
@@ -3713,7 +3713,7 @@ components:
         page_link:
           allOf:
             - $ref: '#/components/schemas/PageLink'
-            - description: 'A link to a page of results'     <<< duplicate description
+            - description: 'A link to a page of results'     &lt;&lt;&lt; duplicate description
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/request-body-name.js
+++ b/packages/ruleset/src/functions/request-body-name.js
@@ -1,4 +1,10 @@
-const { isJsonMimeType, isFormMimeType, isArraySchema } = require('../utils');
+const {
+  isJsonMimeType,
+  isFormMimeType,
+  isArraySchema,
+  isJsonPatchMimeType,
+  isMergePatchMimeType
+} = require('../utils');
 
 module.exports = function(operation, _opts, { path }) {
   return requestBodyName(operation, path);
@@ -78,10 +84,15 @@ function needRequestBodyName(requestBody) {
   // so let's check if the body will be exploded.
 
   // Does the operation support JSON content?
-  const jsonMimeType = mimeTypes.find(m => isJsonMimeType(m));
+  const jsonMimeType = mimeTypes.find(
+    m => isJsonMimeType(m) || isJsonPatchMimeType(m) || isMergePatchMimeType(m)
+  );
 
   // Does the operation support non-JSON content?
-  const hasNonJsonContent = mimeTypes.find(m => !isJsonMimeType(m));
+  const hasNonJsonContent = mimeTypes.find(
+    m =>
+      !isJsonMimeType(m) && !isJsonPatchMimeType(m) && !isMergePatchMimeType(m)
+  );
 
   // Grab the requestBody schema for the JSON mimetype (if present).
   const bodySchema = jsonMimeType && content[jsonMimeType].schema;

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -533,7 +533,6 @@ module.exports = {
             IAM: []
           }
         ],
-        'x-codegen-request-body-name': 'car',
         requestBody: {
           $ref: '#/components/requestBodies/UpdateCarRequest'
         },


### PR DESCRIPTION
## PR summary

This commit updates the 'request-body-name' rule so that it supports
patch operations with requestBody mimetypes `application/json-patch+json` 
and `application/merge-patch+json` and treats those the same as normal
operations with a normal json-based request body.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

