### PR TITLE
fix(property-case-convention): report correct path in errors

### DIFF
--- a/packages/ruleset/src/functions/property-case-convention.js
+++ b/packages/ruleset/src/functions/property-case-convention.js
@@ -25,8 +25,9 @@ function checkPropertyCaseConvention(schema, path) {
       if (result) {
         // 'casing' only reports the message - add the path to it
         // the message itself isn't great either - add some detail to it
-        result[0].message = 'Property names ' + result[0].message;
-        result[0].path = [...path, 'properties', propName];
+        result[0].message =
+          'Property names ' + result[0].message + ': ' + propName;
+        result[0].path = [...path, 'properties'];
         errors.push(result[0]);
       }
     }

--- a/packages/ruleset/test/property-case-convention.test.js
+++ b/packages/ruleset/test/property-case-convention.test.js
@@ -53,7 +53,9 @@ describe('Spectral rule: property-case-convention', () => {
 
     const validation = results[0];
     expect(validation.code).toBe(name);
-    expect(validation.message).toBe('Property names must be snake case');
+    expect(validation.message).toBe(
+      'Property names must be snake case: plotSummary'
+    );
     expect(validation.path).toStrictEqual([
       'paths',
       '/v1/movies',
@@ -62,8 +64,7 @@ describe('Spectral rule: property-case-convention', () => {
       'content',
       'application/json',
       'schema',
-      'properties',
-      'plotSummary'
+      'properties'
     ]);
     expect(validation.severity).toBe(expectedSeverity);
   });

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -180,7 +180,7 @@ describe('cli tool - test expected output - Swagger 2', function() {
 
     // errors
     expect(capturedText[4].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[8].match(/\S+/g)[2]).toEqual('172');
+    expect(capturedText[8].match(/\S+/g)[2]).toEqual('161');
     // warnings
     expect(capturedText[13].match(/\S+/g)[2]).toEqual('59');
     expect(capturedText[17].match(/\S+/g)[2]).toEqual('131');


### PR DESCRIPTION
## PR summary
This commit modifies the "property-case-convention" rule slightly so that when it reports a problem with the case for a specific property, the offending property name will be included in the error message, and the path associated with the error will reflect the schema's "properties" field in which the offending property is defined.
This subtle change will ensure that the spectral "unresolver" will not be overzealous when "unresolving" the path.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

Background info on this PR can be found in the [issue](https://github.ibm.com/arf/planning-sdk-squad/issues/3485)

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
