### PR TITLE
fix: update lint config to make property quoting consistent

### DIFF
--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -35,5 +35,16 @@
       "nimma/legacy": "<rootDir>/../../node_modules/nimma/dist/legacy/cjs",
       "nimma/fallbacks": "<rootDir>/../../node_modules/nimma/dist/cjs/fallbacks/"
     }
+  },
+  "prettier": {
+    "quoteProps": "consistent",
+    "overrides": [
+      {
+        "files": "**/*-document.js",
+        "options": {
+          "quoteProps": "as-needed"
+        }
+      }
+    ]
   }
 }

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -105,7 +105,7 @@ module.exports = {
     'content-type-parameter': ibmRules.contentTypeParameter,
     'delete-body': ibmRules.deleteBody,
     'description-mentions-json': ibmRules.descriptionMentionsJSON,
-    discriminator: ibmRules.discriminator,
+    'discriminator': ibmRules.discriminator,
     'duplicate-path-parameter': ibmRules.duplicatePathParameter,
     'enum-case-convention': ibmRules.enumCaseConvention,
     'examples-name-contains-space': ibmRules.examplesNameContainsSpace,


### PR DESCRIPTION
Signed-off-by: Dan Hudlow <dhudlow@us.ibm.com>

## PR summary
Adjusts `prettier` config to favor consistent property quoting.