### PR TITLE
fix: create executables in correct package

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -10,7 +10,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "npm run pkg && mv bin packages/validator"
+        "prepareCmd": "npm run pkg"
       }
     ],
     [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test-travis": "npm run test-travis --workspaces",
     "lint": "npm run lint --workspaces",
     "fix": "npm run fix --workspaces",
-    "pkg": "./scripts/create-binaries.sh",
+    "pkg": "npm run pkg --workspace packages/validator",
     "link": "npm run link --workspace packages/validator",
     "unlink": "npm run unlink --workspace packages/validator",
     "all": "npm run test && npm run lint"

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -11,7 +11,8 @@
     "test": "jest test",
     "test-travis": "jest --silent --runInBand --no-colors --testNamePattern='^((?!@skip-ci).)*$' test",
     "lint": "eslint --cache --quiet --ext '.js' src test",
-    "fix": "eslint --fix --ext '.js' src test"
+    "fix": "eslint --fix --ext '.js' src test",
+    "pkg": "echo no executables to build in this package"
   },
   "dependencies": {
     "@stoplight/spectral-formats": "^1.1.0",

--- a/packages/validator/CHANGELOG.md
+++ b/packages/validator/CHANGELOG.md
@@ -1,10 +1,3 @@
-## ibm-openapi-validator [0.96.5](https://github.com/IBM/openapi-validator/compare/ibm-openapi-validator@0.96.4...ibm-openapi-validator@0.96.5) (2022-12-07)
-
-
-### Bug Fixes
-
-* force new release of the project ([1208d82](https://github.com/IBM/openapi-validator/commit/1208d8276e43c4a12d979a51ac4a0f071cde14de))
-
 ## ibm-openapi-validator [0.96.4](https://github.com/IBM/openapi-validator/compare/ibm-openapi-validator@0.96.3...ibm-openapi-validator@0.96.4) (2022-11-22)
 
 

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ibm-openapi-validator",
   "description": "Configurable and extensible validator/linter for OpenAPI documents",
-  "version": "0.96.5",
+  "version": "0.96.4",
   "main": "src/lib/index.js",
   "private": false,
   "repository": "https://github.com/IBM/openapi-validator",
@@ -16,7 +16,8 @@
     "test-cli-tool": "jest test/cli-validator/tests",
     "test-travis": "jest --silent --runInBand --no-colors --testNamePattern='^((?!@skip-ci).)*$' test/",
     "lint": "eslint --cache --quiet --ext '.js' src test",
-    "fix": "eslint --fix --ext '.js' src test"
+    "fix": "eslint --fix --ext '.js' src test",
+    "pkg": "../../scripts/create-binaries.sh"
   },
   "dependencies": {
     "@ibm-cloud/openapi-ruleset": "0.44.3",

--- a/scripts/create-binaries.sh
+++ b/scripts/create-binaries.sh
@@ -1,6 +1,12 @@
-./node_modules/.bin/pkg --out-path=./bin ./packages/validator/package.json
+#!/bin/bash
 
+# This script will be run when "npm run pkg" is executed from within
+# the "packages/validator" directory.
+# The commands below assume that the current directory is packages/validator.
+../../node_modules/.bin/pkg --out-path=./bin ./package.json
+ 
 cd ./bin
 mv ibm-openapi-validator-macos lint-openapi-macos
 mv ibm-openapi-validator-linux lint-openapi-linux
 mv ibm-openapi-validator-win.exe lint-openapi-win.exe
+chmod +x lint-openapi-win.exe


### PR DESCRIPTION
## PR summary
This PR adjusts the "pkg" command so that it is ultimately run only in
the validator package.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
