### PR TITLE
fix: fix broken pkg script and publish binaries to github

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,13 @@
 {
   "branches": "main",
-  "verifyConditions": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
-  "prepare": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
-  "publish": ["@semantic-release/npm", { "path": "@semantic-release/github" }]
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/git",
+    ["@semantic-release/github", {
+      "assets": ["bin/*"]
+    }]
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 script:
 - npm run test-travis
 - npm run lint
+- npm run pkg
 deploy:
 - provider: script
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test-travis": "npm run test-travis --workspaces",
     "lint": "npm run lint --workspaces",
     "fix": "npm run fix --workspaces",
-    "pkg": "npm run pkg --workspace packages/validator",
+    "pkg": "./scripts/create-binaries.sh",
     "link": "npm run link --workspace packages/validator",
     "unlink": "npm run unlink --workspace packages/validator",
     "all": "npm run test && npm run lint"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -16,8 +16,7 @@
     "test-cli-tool": "jest test/cli-validator/tests",
     "test-travis": "jest --silent --runInBand --no-colors --testNamePattern='^((?!@skip-ci).)*$' test/",
     "lint": "eslint --cache --quiet --ext '.js' src test",
-    "fix": "eslint --fix --ext '.js' src test",
-    "pkg": "./node_modules/.bin/pkg --out-path=./bin ./package.json; cd bin; rename -f 's/ibm-openapi-validator-(linux|macos|win)/lint-openapi-$1/g' ./ibm-openapi-*"
+    "fix": "eslint --fix --ext '.js' src test"
   },
   "dependencies": {
     "@ibm-cloud/openapi-ruleset": "0.44.0",

--- a/scripts/create-binaries.sh
+++ b/scripts/create-binaries.sh
@@ -1,0 +1,6 @@
+./node_modules/.bin/pkg --out-path=./bin ./packages/validator/package.json
+
+cd ./bin
+mv ibm-openapi-validator-macos lint-openapi-macos
+mv ibm-openapi-validator-linux lint-openapi-linux
+mv ibm-openapi-validator-win.exe lint-openapi-win.exe


### PR DESCRIPTION
The pkg script was broken because of some clever usage of "rename" that wasn't compatible with all devices. This commit removes the need for it by moving the logic into a separate bash script with way more clarity.

This also updates semantic release to include the built platform binaries in the "assets" section of the release on GitHub.

Signed-off-by: Dustin Popp <dpopp07@gmail.com>