### PR TITLE
test: Spectal assumption for resolved reference equivalence

### DIFF
--- a/packages/ruleset/test/meta/spectral-depedencies.test.js
+++ b/packages/ruleset/test/meta/spectral-depedencies.test.js
@@ -1,0 +1,49 @@
+const { testRule } = require('../utils');
+
+// Test cases for dependencies on subtle and possibly fragile Spectral behavior
+describe('Spectral behavior dependencies', () => {
+  it('Multiple instances of the same `$ref` in a resolved schema point to the same object', async () => {
+    const twoRefsDocument = {
+      components: {
+        schemas: {
+          Parent: {
+            properties: {
+              one: {
+                $ref: '#/components/schemas/Same'
+              },
+              two: {
+                $ref: '#/components/schemas/Same'
+              }
+            }
+          },
+          Same: {}
+        }
+      }
+    };
+
+    let ruleWasExecuted = false;
+    let resolvedReferencesAreEqual = false;
+    const checkReferencesFunction = schema => {
+      ruleWasExecuted = true;
+      resolvedReferencesAreEqual =
+        schema.properties.one === schema.properties.two;
+    };
+
+    const resolvedRefsRule = {
+      description:
+        'Multiple references to the same schema result in the same object',
+      message: '{{error}}',
+      severity: 'error',
+      resolved: true,
+      given: '$.components.schemas.Parent',
+      then: {
+        function: checkReferencesFunction
+      }
+    };
+
+    await testRule('resolved-references', resolvedRefsRule, twoRefsDocument);
+
+    expect(ruleWasExecuted).toBe(true);
+    expect(resolvedReferencesAreEqual).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR summary

Add a test for the assumption that when Spectral resolves a schema, two identical `$ref` references will result in the same (`===` equivalent) in-memory object.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)