### PR TITLE
feat(collection-array-property): add new spectral-style rule

### DIFF
--- a/packages/ruleset/src/functions/collection-array-property.js
+++ b/packages/ruleset/src/functions/collection-array-property.js
@@ -1,0 +1,100 @@
+const {
+  checkCompositeSchemaForConstraint,
+  isArraySchema,
+  isObject
+} = require('../utils');
+
+module.exports = function(schema, _opts, context) {
+  return collectionArrayProperty(
+    schema,
+    context.path,
+    context.document.parserResult.data
+  );
+};
+
+/**
+ * This function checks to make sure that for a collection "list" type operation,
+ * the collection's array property name matches the final path segment of the operation's path.
+ * For example, suppose that 'GET /v1/things' (presumably the "list_things" operation) returns an instance
+ * of the ThingCollection schema.  We'll check to make sure that the schema contains an array
+ * property named "things" since that is the final path segment.
+ * @param {*} schema a "success" response schema for a GET operation
+ * @param {*} path the array of path segments indicating the "location" of "schema" within the API definition
+ * @param {*} apidef the resolved API definition
+ * @returns an array containing the violations found or [] if no violations
+ */
+function collectionArrayProperty(schema, path, apidef) {
+  // console.log(`Invoked for path: ${path.join('.')}`);
+
+  // Grab the GET operation that defines "schema" as the success response schema.
+  const pathString = path[1];
+  const operation = apidef.paths[pathString].get;
+
+  // If this is a collection "list"-type operation, then check to make sure
+  // that "schema" defines an array property named after the last path segment.
+  if (isListOperation(operation, pathString, apidef)) {
+    const pathSegments = pathString.split('/');
+    const propertyName = pathSegments[pathSegments.length - 1];
+    if (!checkCompositeSchemaForArrayProperty(schema, propertyName)) {
+      return [
+        {
+          message: `Collection list operation response schema should define array property with name "${propertyName}"`,
+          path
+        }
+      ];
+    }
+  }
+  return [];
+}
+
+/**
+ * Returns true iff "operation" is considered to be a collection "list" operation.
+ * @param {} operation the operation to check
+ * @param {*} path the operation's path string (e.g. '/v1/things')
+ * @param {*} apidef the resolved API spec
+ * @returns boolean
+ */
+function isListOperation(operation, path, apidef) {
+  // Note that we already know this operation is a "get" due to the rule's "given" field.
+
+  // 1. If the operation id starts with "list", we'll assume it's a collection list operation.
+  if (operation.operationId && /^list.*$/.test(operation.operationId)) {
+    return true;
+  }
+
+  // 2. Next, check to see if the final path segment is a path parameter reference.
+  // If so, this is not a list operation.
+  const pathSegments = path.split('/');
+  const lastSegment = pathSegments[pathSegments.length - 1];
+  // To cast a wider net, we'll just look to see if '{' or '}' are in
+  // the path segment.  If so, we'll consider that a path param reference and bail out.
+  if (lastSegment.indexOf('{') >= 0 || lastSegment.indexOf('}') >= 0) {
+    return false;
+  }
+
+  // 3. Is there a sibling path that ends in a path param reference?
+  const siblingPathRE = new RegExp(`^${path}/{[^{}/]+}$`);
+  const siblingPath = Object.keys(apidef.paths).find(p =>
+    siblingPathRE.test(p)
+  );
+
+  return !!siblingPath;
+}
+
+/**
+ * Returns true iff "schema" defines an array property named "name".
+ * The property could be defined directly in "schema" or as part of
+ * a composed schema (e.g. allOf)
+ * @param {*} schema the schema to check
+ * @param {*} name the name of the array property to look for
+ * @returns boolean true if the array property was found, false otherwise
+ */
+function checkCompositeSchemaForArrayProperty(schema, name) {
+  return checkCompositeSchemaForConstraint(
+    schema,
+    s =>
+      'properties' in s &&
+      isObject(s.properties[name]) &&
+      isArraySchema(s.properties[name])
+  );
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -6,6 +6,7 @@ module.exports = {
   binarySchemas: require('./binary-schemas'),
   checkMajorVersion: require('./check-major-version'),
   circularRefs: require('./circular-refs'),
+  collectionArrayProperty: require('./collection-array-property'),
   consecutivePathParamSegments: require('./consecutive-path-param-segments'),
   deleteBody: require('./delete-body'),
   descriptionMentionsJSON: require('./description-mentions-json'),

--- a/packages/ruleset/src/functions/pagination-style.js
+++ b/packages/ruleset/src/functions/pagination-style.js
@@ -294,17 +294,20 @@ function paginationStyle(pathItem, path) {
     }
   }
 
-  // Check #7: The response body must contain an array property whose name matches the final path segment.
-  // Reference: https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-collections-overview#response-format
-  const pathSeg = pathStr.split('/').pop();
-  const resourcesProp = responseSchema.properties[pathSeg];
-  if (!resourcesProp || resourcesProp.type !== 'array') {
-    results.push({
-      message:
-        'A paginated list operation must include an array property whose name matches the final segment of the path',
-      path: responseSchemaPath
-    });
-  }
+  //
+  // This check has been removed from this rule and replaced by the new 'collection-array-property' rule.
+  //
+  // // Check #7: The response body must contain an array property whose name matches the final path segment.
+  // // Reference: https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-collections-overview#response-format
+  // const pathSeg = pathStr.split('/').pop();
+  // const resourcesProp = responseSchema.properties[pathSeg];
+  // if (!resourcesProp || resourcesProp.type !== 'array') {
+  //   results.push({
+  //     message:
+  //       'A paginated list operation must include an array property whose name matches the final segment of the path',
+  //     path: responseSchemaPath
+  //   });
+  // }
 
   // Check #8: If the response body contains a "total_count" property, it must be type integer and required.
   // References:

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -98,6 +98,7 @@ module.exports = {
     'authorization-parameter': ibmRules.authorizationParameter,
     'binary-schemas': ibmRules.binarySchemas,
     'circular-refs': ibmRules.circularRefs,
+    'collection-array-property': ibmRules.collectionArrayProperty,
     'consecutive-path-param-segments': ibmRules.consecutivePathParamSegments,
     'content-entry-contains-schema': ibmRules.contentEntryContainsSchema,
     'content-entry-provided': ibmRules.contentEntryProvided,

--- a/packages/ruleset/src/rules/collection-array-property.js
+++ b/packages/ruleset/src/rules/collection-array-property.js
@@ -1,0 +1,16 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { collectionArrayProperty } = require('../functions');
+
+module.exports = {
+  description:
+    'Collection list operation response schema should define array property whose name matches the final path segment of the operation path',
+  message: '{{error}}',
+  given:
+    '$.paths[*].get.responses[?(@property.match(/2\\d\\d/))].content[*].schema',
+  severity: 'warn',
+  formats: [oas2, oas3],
+  resolved: true,
+  then: {
+    function: collectionArrayProperty
+  }
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -7,6 +7,7 @@ module.exports = {
   authorizationParameter: require('./authorization-parameter'),
   binarySchemas: require('./binary-schemas'),
   circularRefs: require('./circular-refs'),
+  collectionArrayProperty: require('./collection-array-property'),
   consecutivePathParamSegments: require('./consecutive-path-param-segments'),
   contentEntryContainsSchema: require('./content-entry-contains-schema'),
   contentEntryProvided: require('./content-entry-provided'),

--- a/packages/ruleset/test/collection-array-property.test.js
+++ b/packages/ruleset/test/collection-array-property.test.js
@@ -1,0 +1,61 @@
+const { collectionArrayProperty } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = collectionArrayProperty;
+const ruleId = 'collection-array-property';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg =
+  'Collection list operation response schema should define array property with name "movies"';
+
+describe('Spectral rule: collection-array-property', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+  describe('Should yield errors', () => {
+    it('array property with incorrect name', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Effectively rename the "movies" property to be "at_the_movies".
+      const arrayProp =
+        testDocument.components.schemas['MovieCollection'].allOf[1].properties
+          .movies;
+      testDocument.components.schemas['MovieCollection'].allOf[1].properties[
+        'at_the_movies'
+      ] = arrayProp;
+      delete testDocument.components.schemas['MovieCollection'].allOf[1]
+        .properties.movies;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/movies.get.responses.200.content.application/json.schema'
+      );
+    });
+    it('correctly named property not an array', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas[
+        'MovieCollection'
+      ].allOf[1].properties.movies = {
+        type: 'string'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/movies.get.responses.200.content.application/json.schema'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/pagination-style.test.js
+++ b/packages/ruleset/test/pagination-style.test.js
@@ -477,63 +477,6 @@ describe('Spectral rule: pagination-style', () => {
         );
       });
     });
-    describe('Check #7 - response schema must contain array property w/name matching final path segment', () => {
-      it('array property with incorrect name', async () => {
-        const testDocument = makeCopy(rootDocument);
-
-        // Effectively rename the "movies" property to be "misnamed_movies".
-        const arrayProp =
-          testDocument.components.schemas['MovieCollection'].allOf[1].properties
-            .movies;
-        testDocument.components.schemas[
-          'MovieCollection'
-        ].allOf[1].properties.misnamed_prop = arrayProp;
-        testDocument.components.schemas['MovieCollection'].allOf[1].required = [
-          'misnamed_prop'
-        ];
-        delete testDocument.components.schemas['MovieCollection'].allOf[1]
-          .properties.movies;
-
-        const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(1);
-        const r = results[0];
-        expect(r.code).toBe(ruleId);
-        expect(r.message).toBe(expectedMsgArrayProp);
-        expect(r.severity).toBe(expectedSeverity);
-        expect(r.path.join('.')).toBe(
-          'paths./v1/movies.get.responses.200.content.application/json.schema'
-        );
-      });
-      it('correctly named property not an array', async () => {
-        const testDocument = makeCopy(rootDocument);
-
-        // Effectively rename the "movies" property to be "misnamed_movies",
-        // then create a new "movies" property that is not an array.
-        // Note: we need to have an array property in the response schema so that the
-        // operation will not be ignored by the pagination rule.
-        const arrayProp =
-          testDocument.components.schemas['MovieCollection'].allOf[1].properties
-            .movies;
-        testDocument.components.schemas[
-          'MovieCollection'
-        ].allOf[1].properties.array_prop = arrayProp;
-        testDocument.components.schemas[
-          'MovieCollection'
-        ].allOf[1].properties.movies = {
-          type: 'string'
-        };
-
-        const results = await testRule(ruleId, rule, testDocument);
-        expect(results).toHaveLength(1);
-        const r = results[0];
-        expect(r.code).toBe(ruleId);
-        expect(r.message).toBe(expectedMsgArrayProp);
-        expect(r.severity).toBe(expectedSeverity);
-        expect(r.path.join('.')).toBe(
-          'paths./v1/movies.get.responses.200.content.application/json.schema'
-        );
-      });
-    });
     describe('Check #8 - total_count response property should be integer and required', () => {
       it('"total_count" response property not an integer', async () => {
         const testDocument = makeCopy(rootDocument);
@@ -767,8 +710,6 @@ const expectedMsgStartParam =
   'The "start" parameter must be of type string and optional';
 const expectedMsgStartParamName =
   'The "page_token" parameter should be named "start"';
-const expectedMsgArrayProp =
-  'A paginated list operation must include an array property whose name matches the final segment of the path';
 const expectedMsgTotalCountProp =
   'The "total_count" property in the response body of a paginated list operation must be of type integer and required';
 const expectedMsgPagelinkRE = /A paginated list operation should include a ".*" property in the response body schema/;

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -411,7 +411,7 @@ describe('test expected output - OpenAPI 3', function() {
     const jsonOutput = JSON.parse(capturedText);
     const warningToCheck = jsonOutput.warnings[0];
 
-    expect(warningToCheck.rule).toEqual('pagination-style');
+    expect(warningToCheck.rule).toEqual('collection-array-property');
     expect(warningToCheck.path.join('.')).toBe(
       'components.schemas.ListOfCharacters'
     );


### PR DESCRIPTION
## PR summary
This commit introduces the new spectral-style
'collection-array-property' rule, which will
verify that each "list" type operation has a response
schema that defines an array property named after the
plural form of the resource type.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

