### PR TITLE
fix(collection-array-property): avoid bug that crashes nimma

### DIFF
--- a/packages/ruleset/src/functions/collection-array-property.js
+++ b/packages/ruleset/src/functions/collection-array-property.js
@@ -55,7 +55,11 @@ function collectionArrayProperty(schema, path, apidef) {
  * @returns boolean
  */
 function isListOperation(operation, path, apidef) {
-  // Note that we already know this operation is a "get" due to the rule's "given" field.
+  // Note that, if the operation is defined, we already know it is a "get" due
+  // to the rule's "given" field.
+  if (!operation) {
+    return false;
+  }
 
   // 1. If the operation id starts with "list", we'll assume it's a collection list operation.
   if (operation.operationId && /^list.*$/.test(operation.operationId)) {


### PR DESCRIPTION
If a path object does not have a "get" operation, the code would previously pass `undefined` to a function that tried to access properties of the given operation object. This would result in an exception that would crash the underlying nimma parser.

This commit simply adds a check for truthyness before continuing with the function.

Signed-off-by: Dustin Popp <dpopp07@gmail.com>