### PR TITLE
fix: move `validator` dependency to correct package within monorepo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12924,28 +12924,29 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "0.43.0",
+      "version": "0.45.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/spectral-formats": "^1.1.0",
         "@stoplight/spectral-functions": "^1.6.1",
         "@stoplight/spectral-rulesets": "^1.6.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "validator": "^13.7.0"
       },
       "devDependencies": {
         "@stoplight/spectral-core": "^1.12.4",
         "jest": "^27.4.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "0.94.0",
+      "version": "0.97.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "0.43.0",
+        "@ibm-cloud/openapi-ruleset": "0.45.0",
         "@stoplight/spectral-cli": "^6.4.2",
         "@stoplight/spectral-core": "^1.12.4",
         "@stoplight/spectral-parsers": "^1.0.1",
@@ -12963,7 +12964,6 @@
         "pad": "^2.3.0",
         "require-all": "^3.0.0",
         "semver": "^5.7.1",
-        "validator": "^13.7.0",
         "yaml-js": "^0.2.3"
       },
       "bin": {
@@ -12975,7 +12975,7 @@
         "strip-ansi": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "packages/validator/node_modules/semver": {
@@ -13442,7 +13442,8 @@
         "@stoplight/spectral-functions": "^1.6.1",
         "@stoplight/spectral-rulesets": "^1.6.0",
         "jest": "^27.4.5",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "validator": "^13.7.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -16932,7 +16933,7 @@
     "ibm-openapi-validator": {
       "version": "file:packages/validator",
       "requires": {
-        "@ibm-cloud/openapi-ruleset": "0.43.0",
+        "@ibm-cloud/openapi-ruleset": "0.45.0",
         "@stoplight/spectral-cli": "^6.4.2",
         "@stoplight/spectral-core": "^1.12.4",
         "@stoplight/spectral-parsers": "^1.0.1",
@@ -16953,7 +16954,6 @@
         "require-all": "^3.0.0",
         "semver": "^5.7.1",
         "strip-ansi": "^4.0.0",
-        "validator": "^13.7.0",
         "yaml-js": "^0.2.3"
       },
       "dependencies": {

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -18,7 +18,8 @@
     "@stoplight/spectral-formats": "^1.1.0",
     "@stoplight/spectral-functions": "^1.6.1",
     "@stoplight/spectral-rulesets": "^1.6.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "validator": "^13.7.0"
   },
   "devDependencies": {
     "@stoplight/spectral-core": "^1.12.4",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -38,7 +38,6 @@
     "pad": "^2.3.0",
     "require-all": "^3.0.0",
     "semver": "^5.7.1",
-    "validator": "^13.7.0",
     "yaml-js": "^0.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The `validator` dependency is only used in the ruleset package but was still living in the `package.json` for the validator package. This was likely an oversight during the re-architecture into a monorepo. This resolves the issue by moving the dependency to the correct `package.json`.

Resolves #528 