### PR TITLE
fix: remove buggy support for tolerating trailing commas

### DIFF
--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -168,16 +168,6 @@ const processInput = async function(program) {
 
       const fileExtension = ext.getFileExtension(validFile);
       if (fileExtension === 'json') {
-        // find and fix trailing commas
-        const match = originalFile.match(/,\s*[}\]]/m);
-        if (match) {
-          const chars = originalFile.substring(0, match.index);
-          const lineNum = (chars.match(/\n/g) || []).length + 1;
-          const msg = `Trailing comma on line ${lineNum} of file ${validFile}.`;
-          printError(chalk, chalk.red(msg));
-          exitCode = 1;
-          originalFile = originalFile.replace(/,(\s*[}\]])/gm, '$1');
-        }
         input = JSON.parse(originalFile);
       } else if (fileExtension === 'yaml' || fileExtension === 'yml') {
         input = readYaml.safeLoad(originalFile);

--- a/packages/validator/test/cli-validator/tests/error-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/error-handling.test.js
@@ -185,7 +185,7 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when the swagger contains a trailing comma', async function() {
+  it('should return an error when a JSON document contains a trailing comma', async function() {
     const program = {};
     program.args = ['./test/cli-validator/mock-files/trailing-comma.json'];
     program.default_mode = true;
@@ -200,14 +200,10 @@ describe('cli tool - test error handling', function() {
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
     expect(exitCode).toEqual(1);
-    expect(capturedText.length).toEqual(28);
 
-    expect(capturedText[0].trim()).toEqual(
-      '[Error] Trailing comma on line 36 of file ./test/cli-validator/mock-files/trailing-comma.json.'
+    expect(capturedText[0].trim()).toContain('[Error] Invalid input file');
+    expect(capturedText[1].trim()).toEqual(
+      'SyntaxError: Unexpected token ] in JSON at position 815'
     );
-    expect(capturedText[12]).toContain(
-      'Operation "description" must be present and non-empty string.'
-    );
-    expect(capturedText[13]).toContain('paths./v1/thing.post');
   });
 });


### PR DESCRIPTION
Signed-off-by: Dan Hudlow <dhudlow@us.ibm.com>
## PR summary
The feature to remove trailing commas (which are _not valid_ in JSON) mangled properties containing regular expressions such as `"pattern": "^[-0-9a-zA-Z_,]+$"` within an OpenAPI definition.

IMO, we should simply require valid JSON documents.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?