### PR TITLE
feat: add ruleset version string to `--version` output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 script:
 - npm run test-travis
 - npm run lint
-- npm run pkg
+- npm run pkg && mv bin packages/validator
 deploy:
 - provider: script
   skip_cleanup: true

--- a/packages/validator/src/cli-validator/index.js
+++ b/packages/validator/src/cli-validator/index.js
@@ -6,8 +6,8 @@
 require('./utils/check-version')('10.0.0');
 
 const program = require('./utils/modified-commander');
+const getVersionString = require('./utils/get-version-string');
 const cliValidator = require('./run-validator');
-const version = require('../../package.json').version;
 
 // set up the command line options
 /* prettier-ignore */
@@ -56,7 +56,7 @@ program
     '--debug',
     'enable debugging output'
   )
-  .version(version, '--version');
+  .version(getVersionString(), '--version');
 
 function increaseVerbosity(dummyValue, previous) {
   return previous + 1;

--- a/packages/validator/src/cli-validator/utils/get-version-string.js
+++ b/packages/validator/src/cli-validator/utils/get-version-string.js
@@ -1,0 +1,8 @@
+const packageConfig = require('../../../package.json');
+
+module.exports = function() {
+  const validator = packageConfig.version;
+  const ruleset = packageConfig.dependencies['@ibm-cloud/openapi-ruleset'];
+
+  return `validator: ${validator}; ruleset: ${ruleset}`;
+};


### PR DESCRIPTION
This commit adds the ruleset verion number to the `--version` output so it is easier for the user to link their current version to the updates in the changelog, etc.

This also makes a modification to allow for publishing of binaries to the GitHub release.

Example output:
```
$ node packages/validator/src/cli-validator/index.js --version
validator: 0.95.1; ruleset: 0.44.0
```

Resolves #498

Signed-off-by: Dustin Popp <dpopp07@gmail.com>