### PR TITLE
There's no [command] option in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Once pulled, the container can be run directly, but mount a volume containing th
 
 ## Usage
 ### Command line
-`lint-openapi [options] [command] [<files>]`
+`lint-openapi [options] [<files>]`
 
 ##### [options]
 -  -d (--default_mode) : This option turns off [configuration](#configuration) and runs the validator in [default mode](#default-mode).


### PR DESCRIPTION
```
$ npx lint-openapi
Usage: lint-openapi [options] [<file>]

Run the validator on a specified file

Options:
  -c, --config <file>            path to config file, used instead of .validaterc if provided
  -d, --default_mode             ignore config file and run in default mode
  -e, --errors_only              only print the errors, ignore the warnings
  -j, --json                     output as json
  -n, --no_colors                turn off output coloring
  -p, --print_validator_modules  print the validators that catch each error/warning (helpful for development)
  -r, --ruleset <file>           path to Spectral ruleset file, used instead of .spectral.yaml if provided
  -s, --report_statistics        report the frequency of each occurring error/warning
  -v, --verbose                  increase the verbosity of reported results
  --debug                        enable debugging output
  --version                      output the version number
  -h, --help                     output usage information

```

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
