### PR TITLE
feat(path-param-not-crn): add new spectral-style rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -68,6 +68,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [Rule: parameter-order](#rule-parameter-order)
   * [Rule: parameter-schema-or-content](#rule-parameter-schema-or-content)
   * [Rule: patch-request-content-type](#rule-patch-request-content-type)
+  * [Rule: path-param-not-crn](#rule-path-param-not-crn)
   * [Rule: path-segment-case-convention](#rule-path-segment-case-convention)
   * [Rule: precondition-header](#rule-precondition-header)
   * [Rule: prohibit-summary-sentence-style](#rule-prohibit-summary-sentence-style)
@@ -364,6 +365,12 @@ for any resources (paths) that support the <code>If-Match</code> and/or <code>If
 <td>Verifies that PATCH operations support only requestBody content types <code>application/json-patch+json</code>
 or <code>application/merge-patch+json</code>.</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#rule-path-param-not-crn">path-param-not-crn</a></td>
+<td>warn</td>
+<td>Verifies that path parameters are not defined as CRN (Cloud Resource Name) values</td>
+<td>oas2, oas3</td>
 </tr>
 <tr>
 <td><a href="#rule-path-segment-case-convention">path-segment-case-convention</a></td>
@@ -3343,6 +3350,96 @@ paths:
       responses:
         '200':
           description: 'Thing updated successfully!'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### Rule: path-param-not-crn
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>path-param-not-crn</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule checks to make sure that there are no path parameters that are defined as a CRN (Cloud Resource Name) value.
+<p>In order to determine whether or not a path parameter is considered to be defined as a CRN value, this validation rule
+will perform the following checks:
+<ul>
+<li>The parameter's <code>name</code> field contains "crn" (e.g. "resource_crn")</li>
+<li>The parameter's schema is defined with type=string, format=crn</li>
+<li>The parameter's schema is defined with a pattern field that starts with either "crn" or "^crn" (e.g. 'crn:[-0-9A-Fa-f]+')</li>
+<li>The parameter's <code>example</code> field contains a CRN-like value (e.g. "crn:0afd-0138-2636")</li>
+<li>The parameter's <code>examples</code> field contains an entry containing a CRN-like value, as in this example:
+<pre>
+</pre>
+components:
+  parameters:
+    ThingIdParam:
+      name: thing_id
+      description: The id of the Thing instance
+      in: path
+      required: true
+      schema:
+        type: string
+      examples:
+        crn_example:
+          value: 'crn:0afd-0138-2636'
+</li>
+<li>The parameter schema's <code>example</code> field contains a CRN-like value (e.g. "crn:0afd-0138-2636")</li>
+<li>The parameter's <code>description</code> field contains either "CRN" or "Cloud Resource Name"</li>
+<li>The parameter schema's <code>description</code> field contains either "CRN" or "Cloud Resource Name"</li>
+</ul>
+These checks are logically OR'd together, so that if any one or more of these checks
+are true for a particular parameter, then a warning is raised for that parameter. 
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas2, oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  parameters:
+    ThingCrnParam:
+      name: thing_crn
+      description: The CRN associated with the Thing instance
+      in: path
+      required: true
+      schema:
+        type: string
+        format: crn
+        pattern: '^crn:[-0-9A-Fa-f]+$'
+        minLength: 5
+        maxLength: 32
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  parameters:
+    ThingIdParam:
+      name: thing_id
+      description: The id associated with the Thing instance
+      in: path
+      required: true
+      schema:
+        type: string
+        format: identifier
+        pattern: '^id:[-0-9A-Fa-f]+$'
+        minLength: 5
+        maxLength: 32
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -28,6 +28,7 @@ module.exports = {
   parameterDescription: require('./parameter-description'),
   parameterOrder: require('./parameter-order'),
   patchRequestContentType: require('./patch-request-content-type'),
+  pathParamNotCRN: require('./path-param-not-crn'),
   pathSegmentCaseConvention: require('./path-segment-case-convention'),
   preconditionHeader: require('./precondition-header'),
   propertyAttributes: require('./property-attributes'),

--- a/packages/ruleset/src/functions/path-param-not-crn.js
+++ b/packages/ruleset/src/functions/path-param-not-crn.js
@@ -1,0 +1,140 @@
+const {
+  isStringSchema,
+  checkCompositeSchemaForConstraint
+} = require('../utils');
+
+module.exports = function(pathParam, _opts, { path }) {
+  return pathParamNotCRN(pathParam, path);
+};
+
+/**
+ * This function will check "pathParam" (assumed to be a path parameter object)
+ * to make sure that it is not defined as a "CRN" (Cloud Resource Name) value.
+ * @param {*} pathParam the path parameter object to check
+ * @param {*} path the jsonpath location of "pathParam" within the API definition
+ * @returns an array containing the violations found or [] if no violations
+ */
+function pathParamNotCRN(pathParam, path) {
+  const subPath = isCRNParameter(pathParam);
+  if (subPath && subPath.length > 0) {
+    return [
+      {
+        message: 'Path parameter should not be defined as a CRN value',
+        path: [...path, ...subPath]
+      }
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * This function checks to see if the specified parameter object "p" is defined as a CRN-like value.
+ * If "p" does not appear to be defined as a CRN-like value, then [] is returned.
+ * If "p" does appear to be defined as a CRN-like value, then the return value will be a
+ * list of one or more jsonpath segments that represent the relative location of the violation
+ * (relative to "p"'s location within the API definition)
+ * @param {} p the parameter object to check
+ * @returns a list of zero or more jsonpath segments to indicate that a violation
+ * was found at that relative location
+ */
+function isCRNParameter(p) {
+  // Check if the parameter name contains "crn".
+  if (
+    p.name &&
+    typeof p.name === 'string' &&
+    /crn/.test(p.name.toLowerCase())
+  ) {
+    return ['name'];
+  }
+
+  // Grab the parameter's schema object.
+  let schema = p.schema;
+  if (!schema) {
+    // If not set directly on the parameter, grab the first schema within the content map instead.
+    if (p.content && typeof p.content === 'object' && p.content.size > 0) {
+      schema = p.content.values()[0];
+    }
+  }
+
+  // Check if the schema is defined as type=string/format=crn.
+  if (
+    schema &&
+    isStringSchema(schema) &&
+    checkCompositeSchemaForConstraint(schema, s => s.format === 'crn')
+  ) {
+    return ['schema', 'format'];
+  }
+
+  // Check if the schema defines a pattern field that starts with "crn" or "^crn".
+  if (
+    schema &&
+    checkCompositeSchemaForConstraint(
+      schema,
+      s =>
+        s.pattern &&
+        typeof s.pattern === 'string' &&
+        /^\^?crn.*/.test(s.pattern.trim().toLowerCase())
+    )
+  ) {
+    return ['schema', 'pattern'];
+  }
+
+  // Check if the parameter's "example" field is a CRN-like value.
+  if (p.example && isCRNValue(p.example)) {
+    return ['example'];
+  }
+
+  // Check if the parameter's "examples" field contains an entry with a CRN-like value.
+  if (p.examples && typeof p.examples === 'object') {
+    for (const [name, obj] of Object.entries(p.examples)) {
+      if (obj && obj.value && isCRNValue(obj.value)) {
+        return ['examples', name, 'value'];
+      }
+    }
+  }
+
+  // Check if the parameter schema's "example" field is a CRN-like value.
+  if (schema && schema.example && isCRNValue(schema.example)) {
+    return ['schema', 'example'];
+  }
+
+  // Check if the parameter's description contains "CRN" or "Cloud Resource Name".
+  if (isCRNInDescription(p)) {
+    return ['description'];
+  }
+
+  // Check if the parameter schema's description contains "CRN" or "Cloud Resource Name".
+  if (isCRNInDescription(schema)) {
+    return ['schema', 'description'];
+  }
+
+  // If we made it through the gauntlet unscathed, then return an empty list to
+  // indicate no violations.
+  return [];
+}
+
+/**
+ * Returns true iff the specified example value appears to be an example of
+ * a CRN value.
+ * @param {} value the value to check
+ * @return boolean
+ */
+function isCRNValue(value) {
+  return value && typeof value === 'string' && /^crn:.*/.test(value.trim());
+}
+
+/**
+ * Returns true iff "obj" is an object with a "description" field that contains
+ * "CRN" or "Cloud Resource Name".
+ * @param {*} obj the objet whose "description" field should be checked
+ * @return boolean
+ */
+function isCRNInDescription(obj) {
+  return (
+    obj &&
+    obj.description &&
+    typeof obj.description === 'string' &&
+    /^.*((CRN)|(Cloud\s*Resource\s*Name)).*$/.test(obj.description)
+  );
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -130,6 +130,7 @@ module.exports = {
     'parameter-order': ibmRules.parameterOrder,
     'parameter-schema-or-content': ibmRules.parameterSchemaOrContent,
     'patch-request-content-type': ibmRules.patchRequestContentType,
+    'path-param-not-crn': ibmRules.pathParamNotCRN,
     'path-segment-case-convention': ibmRules.pathSegmentCaseConvention,
     'precondition-header': ibmRules.preconditionHeader,
     'prohibit-summary-sentence-style': ibmRules.prohibitSummarySentenceStyle,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -39,6 +39,7 @@ module.exports = {
   parameterOrder: require('./parameter-order'),
   parameterSchemaOrContent: require('./parameter-schema-or-content'),
   patchRequestContentType: require('./patch-request-content-type'),
+  pathParamNotCRN: require('./path-param-not-crn'),
   pathSegmentCaseConvention: require('./path-segment-case-convention'),
   preconditionHeader: require('./precondition-header'),
   prohibitSummarySentenceStyle: require('./prohibit-summary-sentence-style'),

--- a/packages/ruleset/src/rules/path-param-not-crn.js
+++ b/packages/ruleset/src/rules/path-param-not-crn.js
@@ -1,0 +1,18 @@
+const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { pathParamNotCRN } = require('../functions');
+
+module.exports = {
+  description:
+    'Path parameter should not be defined as a CRN (Cloud Resource Name) value',
+  message: '{{error}}',
+  formats: [oas2, oas3],
+  given: [
+    '$.paths[*].parameters[?(@.in === "path")]',
+    '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[?(@.in === "path")]'
+  ],
+  severity: 'warn',
+  resolved: true,
+  then: {
+    function: pathParamNotCRN
+  }
+};

--- a/packages/ruleset/test/path-param-not-crn.test.js
+++ b/packages/ruleset/test/path-param-not-crn.test.js
@@ -1,0 +1,146 @@
+const { pathParamNotCRN } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = pathParamNotCRN;
+const ruleId = 'path-param-not-crn';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg = 'Path parameter should not be defined as a CRN value';
+
+describe('Spectral rule: path-param-not-crn', () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Query param w/ CRN in description', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.VerboseParam.description =
+        'this is a CRN value';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Path param w/ crn in name', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.DrinkIdParam.name = 'drink_crn';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.parameters.0.name'
+      );
+    });
+
+    it('Path param w/ format=crn', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.MovieIdParam.schema.format = 'crn';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.parameters.0.schema.format'
+      );
+    });
+
+    it('Path param w/ pattern="crn..."', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.MovieIdParam.schema.pattern =
+        'crn:[0-9A-F]+';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.parameters.0.schema.pattern'
+      );
+    });
+
+    it('Path param w/ pattern="^crn..."', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.MovieIdParam.schema.pattern =
+        '^crn:[0-9A-F]+$';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.parameters.0.schema.pattern'
+      );
+    });
+
+    it('Path param w/ crn-like example value', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.MovieIdParam.example =
+        'crn:88adez-01abdfe';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.parameters.0.example'
+      );
+    });
+
+    it('Path param w/ crn-like value in "examples" field', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.MovieIdParam.examples = {
+        good: {
+          description: 'A good example',
+          value: '88adez-01abdfe'
+        },
+        bad: {
+          description: 'A bad example',
+          value: 'crn:88adez-01abdfe'
+        }
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.parameters.0.examples.bad.value'
+      );
+    });
+
+    it('Path param w/ crn-like example value in schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.MovieIdParam.schema.example =
+        'crn:88adez-01abdfe';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.parameters.0.schema.example'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
This commit introduces the new spectral-style
'path-param-not-crn' validation rule which will verify that there are no path parameters that are defined as a CRN (Cloud Resource Name) value.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)

#### Checklist for removing an old validation rule:
- [ ] Removed old rule implementation (packages/validator/src/plugins/validation/*.js)
- [ ] Removed or adjusted testcases (packages/validator/test)
- [ ] Updated default configuration to deprecate old rule (packages/validator/src/.defaultsForValidator.js)
- [ ] Removed docs of old rule (docs/ibm-legacy-rules.md)

