### PR TITLE
fix(ref-pattern): better regex matching if path contains OpenAPI field name

### DIFF
--- a/packages/ruleset/src/functions/ref-pattern.js
+++ b/packages/ruleset/src/functions/ref-pattern.js
@@ -10,7 +10,7 @@ module.exports = function($ref, _opts, { path }) {
 // The entries of this object are ordered in descending order of presumed prevalence.
 const validRefPrefixes = {
   schemas: {
-    refPathRegex: /,(schema)|(properties,[^,]+)|(items)|(additionalProperties)|((allOf|anyOf|oneOf),\d+)$/,
+    refPathRegex: /,((schema)|(properties,[^,]+)|(items)|(additionalProperties)|((allOf|anyOf|oneOf),\d+))$/,
     prefix: '#/components/schemas/'
   },
   parameters: {


### PR DESCRIPTION
## PR summary
This commit fixes a regex pattern in the `ref-pattern` rule.
When an operation path contained a specific OpenAPI field name
(e.g. `properties`) the old regex pattern could match and it resulted
in a false positive warning.
The cause of the issue was missing parentheses around the "main"
pattern which made the first comma "optional" due to the OR operators.
(Actually it was only required for the `schema`.)

```yaml
/tekton_pipelines/{pipeline_id}/properties:
  parameters:
    - $ref: '#/components/parameters/pipelineId'
```

Before:
![image](https://user-images.githubusercontent.com/15990318/211387390-35c6527b-27d1-4f44-b3dd-1616a0088d67.png)

After:
![image](https://user-images.githubusercontent.com/15990318/211387417-78a3cc8e-4e74-4b41-8658-2d684dd0a769.png)

Closes: #489 

Signed-off-by: Norbert Biczo <pyrooka@users.noreply.github.com>

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
