### PR TITLE
perf: remove accidental recursion in given statements

### DIFF
--- a/packages/ruleset/src/rules/content-entry-contains-schema.js
+++ b/packages/ruleset/src/rules/content-entry-contains-schema.js
@@ -5,8 +5,8 @@ module.exports = {
   description: 'Content entries must specify a schema',
   formats: [oas3],
   given: [
-    '$.paths[*].[post,put,patch].requestBody.content[*]',
-    '$.paths[*].[get,post,put,patch,delete].[parameters,responses][*].content[*]'
+    '$.paths[*][post,put,patch].requestBody.content[*]',
+    '$.paths[*][get,post,put,patch,delete][parameters,responses][*].content[*]'
   ],
   severity: 'warn',
   resolved: true,

--- a/packages/ruleset/src/rules/optional-request-body.js
+++ b/packages/ruleset/src/rules/optional-request-body.js
@@ -6,7 +6,7 @@ module.exports = {
     'An optional requestBody with required properties should probably be required',
   message: '{{description}}',
   given:
-    "$.paths[*].[*].[?(@property === 'requestBody' && @.required !== true)].content.[*].schema",
+    "$.paths[*][*][?(@property === 'requestBody' && @.required !== true)].content[*].schema",
   severity: 'info',
   formats: [oas3],
   resolved: true,

--- a/packages/ruleset/src/rules/request-body-object.js
+++ b/packages/ruleset/src/rules/request-body-object.js
@@ -3,7 +3,7 @@ const { enumeration } = require('@stoplight/spectral-functions');
 module.exports = {
   description: 'All request bodies MUST be structured as an object',
   given:
-    '$.paths[*][*].requestBody.content.[?(@property ~= "^application\\\\/json(;.*)*$")].schema',
+    '$.paths[*][*].requestBody.content[?(@property ~= "^application\\\\/json(;.*)*$")].schema',
   severity: 'error',
   then: {
     field: 'type',

--- a/packages/ruleset/test/meta/rule-style.test.js
+++ b/packages/ruleset/test/meta/rule-style.test.js
@@ -1,0 +1,19 @@
+const rules = require('../../src/rules');
+
+// Test cases to enforce rule style
+describe.each(Object.entries(rules))(
+  'Rules conform to required style',
+  (name, rule) => {
+    it(`${name} rule does not contain implicit .[] recursion`, async () => {
+      const implicitRecursionRegex = /\.(?=\[)/;
+
+      if (Array.isArray(rule.given)) {
+        // `given` array
+        rule.given.map(g => expect(g).not.toMatch(implicitRecursionRegex));
+      } else {
+        // `given` string
+        expect(rule.given).not.toMatch(implicitRecursionRegex);
+      }
+    });
+  }
+);


### PR DESCRIPTION
## PR summary

I'm wary of proclaiming that this definitely fixes our recent performance issues since @dpopp07 saw some really unpredictable behavior that seemed unrelated to this specific rule. But, I did profile the validator with `node --prof` and, in the resulting log, a fragment of this JSON path expression was being executed hundreds of times for an extremely simple API definition and millions of times for a complex definition.

It bothers me that I can't figure out exactly what a `.[*]` construct is **supposed** to do in JSON path, but in practice, it seems to result in some sort of recursion (maybe it's a synonym for `..`?). I'm guessing that the three instances meant it was `O(n^3)` or something.

In any case, the update didn't cause any test failures and did seem to resolve the performance problems I was able to replicate. Hoping it works for others as well.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).