### PR TITLE
feat(optional-request-body): add new spectral-style rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -58,6 +58,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: operation-id-case-convention](#rule-operation-id-case-convention)
   * [Rule: operation-id-naming-convention](#rule-operation-id-naming-convention)
   * [Rule: operation-summary](#rule-operation-summary)
+  * [Rule: optional-request-body](#rule-optional-request-body)
   * [Rule: pagination-style](#rule-pagination-style)
   * [Rule: parameter-case-convention](#rule-parameter-case-convention)
   * [Rule: parameter-default](#rule-parameter-default)
@@ -290,6 +291,12 @@ for any resources (paths) that support the <code>If-Match</code> and/or <code>If
 <td><a href="#rule-operation-summary">operation-summary</a></td>
 <td>warn</td>
 <td>Operation <code>summary</code> must be present and non-empty string.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-optional-request-body">optional-request-body</a></td>
+<td>info</td>
+<td>An optional requestBody with required properties should probably be required</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -2576,6 +2583,65 @@ paths:
       operationId: create_thing
       description: Create a new Thing instance.
       summary: Create a Thing
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: optional-request-body
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>optional-request-body</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule scrutinizes optional request bodies because in most cases, they should be required.
+Specifically, this rule examines the schemas associated with optional request bodies and
+if there are required properties, then it is likely that the API author intended for the
+request body to be required.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>info</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/things':
+    post:
+      operationId: create_thing
+      requestBody:
+        required: false
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Thing'    # Assume "Thing" schema has required properties
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things':
+    post:
+      operationId: create_thing
+      requestBody:
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Thing'    # Assume "Thing" schema has required properties
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -19,6 +19,7 @@ module.exports = {
   operationIdCaseConvention: require('./operation-id-case-convention'),
   operationIdNamingConvention: require('./operation-id-naming-convention'),
   operationSummary: require('./operation-summary'),
+  optionalRequestBody: require('./optional-request-body'),
   paginationStyle: require('./pagination-style'),
   parameterCaseConvention: require('./parameter-case-convention'),
   parameterDefault: require('./parameter-default'),

--- a/packages/ruleset/src/functions/optional-request-body.js
+++ b/packages/ruleset/src/functions/optional-request-body.js
@@ -1,0 +1,22 @@
+const { getCompositeSchemaAttribute } = require('../utils');
+
+module.exports = function(schema, _opts, { path }) {
+  return checkOptionalRequestBodySchema(schema, path);
+};
+
+function checkOptionalRequestBodySchema(schema, path) {
+  // If the schema has any required properties, then return a warning.
+  const required = getCompositeSchemaAttribute(schema, 'required');
+  if (Array.isArray(required)) {
+    return [
+      {
+        message: '',
+
+        // Return the path to the requestBody, not the schema.
+        path: path.slice(0, 4)
+      }
+    ];
+  }
+
+  return [];
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -120,6 +120,7 @@ module.exports = {
     'operation-id-case-convention': ibmRules.operationIdCaseConvention,
     'operation-id-naming-convention': ibmRules.operationIdNamingConvention,
     'operation-summary': ibmRules.operationSummary,
+    'optional-request-body': ibmRules.optionalRequestBody,
     'pagination-style': ibmRules.paginationStyle,
     'parameter-case-convention': ibmRules.parameterCaseConvention,
     'parameter-default': ibmRules.parameterDefault,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -29,6 +29,7 @@ module.exports = {
   operationIdCaseConvention: require('./operation-id-case-convention'),
   operationIdNamingConvention: require('./operation-id-naming-convention'),
   operationSummary: require('./operation-summary'),
+  optionalRequestBody: require('./optional-request-body'),
   paginationStyle: require('./pagination-style'),
   parameterCaseConvention: require('./parameter-case-convention'),
   parameterDefault: require('./parameter-default'),

--- a/packages/ruleset/src/rules/optional-request-body.js
+++ b/packages/ruleset/src/rules/optional-request-body.js
@@ -1,0 +1,16 @@
+const { oas3 } = require('@stoplight/spectral-formats');
+const { optionalRequestBody } = require('../functions');
+
+module.exports = {
+  description:
+    'An optional requestBody with required properties should probably be required',
+  message: '{{description}}',
+  given:
+    "$.paths[*].[*].[?(@property === 'requestBody' && @.required !== true)].content.[*].schema",
+  severity: 'info',
+  formats: [oas3],
+  resolved: true,
+  then: {
+    function: optionalRequestBody
+  }
+};

--- a/packages/ruleset/test/optional-request-body.test.js
+++ b/packages/ruleset/test/optional-request-body.test.js
@@ -1,0 +1,85 @@
+const { optionalRequestBody } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = optionalRequestBody;
+const ruleId = 'optional-request-body';
+const expectedSeverity = severityCodes.info;
+const expectedMsg =
+  'An optional requestBody with required properties should probably be required';
+
+describe('Spectral rule: optional-request-body', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('requestBody.required not present', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.components.requestBodies['CarRequest'].required;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe('paths./v1/cars.post.requestBody');
+    });
+
+    it('requestBody.required explicitly false', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.requestBodies[
+        'UpdateCarRequest'
+      ].required = false;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody'
+      );
+    });
+
+    it('requestBody.schema required field in an allOf child', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.requestBodies['UpdateCarRequest'] = {
+        required: false,
+        content: {
+          'application/merge-patch+json': {
+            schema: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Car'
+                }
+              ]
+            },
+            examples: {
+              RequestExample: {
+                $ref: '#/components/examples/CarExample'
+              }
+            }
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -38,6 +38,7 @@ module.exports = {
         ],
         'x-codegen-request-body-name': 'drink',
         requestBody: {
+          required: true,
           content: {
             'application/json': {
               schema: {
@@ -218,6 +219,7 @@ module.exports = {
           }
         ],
         requestBody: {
+          required: true,
           content: {
             'application/octet-stream': {
               schema: {
@@ -259,6 +261,7 @@ module.exports = {
           }
         ],
         requestBody: {
+          required: true,
           content: {
             'application/json': {
               schema: {
@@ -416,6 +419,7 @@ module.exports = {
         ],
         'x-codegen-request-body-name': 'movie',
         requestBody: {
+          required: true,
           content: {
             'application/json': {
               schema: {
@@ -1156,6 +1160,7 @@ module.exports = {
     },
     requestBodies: {
       CarRequest: {
+        required: true,
         content: {
           'application/json': {
             schema: {
@@ -1170,6 +1175,7 @@ module.exports = {
         }
       },
       UpdateCarRequest: {
+        required: true,
         content: {
           'application/merge-patch+json; charset=utf-8': {
             schema: {


### PR DESCRIPTION
## PR summary
This commit introduces a new spectral-style
'optional-request-body' rule, which will examine
each optional request body and it's associated schema
to see if it looks like the API author might have
intended to define the requestBody as required.
It is rare to have an optional requestBody with
a schema that contains required properties.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

