### PR TITLE
feat(merge-patch-optional-properties): add new spectral-style rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -53,6 +53,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: if-unmodified-since-parameter](#rule-if-unmodified-since-parameter)
   * [Rule: inline-response-schema](#rule-inline-response-schema)
   * [Rule: major-version-in-path](#rule-major-version-in-path)
+  * [Rule: merge-patch-optional-properties](#rule-merge-patch-optional-properties)
   * [Rule: missing-required-property](#rule-missing-required-property)
   * [Rule: no-etag-header](#rule-no-etag-header)
   * [Rule: operation-id-case-convention](#rule-operation-id-case-convention)
@@ -260,6 +261,12 @@ which is not allowed.</td>
 <td>warn</td>
 <td>All paths must contain the API major version as a distinct path segment</td>
 <td>oas2, oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-merge-patch-optional-properties">merge-patch-optional-properties</a></td>
+<td>warn</td>
+<td>JSON merge-patch requestBody schemas should have no required properties</td>
+<td>oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-missing-required-property">missing-required-property</a></td>
@@ -2216,7 +2223,7 @@ info:
   ...
 paths:
   /things:
-    ,,,
+    ...
 </pre>
 </td>
 </tr>
@@ -2230,12 +2237,91 @@ info:
   ...
 paths:
   /v1/things:
-    ,,,
+    ...
 </pre>
 </td>
 </tr>
 </table>
 
+
+### Rule: merge-patch-optional-properties
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>merge-patch-optional-properties</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>In order to adhere to the "merge-patch" semantics, the requestBody schema for a patch operation
+with <code>application/merge-patch+json</code> requestBody content should not
+define any required properties or specify a non-zero value for the <code>minProperties</code> field.
+<p>This rule verifies that "merge-patch" operations adhere to this requirement.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  /v1/things/{thing_id}:
+    patch:
+      operationId: update_thing
+      requestBody:
+        content:
+          'application/merge-patch+json':
+            schema:
+              $ref: '#/components/schemas/ThingPatch'
+components:
+  schemas:
+    ThingPatch:
+      type: object
+      required:
+        - name
+        - long_description
+      properties:
+        name:
+          description: The name of the Thing
+          type: string
+        long_description:
+          description: The long description of the Thing
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  /v1/things/{thing_id}:
+    patch:
+      operationId: update_thing
+      requestBody:
+        content:
+          'application/merge-patch+json':
+            schema:
+              $ref: '#/components/schemas/ThingPatch'
+components:
+  schemas:
+    ThingPatch:          &lt;&lt;&lt; no longer defines any required properties
+      type: object
+      properties:
+        name:
+          description: The name of the Thing
+          type: string
+        long_description:
+          description: The long description of the Thing
+</pre>
+</td>
+</tr>
+</table>
 
 ### Rule: missing-required-property
 <table>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -15,6 +15,7 @@ module.exports = {
   enumCaseConvention: require('./enum-case-convention'),
   errorResponseSchema: require('./error-response-schema'),
   inlineResponseSchema: require('./inline-response-schema'),
+  mergePatchOptionalProperties: require('./merge-patch-optional-properties'),
   noEtagHeader: require('./no-etag-header'),
   operationIdCaseConvention: require('./operation-id-case-convention'),
   operationIdNamingConvention: require('./operation-id-naming-convention'),

--- a/packages/ruleset/src/functions/merge-patch-optional-properties.js
+++ b/packages/ruleset/src/functions/merge-patch-optional-properties.js
@@ -1,0 +1,40 @@
+const { checkCompositeSchemaForConstraint } = require('../utils');
+
+module.exports = function(schema, _opts, { path }) {
+  return mergePatchOptionalProperties(schema, path);
+};
+
+/**
+ * This function is invoked for each merge-patch operation's requestBody schema and
+ * will check to make sure the schema doesn't define any required properties.
+ *
+ * @param {} schema the requestBody schema to check for required properties
+ * @param {*} path the array of path segments indicating the "location" of a
+ * requestBody schema for a merge-patch operation (e.g. ['paths', '/v1/things/{thing_id}',
+ * 'patch', 'requestBody', 'content', 'application/merge-patch+json', 'schema'])).
+ * @returns an array containing the violations found or [] if no violations
+ */
+function mergePatchOptionalProperties(schema, path) {
+  if (containsRequiredProperties(schema) || hasMinProperties(schema)) {
+    return [
+      {
+        // The rule's description field is used as the error message.
+        message: '',
+        path
+      }
+    ];
+  }
+
+  return [];
+}
+
+function containsRequiredProperties(schema) {
+  return checkCompositeSchemaForConstraint(
+    schema,
+    s => s && Array.isArray(s.required) && s.required.length > 0
+  );
+}
+
+function hasMinProperties(schema) {
+  return checkCompositeSchemaForConstraint(schema, s => s && s.minProperties);
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -115,6 +115,7 @@ module.exports = {
     'if-unmodified-since-parameter': ibmRules.ifUnmodifiedSinceParameter,
     'inline-response-schema': ibmRules.inlineResponseSchema,
     'major-version-in-path': ibmRules.majorVersionInPath,
+    'merge-patch-optional-properties': ibmRules.mergePatchOptionalProperties,
     'missing-required-property': ibmRules.missingRequiredProperty,
     'no-etag-header': ibmRules.noEtagHeader,
     'operation-id-case-convention': ibmRules.operationIdCaseConvention,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -24,6 +24,7 @@ module.exports = {
   ifUnmodifiedSinceParameter: require('./if-unmodified-since-parameter'),
   inlineResponseSchema: require('./inline-response-schema'),
   majorVersionInPath: require('./major-version-in-path'),
+  mergePatchOptionalProperties: require('./merge-patch-optional-properties'),
   missingRequiredProperty: require('./missing-required-property'),
   noEtagHeader: require('./no-etag-header'),
   operationIdCaseConvention: require('./operation-id-case-convention'),

--- a/packages/ruleset/src/rules/merge-patch-optional-properties.js
+++ b/packages/ruleset/src/rules/merge-patch-optional-properties.js
@@ -1,0 +1,18 @@
+const { oas3 } = require('@stoplight/spectral-formats');
+const { mergePatchOptionalProperties } = require('../functions');
+
+module.exports = {
+  description:
+    'A JSON merge-patch requestBody should have no required properties',
+  message: '{{description}}',
+  given: [
+    // This expression should visit the request body schema for each "merge-patch" type operation.
+    '$.paths[*][patch].requestBody.content[?(@property.match(/^application\\/merge-patch\\+json(;.*)*/))].schema'
+  ],
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  then: {
+    function: mergePatchOptionalProperties
+  }
+};

--- a/packages/ruleset/test/merge-patch-optional-properties.test.js
+++ b/packages/ruleset/test/merge-patch-optional-properties.test.js
@@ -1,0 +1,205 @@
+const { mergePatchOptionalProperties } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = mergePatchOptionalProperties;
+const ruleId = 'merge-patch-optional-properties';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg =
+  'A JSON merge-patch requestBody should have no required properties';
+
+describe('Spectral rule: merge-patch-optional-properties', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('Patch requestBody not merge-patch', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.requestBodies.UpdateCarRequest.content = {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Car'
+          },
+          examples: {
+            RequestExample: {
+              $ref: '#/components/examples/CarExample'
+            }
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Patch requestBody schema defines required properties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.requestBodies.UpdateCarRequest.content = {
+        'application/merge-patch+json; charset=utf-8': {
+          schema: {
+            $ref: '#/components/schemas/Car'
+          },
+          examples: {
+            RequestExample: {
+              $ref: '#/components/examples/CarExample'
+            }
+          }
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema'
+      );
+    });
+
+    it('Patch requestBody schema defines minProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.CarPatch.minProperties = 1;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema'
+      );
+    });
+
+    it('Patch requestBody defines required properties in allOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['CarPatchProperties'] =
+        testDocument.components.schemas['CarPatch'];
+      testDocument.components.schemas['CarPatch'] = {
+        allOf: [
+          {
+            $ref: '#/components/schemas/CarPatchProperties'
+          },
+          {
+            required: ['make', 'model']
+          }
+        ]
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema'
+      );
+    });
+
+    it('Patch requestBody defines minProperties in allOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['CarPatchProperties'] =
+        testDocument.components.schemas['CarPatch'];
+      testDocument.components.schemas['CarPatch'] = {
+        allOf: [
+          {
+            $ref: '#/components/schemas/CarPatchProperties'
+          },
+          {
+            minProperties: 1
+          }
+        ]
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema'
+      );
+    });
+
+    it('Patch requestBody defines required in nested allOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['CarPatchProperties'] =
+        testDocument.components.schemas['CarPatch'];
+      testDocument.components.schemas['CarPatch'] = {
+        allOf: [
+          {
+            $ref: '#/components/schemas/CarPatchProperties'
+          },
+          {
+            allOf: [
+              {
+                allOf: [
+                  {
+                    required: ['make', 'model']
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema'
+      );
+    });
+
+    it('Patch requestBody defines minProperties in nested allOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas['CarPatchProperties'] =
+        testDocument.components.schemas['CarPatch'];
+      testDocument.components.schemas['CarPatch'] = {
+        allOf: [
+          {
+            $ref: '#/components/schemas/CarPatchProperties'
+          },
+          {
+            allOf: [
+              {
+                allOf: [
+                  {
+                    minProperties: 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/optional-request-body.test.js
+++ b/packages/ruleset/test/optional-request-body.test.js
@@ -36,6 +36,7 @@ describe('Spectral rule: optional-request-body', () => {
       testDocument.components.requestBodies[
         'UpdateCarRequest'
       ].required = false;
+      testDocument.components.schemas['CarPatch'].required = ['make', 'model'];
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);

--- a/packages/ruleset/test/property-attributes.test.js
+++ b/packages/ruleset/test/property-attributes.test.js
@@ -145,12 +145,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minimum',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.minimum',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minimum'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -171,12 +170,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minimum',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.minimum',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minimum'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -197,12 +195,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.maximum',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.maximum',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.maximum',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.maximum',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maximum'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -231,12 +228,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minItems',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minItems',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minItems',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.minItems',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minItems'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -257,12 +253,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minItems',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minItems',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minItems',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.minItems',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minItems'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -283,12 +278,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.maxItems',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.maxItems',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.maxItems',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.maxItems',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maxItems'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -313,12 +307,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minProperties',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.minProperties',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minProperties'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -339,12 +332,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minProperties',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.minProperties',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minProperties'
         ];
         for (let i = 0; i < results.length; i++) {
@@ -366,12 +358,11 @@ describe('Spectral rule: property-attributes', () => {
         };
 
         const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(5);
+        expect(results).toHaveLength(4);
         const expectedPaths = [
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.maxProperties',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.maxProperties',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.maxProperties',
-          'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.wheel_count.maxProperties',
           'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maxProperties'
         ];
         for (let i = 0; i < results.length; i++) {

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -861,6 +861,29 @@ module.exports = {
           }
         }
       },
+      CarPatch: {
+        description: 'Information about a car.',
+        type: 'object',
+        properties: {
+          id: {
+            description: 'The car id.',
+            type: 'string',
+            minLength: 1,
+            maxLength: 64,
+            pattern: '[0-9]+'
+          },
+          make: {
+            description: 'The car make.',
+            type: 'string',
+            minLength: 1,
+            maxLength: 32,
+            pattern: '.*'
+          },
+          model: {
+            $ref: '#/components/schemas/CarModelType'
+          }
+        }
+      },
       CarModelType: {
         description: 'The car model.',
         type: 'string',
@@ -1179,7 +1202,7 @@ module.exports = {
         content: {
           'application/merge-patch+json; charset=utf-8': {
             schema: {
-              $ref: '#/components/schemas/Car'
+              $ref: '#/components/schemas/CarPatch'
             },
             examples: {
               RequestExample: {


### PR DESCRIPTION
## PR summary
This commit introduces the new spectral-style
'merge-patch-optional-properties' rule which will verify that
the requestBody schemas for "merge-patch" type operations do not
contain any required properties and do not specify a non-zero
value for the "minProperties" field.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

