### PR TITLE
feat(logger): add logger facility to validator core

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-09-14T18:32:30Z",
+  "generated_at": "2023-01-27T15:53:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -86,7 +86,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.51.dss",
+  "version": "0.13.1+ibm.56.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ as well as IBM-defined best practices.
   * [Customization](#customization)
 - [Installation](#installation)
   * [Install with NPM (recommended)](#install-with-npm-recommended)
+  * [Download an executable binary](#download-an-executable-binary)
   * [Build from source](#build-from-source)
-  * [Platform specific binaries](#platform-specific-binaries)
+    + [Build platform-specific binaries](#build-platform-specific-binaries)
   * [Docker container](#docker-container)
 - [Usage](#usage)
   * [Command line](#command-line)
@@ -98,10 +99,11 @@ Once pulled, the container can be run directly, but mount a volume containing th
 -  -d (--default_mode) : This option turns off [configuration](#configuration) and runs the validator in [default mode](#default-mode).
 -  -e (--errors_only) : Only print the errors, ignore the warnings.
 -  -j (--json) : Output results as a JSON object
+-  -l (--loglevel) `<loggername>=<loglevel> ...` : Set loglevel of logger named `<loggername>` to `<loglevel>` (e.g. `-l root=info -l ibm-schema-description=debug`)
 -  -n (--no_colors) : The output is colored by default. If this bothers you, this flag will turn off the coloring.
 -  -p (--print_validator_modules) : Print the name of the validator source file the error/warning was caught it. This can be helpful for developing validations.
 -  -v (--verbose) : Increase verbosity of reported results.  Use this option to display the rule for each reported result.
--  -r (--ruleset) <path/to/your/ruleset> : Path to Spectral ruleset file, used instead of .spectral.yaml if provided.
+-  -r (--ruleset) `<path/to/your/ruleset>` : Path to Spectral ruleset file, used instead of .spectral.yaml if provided.
 -  -s (--report_statistics) : Print a simple report at the end of the output showing the frequency, in percentage, of each error/warning.
 -  --debug : Enable debugging output.
 -  --version : Print the current semantic version of the validator

--- a/package-lock.json
+++ b/package-lock.json
@@ -3002,9 +3002,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -6722,6 +6725,18 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
+    },
+    "node_modules/loglevel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/longest": {
       "version": "1.0.1",
@@ -12906,7 +12921,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "0.45.2",
+      "version": "0.45.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "0.0.1",
@@ -12914,6 +12929,8 @@
         "@stoplight/spectral-functions": "^1.6.1",
         "@stoplight/spectral-rulesets": "^1.6.0",
         "lodash": "^4.17.21",
+        "loglevel": "^1.8.1",
+        "minimatch": "^6.1.6",
         "validator": "^13.7.0"
       },
       "devDependencies": {
@@ -12922,6 +12939,28 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "packages/ruleset/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/ruleset/node_modules/minimatch": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.1.6.tgz",
+      "integrity": "sha512-6bR3UIeh/DF8+p6A9Spyuy67ShOq42rOkHWi7eUe3Ua99Zo5lZfGC6lJJWkeoK4k9jQFT3Pl7czhTXimG2XheA==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/utilities": {
@@ -12938,15 +12977,15 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "0.97.2",
+      "version": "0.97.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "0.45.2",
+        "@ibm-cloud/openapi-ruleset": "0.45.3",
         "@stoplight/spectral-cli": "^6.4.2",
         "@stoplight/spectral-core": "^1.12.4",
         "@stoplight/spectral-parsers": "^1.0.1",
         "chalk": "^4.1.1",
-        "commander": "^2.20.3",
+        "commander": "^10.0.0",
         "deepmerge": "^2.2.1",
         "find-up": "^3.0.0",
         "globby": "^11.0.4",
@@ -13439,7 +13478,27 @@
         "@stoplight/spectral-rulesets": "^1.6.0",
         "jest": "^27.4.5",
         "lodash": "^4.17.21",
+        "loglevel": "^1.8.1",
+        "minimatch": "^6.1.6",
         "validator": "^13.7.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.1.6.tgz",
+          "integrity": "sha512-6bR3UIeh/DF8+p6A9Spyuy67ShOq42rOkHWi7eUe3Ua99Zo5lZfGC6lJJWkeoK4k9jQFT3Pl7czhTXimG2XheA==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@ibm-cloud/openapi-ruleset-utilities": {
@@ -15325,9 +15384,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -16921,12 +16980,12 @@
     "ibm-openapi-validator": {
       "version": "file:packages/validator",
       "requires": {
-        "@ibm-cloud/openapi-ruleset": "0.45.2",
+        "@ibm-cloud/openapi-ruleset": "0.45.3",
         "@stoplight/spectral-cli": "^6.4.2",
         "@stoplight/spectral-core": "^1.12.4",
         "@stoplight/spectral-parsers": "^1.0.1",
         "chalk": "^4.1.1",
-        "commander": "^2.20.3",
+        "commander": "^10.0.0",
         "deepmerge": "^2.2.1",
         "find-up": "^3.0.0",
         "globby": "^11.0.4",
@@ -18197,6 +18256,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
+    },
+    "loglevel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg=="
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ibm-openapi-validator",
   "workspaces": [
-    "packages/validator",
+    "packages/utilities",
     "packages/ruleset",
-    "packages/utilities"
+    "packages/validator"
   ],
   "version": "0.0.0",
   "private": true,

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/IBM/openapi-validator",
   "scripts": {
     "clean": "rm -rf node_modules",
+    "jest": "jest",
     "test": "jest test",
     "test-travis": "jest --silent --runInBand --no-colors --testNamePattern='^((?!@skip-ci).)*$' test",
     "lint": "eslint --cache --quiet --ext '.js' src test",
@@ -20,7 +21,9 @@
     "@stoplight/spectral-functions": "^1.6.1",
     "@stoplight/spectral-rulesets": "^1.6.0",
     "lodash": "^4.17.21",
-    "validator": "^13.7.0"
+    "validator": "^13.7.0",
+    "loglevel": "^1.8.1",
+    "minimatch": "^6.1.6"
   },
   "devDependencies": {
     "@stoplight/spectral-core": "^1.12.4",

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -3,6 +3,7 @@ module.exports = {
   isDeprecated: require('./is-deprecated'),
   isEmptyObjectSchema: require('./is-empty-object-schema'),
   isRefSiblingSchema: require('./is-ref-sibling-schema'),
+  LoggerFactory: require('./logger-factory'),
   mergeAllOfSchemaProperties: require('./merge-allof-schema-properties'),
   ...require('./mimetype-utils'),
   operationMethods: require('./constants'),

--- a/packages/ruleset/src/utils/logger-factory.js
+++ b/packages/ruleset/src/utils/logger-factory.js
@@ -1,0 +1,91 @@
+const log = require('loglevel');
+const minimatch = require('minimatch');
+
+/**
+ * This class serves as a factory for creating loggers implemented by the 'loglevel' package.
+ * The primary benefit provided by this factory class is the ability to honor logging-level-related
+ * command-line options for loggers that haven't yet been created.
+ */
+module.exports = class LoggerFactory {
+  static _factory = null;
+
+  constructor() {
+    this.rootLogger = log;
+    this.loggerSettings = [];
+  }
+
+  /**
+   * @returns a single instance of our factory.
+   */
+  static newInstance() {
+    if (!this._factory) {
+      this._factory = new LoggerFactory();
+    }
+    return this._factory;
+  }
+
+  /**
+   * A logger setting consists of a logger name (a glob-like string,
+   * e.g. 'my-*-logger' or 'my-first-logger') and a log level
+   * (e.g. 'error', 'warn', 'info', 'debug', or 'trace').
+   * This function adds the logger setting specified by "name" and
+   * "logLevel" to the current array of logger settings.
+   * @param {*} name the name of the logger (glob-like string)
+   * @param {*} logLevel the log level to set on the logger
+   */
+  addLoggerSetting(name, logLevel) {
+    this.loggerSettings.push({
+      loggerName: name,
+      logLevel
+    });
+  }
+
+  /**
+   * Returns the logger with name "<name>".
+   * If "name" is falsy or the string "root", then the root logger is returned.
+   * The resulting logger will have the current logger settings applied to it, which
+   * might affect the logging level.
+   * @param {*} name the name of the logger to be retrieved
+   * @returns the logger with the specified name
+   */
+  getLogger(name) {
+    const logger =
+      name && name !== 'root'
+        ? this.rootLogger.getLogger(name)
+        : this.rootLogger;
+    this.applyLoggerSettings(name, logger);
+    return logger;
+  }
+
+  /**
+   * Applies the currently-defined logger settings to the specified logger with name "<name>".
+   * @param {*} name the name of the logger
+   * @param {*} logger the logger to apply logger settings to
+   */
+  applyLoggerSettings(name, logger) {
+    if (!name) {
+      name = 'root';
+    }
+
+    for (const setting of this.loggerSettings) {
+      // If the name of the logger matches the (potential) glob-pattern
+      // previously-specified via the command-line, then apply the
+      // specified log level to that logger.
+      if (minimatch(name, setting.loggerName)) {
+        logger.setLevel(setting.logLevel);
+      }
+    }
+  }
+
+  /**
+   * Visits all existing loggers and applies the currently-defined logger settings
+   * to each one.  This is useful in situations where some loggers might already exist
+   * prior to the command-line arguments being processed.
+   */
+  applySettingsToAllLoggers() {
+    this.applyLoggerSettings('root', this.rootLogger);
+    for (const key in this.rootLogger.getLoggers()) {
+      this.applyLoggerSettings(key, this.rootLogger.getLogger(key));
+    }
+  }
+};

--- a/packages/ruleset/src/utils/logger-factory.js
+++ b/packages/ruleset/src/utils/logger-factory.js
@@ -34,6 +34,7 @@ module.exports = class LoggerFactory {
    * @param {*} logLevel the log level to set on the logger
    */
   addLoggerSetting(name, logLevel) {
+    checkLevel(logLevel);
     this.loggerSettings.push({
       loggerName: name,
       logLevel
@@ -89,3 +90,10 @@ module.exports = class LoggerFactory {
     }
   }
 };
+
+const validLevels = ['error', 'warn', 'info', 'debug', 'trace'];
+function checkLevel(logLevel) {
+  if (!validLevels.includes(logLevel.toLowerCase())) {
+    throw `Invalid log level '${logLevel}'. Valid log levels: ${validLevels}`;
+  }
+}

--- a/packages/ruleset/test/logger-factory.test.js
+++ b/packages/ruleset/test/logger-factory.test.js
@@ -1,0 +1,150 @@
+const { LoggerFactory } = require('../src/utils');
+
+describe('LoggerFactory tests', () => {
+  let consoleSpy;
+  let loggerFactory;
+  const originalDebug = console.debug;
+  const originalInfo = console.info;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    console.debug = console.log;
+    console.info = console.log;
+    console.warn = console.log;
+    console.error = console.log;
+    loggerFactory = new LoggerFactory();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    console.debug = originalDebug;
+    console.info = originalInfo;
+    console.warn = originalWarn;
+    console.error = originalError;
+    loggerFactory = null;
+  });
+
+  it('Root logger has default loglevel WARN', async () => {
+    const logger = loggerFactory.getLogger(null);
+    expect(logger.getLevel()).toBe(logger.levels.WARN);
+  });
+
+  it('addLoggerSetting() before root logger is created', async () => {
+    loggerFactory.addLoggerSetting('root', 'info');
+    const logger = loggerFactory.getLogger(null);
+    expect(logger.getLevel()).toBe(logger.levels.INFO);
+  });
+
+  it('addLoggerSetting() after root logger is created', async () => {
+    const logger = loggerFactory.getLogger(null);
+    loggerFactory.addLoggerSetting('root', 'info');
+    loggerFactory.applySettingsToAllLoggers();
+    expect(logger.getLevel()).toBe(logger.levels.INFO);
+  });
+
+  it('addLoggerSetting() before non-root logger is created', async () => {
+    loggerFactory.addLoggerSetting('ibm-*', 'debug');
+    const logger = loggerFactory.getLogger('ibm-rule1');
+    expect(logger.getLevel()).toBe(logger.levels.DEBUG);
+  });
+
+  it('addLoggerSetting() after non-root logger is created', async () => {
+    const logger = loggerFactory.getLogger('ibm-rule2');
+    loggerFactory.addLoggerSetting('ibm-*', 'error');
+    loggerFactory.applySettingsToAllLoggers();
+    expect(logger.getLevel()).toBe(logger.levels.ERROR);
+  });
+
+  it('Ensure level=error is honored', async () => {
+    loggerFactory.addLoggerSetting('rule-logger-error', 'error');
+    loggerFactory.applySettingsToAllLoggers();
+    const logger = loggerFactory.getLogger('rule-logger-error');
+    expect(logger.getLevel()).toBe(logger.levels.ERROR);
+
+    logger.debug('This debug message should not be displayed');
+    logger.info('This info message should not be displayed');
+    logger.warn('This warn message should not be displayed');
+    logger.error('This error message should be displayed');
+
+    const messages = captureMessages(consoleSpy.mock.calls);
+    // originalError(`captured messages:\n${messages}`);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('should be');
+  });
+
+  it('Ensure level=warn is honored', async () => {
+    loggerFactory.addLoggerSetting('rule-logger-warn', 'warn');
+    loggerFactory.applySettingsToAllLoggers();
+    const logger = loggerFactory.getLogger('rule-logger-warn');
+    expect(logger.getLevel()).toBe(logger.levels.WARN);
+
+    logger.debug('This debug message should not be displayed');
+    logger.info('This info message should not be displayed');
+    logger.warn('This warn message should be displayed');
+    logger.error('This error message should be displayed');
+
+    const messages = captureMessages(consoleSpy.mock.calls);
+    // originalError(`captured messages:\n${messages}`);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toContain('should be');
+    expect(messages[1]).toContain('should be');
+  });
+
+  it('Ensure level=info is honored', async () => {
+    loggerFactory.addLoggerSetting('rule-logger-info', 'info');
+    loggerFactory.applySettingsToAllLoggers();
+    const logger = loggerFactory.getLogger('rule-logger-info');
+    expect(logger.getLevel()).toBe(logger.levels.INFO);
+
+    logger.debug('This debug message should not be displayed');
+    logger.info('This info message should be displayed');
+    logger.warn('This warn message should be displayed');
+    logger.error('This error message should be displayed');
+
+    const messages = captureMessages(consoleSpy.mock.calls);
+    // originalError(`captured messages:\n${messages}`);
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toContain('should be');
+    expect(messages[1]).toContain('should be');
+    expect(messages[2]).toContain('should be');
+  });
+
+  it('Ensure level=debug is honored', async () => {
+    loggerFactory.addLoggerSetting('rule-logger-debug', 'debug');
+    loggerFactory.applySettingsToAllLoggers();
+    const logger = loggerFactory.getLogger('rule-logger-debug');
+    expect(logger.getLevel()).toBe(logger.levels.DEBUG);
+
+    logger.debug('This debug message should be displayed');
+    logger.info('This info message should be displayed');
+    logger.warn('This warn message should be displayed');
+    logger.error('This error message should be displayed');
+
+    const messages = captureMessages(consoleSpy.mock.calls);
+    // originalError(`captured messages:\n${messages}`);
+
+    expect(messages).toHaveLength(4);
+    expect(messages[0]).toContain('should be');
+    expect(messages[1]).toContain('should be');
+    expect(messages[2]).toContain('should be');
+    expect(messages[3]).toContain('should be');
+  });
+});
+
+/**
+ * Returns a list consisting of the first argument within each "call" entry.
+ * We only use the first argument since we only pass one arg to each of the
+ * logger methods.
+ * @param {*} calls the list of calls made to the mock object
+ * @returns a list of messages logged
+ */
+function captureMessages(calls) {
+  return calls.map(args => {
+    return args[0];
+  });
+}

--- a/packages/ruleset/test/logger-factory.test.js
+++ b/packages/ruleset/test/logger-factory.test.js
@@ -57,6 +57,12 @@ describe('LoggerFactory tests', () => {
     expect(logger.getLevel()).toBe(logger.levels.ERROR);
   });
 
+  it('addLoggerSetting() should throw exception for invalid level', async () => {
+    expect(() => {
+      loggerFactory.addLoggerSetting('ibm-*', 'BADLEVEL');
+    }).toThrow(/Invalid log level 'BADLEVEL'/);
+  });
+
   it('Ensure level=error is honored', async () => {
     loggerFactory.addLoggerSetting('rule-logger-error', 'error');
     loggerFactory.applySettingsToAllLoggers();

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -25,7 +25,7 @@
     "@stoplight/spectral-core": "^1.12.4",
     "@stoplight/spectral-parsers": "^1.0.1",
     "chalk": "^4.1.1",
-    "commander": "^2.20.3",
+    "commander": "^10.0.0",
     "deepmerge": "^2.2.1",
     "find-up": "^3.0.0",
     "globby": "^11.0.4",

--- a/packages/validator/src/cli-validator/index.js
+++ b/packages/validator/src/cli-validator/index.js
@@ -57,7 +57,7 @@ program
     'enable debugging output'
   )
   .option(
-    '-l, --loglevel <loglevel...>',
+    '-l, --log-level <loglevel...>',
     'Set the log level for one or more loggers (e.g. -l root=info -l schema-description=debug ...)'
   )
   .version(getVersionString(), '--version');

--- a/packages/validator/src/cli-validator/index.js
+++ b/packages/validator/src/cli-validator/index.js
@@ -56,7 +56,15 @@ program
     '--debug',
     'enable debugging output'
   )
+  .option(
+    '-l, --loglevel <loglevel...>',
+    'Set the log level for one or more loggers (e.g. -l root=info -l schema-description=debug ...)'
+  )
   .version(getVersionString(), '--version');
+program.addHelpText(
+  'beforeAll',
+  `IBM OpenAPI Validator: ${getVersionString()}\n`
+);
 
 function increaseVerbosity(dummyValue, previous) {
   return previous + 1;

--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -40,13 +40,14 @@ const processInput = async function(program) {
   // The user can change this via the command line.
   const loggerFactory = LoggerFactory.newInstance();
   loggerFactory.addLoggerSetting('root', 'info');
-  logger = loggerFactory.getLogger(null);
+  logger = loggerFactory.getLogger('root');
 
   let opts = program;
   if (typeof program.opts === 'function') {
     opts = program.opts();
   }
 
+  // Leaving this here for debugging.
   // console.log(`Program opts:\n`, opts);
 
   // interpret the options
@@ -71,9 +72,9 @@ const processInput = async function(program) {
   // log level of both existing loggers and loggers created later by individual rules.
   // Examples:
   //   -l info  (equivalent to -l root=info)
-  //   --loglevel schema-*=debug (enable debug for all rules like "schema-*")
+  //   --log-level schema-*=debug (enable debug for all rules like "schema-*")
   //   -l property-description=debug (enable debug for the "property-description" rule)
-  let logLevels = opts.loglevel;
+  let logLevels = opts.logLevel;
   if (!logLevels) {
     logLevels = [];
   }

--- a/packages/validator/src/cli-validator/utils/json-results.js
+++ b/packages/validator/src/cli-validator/utils/json-results.js
@@ -8,6 +8,7 @@ const validatorVersion = require('../../../package.json').version;
 
 // function to print the results as json to the console.
 function printJson(
+  logger,
   results,
   originalFile = null,
   verbose = false,
@@ -15,7 +16,7 @@ function printJson(
 ) {
   // render the results to json in the console with 2 char spacing
   results = formatResultsAsObject(results, originalFile, verbose, errorsOnly);
-  console.log(JSON.stringify(results, null, 2));
+  logger.info(JSON.stringify(results, null, 2));
 }
 
 function formatResultsAsObject(

--- a/packages/validator/src/cli-validator/utils/print-results.js
+++ b/packages/validator/src/cli-validator/utils/print-results.js
@@ -8,6 +8,7 @@ const getLineNumberForPath = require(__dirname + '/../../plugins/ast/ast')
 
 // this function prints all of the output
 module.exports = function print(
+  logger,
   results,
   chalk,
   printValidators,
@@ -42,12 +43,12 @@ module.exports = function print(
     }
   };
 
-  console.log();
+  logger.info('');
 
   types.forEach(type => {
     let color = colors[type];
     if (Object.keys(results[type]).length) {
-      console.log(chalk[color].bold(`${type}\n`));
+      logger.info(chalk[color].bold(`${type}\n`));
     }
 
     // convert 'color' from a background color to foreground color
@@ -55,7 +56,7 @@ module.exports = function print(
 
     each(results[type], (problems, validator) => {
       if (printValidators) {
-        console.log(`Validator: ${validator}`);
+        logger.info(`Validator: ${validator}`);
       }
 
       problems.forEach(problem => {
@@ -88,24 +89,24 @@ module.exports = function print(
 
         // print the path array as a dot-separated string
 
-        console.log(chalk[color](`  Message :   ${problem.message}`));
+        logger.info(chalk[color](`  Message :   ${problem.message}`));
         if (verbose && problem.rule) {
-          console.log(chalk[color](`  Rule    :   ${problem.rule}`));
+          logger.info(chalk[color](`  Rule    :   ${problem.rule}`));
         }
-        console.log(chalk[color](`  Path    :   ${path.join('.')}`));
-        console.log(chalk[color](`  Line    :   ${lineNumber}`));
+        logger.info(chalk[color](`  Path    :   ${path.join('.')}`));
+        logger.info(chalk[color](`  Line    :   ${lineNumber}`));
         if (verbose && problem.componentPath) {
           const componentPath = getPathAsArray(problem.componentPath);
           const componentLine = getLineNumberForPath(
             originalFile,
             componentPath
           );
-          console.log(
+          logger.info(
             chalk[color](`  Component Path    :   ${componentPath.join('.')}`)
           );
-          console.log(chalk[color](`  Component Line    :   ${componentLine}`));
+          logger.info(chalk[color](`  Component Line    :   ${componentLine}`));
         }
-        console.log();
+        logger.info('');
       });
     });
   });
@@ -118,30 +119,30 @@ module.exports = function print(
       stats.infos.total ||
       stats.hints.total)
   ) {
-    console.log(chalk.bgCyan('statistics\n'));
+    logger.info(chalk.bgCyan('statistics\n'));
 
-    console.log(
+    logger.info(
       chalk.cyan(`  Total number of errors   : ${stats.errors.total}`)
     );
-    console.log(
+    logger.info(
       chalk.cyan(`  Total number of warnings : ${stats.warnings.total}`)
     );
     if (stats.infos.total > 0) {
-      console.log(
+      logger.info(
         chalk.cyan(`  Total number of infos    : ${stats.infos.total}`)
       );
     }
     if (stats.hints.total > 0) {
-      console.log(
+      logger.info(
         chalk.cyan(`  Total number of hints    : ${stats.hints.total}`)
       );
     }
-    console.log('');
+    logger.info('');
 
     types.forEach(type => {
       // print the type, either error or warning
       if (stats[type].total) {
-        console.log('  ' + chalk.underline.cyan(type));
+        logger.info('  ' + chalk.underline.cyan(type));
       }
 
       Object.keys(stats[type]).forEach(message => {
@@ -158,13 +159,13 @@ module.exports = function print(
           // use 6 for largest case of '(100%)'
           const frequencyString = pad(6, `(${percentage}%)`);
 
-          console.log(
+          logger.info(
             chalk.cyan(`${numberString} ${frequencyString} : ${message}`)
           );
         }
       });
       if (stats[type].total) {
-        console.log();
+        logger.info('');
       }
     });
   }

--- a/packages/validator/src/cli-validator/utils/validator.js
+++ b/packages/validator/src/cli-validator/utils/validator.js
@@ -30,6 +30,7 @@ const validators = {
 
 // this function runs the validators on the swagger object
 module.exports = function validateSwagger(
+  logger,
   allSpecs,
   config,
   spectralResults,
@@ -56,6 +57,7 @@ module.exports = function validateSwagger(
 
   // merge the spectral results
   const parsedSpectralResults = spectralValidator.parseResults(
+    logger,
     spectralResults,
     debug
   );

--- a/packages/validator/src/lib/index.js
+++ b/packages/validator/src/lib/index.js
@@ -7,6 +7,7 @@ const {
 } = require('../cli-validator/utils/json-results');
 const spectralValidator = require('../spectral/spectral-validator');
 const validator = require('../cli-validator/utils/validator');
+const { LoggerFactory } = require('@ibm-cloud/openapi-ruleset/src/utils');
 
 module.exports = async function(
   input,
@@ -14,6 +15,11 @@ module.exports = async function(
   configFileOverride = null,
   debug = false
 ) {
+  // Use a root logger with loglevel "info".
+  const loggerFactory = LoggerFactory.newInstance();
+  loggerFactory.addLoggerSetting('root', 'info');
+  const logger = loggerFactory.getLogger(null);
+
   // process the config file for the validations &
   // create an instance of spectral & load the spectral ruleset, either a user's
   // or the default ruleset
@@ -29,12 +35,12 @@ module.exports = async function(
   const swagger = await buildSwaggerObject(input);
 
   try {
-    const spectral = await spectralValidator.setup(null, debug, chalk);
+    const spectral = await spectralValidator.setup(logger, null, debug, chalk);
     spectralResults = await spectral.run(input);
   } catch (err) {
     return Promise.reject(err);
   }
-  const results = validator(swagger, configObject, spectralResults);
+  const results = validator(logger, swagger, configObject, spectralResults);
 
   // return a json object containing the errors/warnings
   return formatResultsAsObject(results);

--- a/packages/validator/test/cli-validator/tests/config-file-validator.test.js
+++ b/packages/validator/test/cli-validator/tests/config-file-validator.test.js
@@ -11,13 +11,22 @@ const configFileValidator = require('../../../src/cli-validator/utils/process-co
 
 describe('cli tool - test config file validator', function() {
   let consoleSpy;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const originalInfo = console.info;
 
   beforeEach(() => {
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    console.warn = console.log;
+    console.error = console.log;
+    console.info = console.log;
   });
 
   afterEach(() => {
     consoleSpy.mockRestore();
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.info = originalInfo;
   });
 
   it('should print no errors with a clean config object', function() {

--- a/packages/validator/test/cli-validator/tests/error-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/error-handling.test.js
@@ -6,13 +6,22 @@ const { getCapturedText } = require('../../test-utils');
 
 describe('cli tool - test error handling', function() {
   let consoleSpy;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const originalInfo = console.info;
 
   beforeEach(() => {
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    console.warn = console.log;
+    console.error = console.log;
+    console.info = console.log;
   });
 
   afterEach(() => {
     consoleSpy.mockRestore();
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.info = originalInfo;
   });
 
   const helpMessage = function() {
@@ -70,17 +79,17 @@ describe('cli tool - test error handling', function() {
     }
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
+    // originalError('Captured text:\n', capturedText);
 
     expect(exitCode).toEqual(2);
-    expect(capturedText.length).toEqual(5);
-    expect(capturedText[0].trim()).toEqual('');
-    expect(capturedText[1].trim()).toEqual(
+    expect(capturedText.length).toEqual(3);
+    expect(capturedText[0].trim()).toEqual(
       '[Warning] Skipping file with unsupported file type: json'
     );
-    expect(capturedText[2].trim()).toEqual(
+    expect(capturedText[1].trim()).toEqual(
       'Supported file types are JSON (.json) and YAML (.yml, .yaml)'
     );
-    expect(capturedText[3].trim()).toEqual(
+    expect(capturedText[2].trim()).toEqual(
       '[Error] None of the given arguments are valid files.'
     );
   });
@@ -98,17 +107,17 @@ describe('cli tool - test error handling', function() {
     }
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
+    // originalError('Captured text:\n', capturedText);
 
     expect(exitCode).toEqual(2);
-    expect(capturedText.length).toEqual(5);
-    expect(capturedText[0].trim()).toEqual('');
-    expect(capturedText[1].trim()).toEqual(
+    expect(capturedText.length).toEqual(3);
+    expect(capturedText[0].trim()).toEqual(
       '[Warning] Skipping file with unsupported file type: badExtension.jsob'
     );
-    expect(capturedText[2].trim()).toEqual(
+    expect(capturedText[1].trim()).toEqual(
       'Supported file types are JSON (.json) and YAML (.yml, .yaml)'
     );
-    expect(capturedText[3].trim()).toEqual(
+    expect(capturedText[2].trim()).toEqual(
       '[Error] None of the given arguments are valid files.'
     );
   });
@@ -126,9 +135,10 @@ describe('cli tool - test error handling', function() {
     }
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
+    // originalError('Captured text:\n', capturedText);
 
     expect(exitCode).toEqual(1);
-    expect(capturedText.length).toEqual(3);
+    expect(capturedText.length).toEqual(2);
     expect(capturedText[0].trim()).toEqual(
       '[Error] Invalid input file: ./test/cli-validator/mock-files/bad-json.json. See below for details.'
     );
@@ -150,9 +160,10 @@ describe('cli tool - test error handling', function() {
     }
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
+    // originalError('Captured text:\n', capturedText);
 
     expect(exitCode).toEqual(1);
-    expect(capturedText.length).toEqual(3);
+    expect(capturedText.length).toEqual(2);
     expect(capturedText[0].trim()).toEqual(
       '[Error] Invalid input file: ./test/cli-validator/mock-files/duplicate-keys.json. See below for details.'
     );
@@ -174,11 +185,12 @@ describe('cli tool - test error handling', function() {
     }
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
+    // originalError('Captured text:\n', capturedText);
 
     expect(exitCode).toEqual(1);
-    expect(capturedText.length).toEqual(3);
+    expect(capturedText.length).toEqual(2);
     expect(capturedText[0].trim()).toEqual(
-      '[Error] There is a problem with the Swagger.'
+      '[Error] There is a problem with the API definition.'
     );
     expect(capturedText[1].split('\n')[1].trim()).toEqual(
       'Token "NonExistentObject" does not exist.'

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -9,412 +9,421 @@ const count = (array, regex) => {
   return array.reduce((a, v) => (v.match(regex) ? a + 1 : a), 0);
 };
 
-describe('cli tool - test expected output - Swagger 2', function() {
+describe('Expected output tests', function() {
   let consoleSpy;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const originalInfo = console.info;
 
   beforeEach(() => {
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    console.warn = console.log;
+    console.error = console.log;
+    console.info = console.log;
   });
 
   afterEach(() => {
     consoleSpy.mockRestore();
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.info = originalInfo;
   });
 
-  it('should not produce any errors or warnings from mock-files/clean.yml', async function() {
-    // set up mock user input
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/clean.yml'];
-    program.default_mode = true;
+  describe('Swagger 2', function() {
+    it('should not produce any errors or warnings from mock-files/clean.yml', async function() {
+      // set up mock user input
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/clean.yml'];
+      program.default_mode = true;
 
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      // originalError('Captured text:\n', capturedText);
 
-    expect(exitCode).toEqual(0);
-    expect(capturedText.length).toEqual(2);
-    expect(capturedText[0].trim()).toEqual(
-      './test/cli-validator/mock-files/clean.yml passed the validator'
-    );
-    expect(capturedText[1].trim()).toEqual('');
-  });
-
-  it('should produce errors, then warnings from mock-files/err-and-warn.yaml', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
-    program.default_mode = true;
-
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    const whichProblems = [];
-
-    expect(exitCode).toEqual(1);
-
-    capturedText.forEach(function(line) {
-      if (line.includes('errors')) {
-        whichProblems.push('errors');
-      }
-      if (line.includes('warnings')) {
-        whichProblems.push('warnings');
-      }
+      expect(exitCode).toEqual(0);
+      expect(capturedText.length).toEqual(1);
+      expect(capturedText[0].trim()).toEqual(
+        './test/cli-validator/mock-files/clean.yml passed the validator'
+      );
     });
 
-    expect(whichProblems[0]).toEqual('errors');
-    expect(whichProblems[1]).toEqual('warnings');
+    it('should produce errors, then warnings from mock-files/err-and-warn.yaml', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
+      program.default_mode = true;
+
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      // originalError('Captured text:\n', capturedText);
+
+      const whichProblems = [];
+
+      expect(exitCode).toEqual(1);
+
+      capturedText.forEach(function(line) {
+        if (line.includes('errors')) {
+          whichProblems.push('errors');
+        }
+        if (line.includes('warnings')) {
+          whichProblems.push('warnings');
+        }
+      });
+
+      expect(whichProblems[0]).toEqual('errors');
+      expect(whichProblems[1]).toEqual('warnings');
+    });
+
+    it('should display the associated rule with each error and warning', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
+      program.default_mode = true;
+      program.verbose = 1;
+
+      const exitCode = await commandLineValidator(program);
+      expect(exitCode).toEqual(1);
+
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+      const messageCount = count(capturedText, /^\s*Message\s*:/);
+      const ruleCount = count(capturedText, /^\s*Rule\s*:/);
+      expect(messageCount).toEqual(ruleCount);
+    });
+
+    it('should include the validator version in JSON output', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/clean.yml'];
+      program.default_mode = true;
+      program.json = true;
+
+      const exitcode = await commandLineValidator(program);
+      expect(exitcode).toBe(0);
+
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      const jsonOutput = JSON.parse(capturedText);
+      const expectedValidatorVersion = require('../../../package.json').version;
+      expect(jsonOutput.version).toBeTruthy();
+      expect(jsonOutput.version).toBe(expectedValidatorVersion);
+    });
+
+    it('should include the validator version in JSON output for the inCodeValidator', async function() {
+      const content = fs
+        .readFileSync('./test/cli-validator/mock-files/clean.yml')
+        .toString();
+      const spec = yaml.load(content);
+
+      const defaultMode = true;
+      const validationResults = await inCodeValidator(spec, defaultMode);
+
+      const expectedValidatorVersion = require('../../../package.json').version;
+      expect(validationResults.version).toBeTruthy();
+      expect(validationResults.version).toBe(expectedValidatorVersion);
+    });
+
+    it('should include the associated rule with each error and warning in JSON output', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
+      program.default_mode = true;
+      program.json = true;
+
+      const exitcode = await commandLineValidator(program);
+      expect(exitcode).toBe(1);
+
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      const jsonOutput = JSON.parse(capturedText);
+
+      const msgsByType = Object.assign(
+        {},
+        jsonOutput.errors,
+        jsonOutput.warnings,
+        jsonOutput.infos,
+        jsonOutput.hints
+      );
+      const allMessages = Object.entries(msgsByType).reduce(
+        (newObj, val) => newObj.concat(val[1]),
+        []
+      );
+
+      allMessages.forEach(msg => expect(msg).toHaveProperty('rule'));
+    });
+
+    it('should include the associated rule in return value of in-memory validator', async function() {
+      const content = fs
+        .readFileSync('./test/cli-validator/mock-files/err-and-warn.yaml')
+        .toString();
+      const oas2Object = yaml.load(content);
+
+      const defaultMode = true;
+      const validationResults = await inCodeValidator(oas2Object, defaultMode);
+
+      // console.warn(JSON.stringify(validationResults, null, 2));
+
+      expect(validationResults.errors.length).toBe(3);
+      expect(validationResults.warnings.length).toBe(6);
+      expect(validationResults.infos).not.toBeDefined();
+      expect(validationResults.hints).not.toBeDefined();
+
+      validationResults.errors.forEach(msg =>
+        expect(msg).toHaveProperty('rule')
+      );
+      validationResults.warnings.forEach(msg =>
+        expect(msg).toHaveProperty('rule')
+      );
+    });
+
+    it('should print the correct line numbers for each error/warning', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
+      program.default_mode = true;
+
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+      // This can be uncommented to display the output when adjustments to
+      // the expect statements below are needed.
+      // let textOutput = '';
+      // capturedText.forEach((elem, index) => {
+      //   textOutput += `[${index}]: ${elem}\n`;
+      // });
+      // console.warn(textOutput);
+
+      expect(exitCode).toEqual(1);
+
+      // .match(/\S+/g) returns an array of all non-whitespace strings
+      //   example output would be [ 'Line', ':', '59' ]
+
+      // errors
+      expect(capturedText[4].match(/\S+/g)[2]).toEqual('59');
+      expect(capturedText[8].match(/\S+/g)[2]).toEqual('161');
+      // warnings
+      expect(capturedText[13].match(/\S+/g)[2]).toEqual('59');
+      expect(capturedText[17].match(/\S+/g)[2]).toEqual('131');
+      expect(capturedText[21].match(/\S+/g)[2]).toEqual('134');
+      expect(capturedText[25].match(/\S+/g)[2]).toEqual('197');
+    });
+
+    it('should return exit code of 0 if there are only warnings', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/just-warn.yml'];
+      program.default_mode = true;
+
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+      expect(exitCode).toEqual(0);
+
+      const allOutput = capturedText.join('');
+      expect(allOutput.includes('warnings')).toEqual(true);
+    });
+
+    it('should handle an array of file names', async function() {
+      const program = {};
+      program.args = [
+        './test/cli-validator/mock-files/err-and-warn.yaml',
+        'notAFile.json',
+        './test/cli-validator/mock-files/clean.yml'
+      ];
+      program.default_mode = true;
+
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+      expect(exitCode).toEqual(1);
+
+      const allOutput = capturedText.join('');
+
+      expect(
+        allOutput.includes(
+          '[Warning] Skipping non-existent file: notAFile.json'
+        )
+      ).toEqual(true);
+
+      expect(
+        allOutput.includes(
+          'Validation Results for ./test/cli-validator/mock-files/err-and-warn.yaml:'
+        )
+      ).toEqual(true);
+
+      expect(
+        allOutput.includes(
+          'Validation Results for ./test/cli-validator/mock-files/clean.yml:'
+        )
+      ).toEqual(true);
+    });
+
+    it('should return errors and warnings using the in-memory module', async function() {
+      const defaultMode = true;
+      const validationResults = await inCodeValidator(
+        swaggerInMemory,
+        defaultMode
+      );
+
+      // should produce an object with `errors` and `warnings` keys that should
+      // both be non-empty
+      expect(validationResults.errors.length).toBeGreaterThan(0);
+      expect(validationResults.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('should not produce any errors or warnings from mock-files/clean-with-tabs.yml', async function() {
+      // set up mock user input
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/clean-with-tabs.yml'];
+      program.default_mode = true;
+
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      // originalError('Captured text:\n', capturedText);
+
+      expect(exitCode).toEqual(0);
+      expect(capturedText.length).toEqual(1);
+      expect(capturedText[0].trim()).toEqual(
+        './test/cli-validator/mock-files/clean-with-tabs.yml passed the validator'
+      );
+    });
   });
 
-  it('should display the associated rule with each error and warning', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
-    program.default_mode = true;
-    program.verbose = 1;
-
-    const exitCode = await commandLineValidator(program);
-    expect(exitCode).toEqual(1);
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    const messageCount = count(capturedText, /^\s*Message\s*:/);
-    const ruleCount = count(capturedText, /^\s*Rule\s*:/);
-    expect(messageCount).toEqual(ruleCount);
-  });
-
-  it('should include the validator version in JSON output', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/clean.yml'];
-    program.default_mode = true;
-    program.json = true;
-
-    const exitcode = await commandLineValidator(program);
-    expect(exitcode).toBe(0);
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const jsonOutput = JSON.parse(capturedText);
-    const expectedValidatorVersion = require('../../../package.json').version;
-    expect(jsonOutput.version).toBeTruthy();
-    expect(jsonOutput.version).toBe(expectedValidatorVersion);
-  });
-
-  it('should include the validator version in JSON output for the inCodeValidator', async function() {
-    const content = fs
-      .readFileSync('./test/cli-validator/mock-files/clean.yml')
-      .toString();
-    const spec = yaml.load(content);
-
-    const defaultMode = true;
-    const validationResults = await inCodeValidator(spec, defaultMode);
-
-    const expectedValidatorVersion = require('../../../package.json').version;
-    expect(validationResults.version).toBeTruthy();
-    expect(validationResults.version).toBe(expectedValidatorVersion);
-  });
-
-  it('should include the associated rule with each error and warning in JSON output', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
-    program.default_mode = true;
-    program.json = true;
-
-    const exitcode = await commandLineValidator(program);
-    expect(exitcode).toBe(1);
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const jsonOutput = JSON.parse(capturedText);
-
-    const msgsByType = Object.assign(
-      {},
-      jsonOutput.errors,
-      jsonOutput.warnings,
-      jsonOutput.infos,
-      jsonOutput.hints
-    );
-    const allMessages = Object.entries(msgsByType).reduce(
-      (newObj, val) => newObj.concat(val[1]),
-      []
-    );
-
-    allMessages.forEach(msg => expect(msg).toHaveProperty('rule'));
-  });
-
-  it('should include the associated rule in return value of in-memory validator', async function() {
-    const content = fs
-      .readFileSync('./test/cli-validator/mock-files/err-and-warn.yaml')
-      .toString();
-    const oas2Object = yaml.load(content);
-
-    const defaultMode = true;
-    const validationResults = await inCodeValidator(oas2Object, defaultMode);
-
-    // console.warn(JSON.stringify(validationResults, null, 2));
-
-    expect(validationResults.errors.length).toBe(3);
-    expect(validationResults.warnings.length).toBe(6);
-    expect(validationResults.infos).not.toBeDefined();
-    expect(validationResults.hints).not.toBeDefined();
-
-    validationResults.errors.forEach(msg => expect(msg).toHaveProperty('rule'));
-    validationResults.warnings.forEach(msg =>
-      expect(msg).toHaveProperty('rule')
-    );
-  });
-
-  it('should print the correct line numbers for each error/warning', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
-    program.default_mode = true;
-
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    // This can be uncommented to display the output when adjustments to
-    // the expect statements below are needed.
-    // let textOutput = '';
-    // capturedText.forEach((elem, index) => {
-    //   textOutput += `[${index}]: ${elem}\n`;
-    // });
-    // console.warn(textOutput);
-
-    expect(exitCode).toEqual(1);
-
-    // .match(/\S+/g) returns an array of all non-whitespace strings
-    //   example output would be [ 'Line', ':', '59' ]
-
-    // errors
-    expect(capturedText[4].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[8].match(/\S+/g)[2]).toEqual('161');
-    // warnings
-    expect(capturedText[13].match(/\S+/g)[2]).toEqual('59');
-    expect(capturedText[17].match(/\S+/g)[2]).toEqual('131');
-    expect(capturedText[21].match(/\S+/g)[2]).toEqual('134');
-    expect(capturedText[25].match(/\S+/g)[2]).toEqual('197');
-  });
-
-  it('should return exit code of 0 if there are only warnings', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/just-warn.yml'];
-    program.default_mode = true;
-
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    expect(exitCode).toEqual(0);
-
-    const allOutput = capturedText.join('');
-    expect(allOutput.includes('warnings')).toEqual(true);
-  });
-
-  it('should handle an array of file names', async function() {
-    const program = {};
-    program.args = [
-      './test/cli-validator/mock-files/err-and-warn.yaml',
-      'notAFile.json',
-      './test/cli-validator/mock-files/clean.yml'
-    ];
-    program.default_mode = true;
-
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    expect(exitCode).toEqual(1);
-
-    const allOutput = capturedText.join('');
-
-    expect(
-      allOutput.includes('[Warning] Skipping non-existent file: notAFile.json')
-    ).toEqual(true);
-
-    expect(
-      allOutput.includes(
-        'Validation Results for ./test/cli-validator/mock-files/err-and-warn.yaml:'
-      )
-    ).toEqual(true);
-
-    expect(
-      allOutput.includes(
-        'Validation Results for ./test/cli-validator/mock-files/clean.yml:'
-      )
-    ).toEqual(true);
-  });
-
-  it('should return errors and warnings using the in-memory module', async function() {
-    const defaultMode = true;
-    const validationResults = await inCodeValidator(
-      swaggerInMemory,
-      defaultMode
-    );
-
-    // should produce an object with `errors` and `warnings` keys that should
-    // both be non-empty
-    expect(validationResults.errors.length).toBeGreaterThan(0);
-    expect(validationResults.warnings.length).toBeGreaterThan(0);
-  });
-
-  it('should not produce any errors or warnings from mock-files/clean-with-tabs.yml', async function() {
-    // set up mock user input
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/clean-with-tabs.yml'];
-    program.default_mode = true;
-
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    expect(exitCode).toEqual(0);
-    expect(capturedText.length).toEqual(2);
-    expect(capturedText[0].trim()).toEqual(
-      './test/cli-validator/mock-files/clean-with-tabs.yml passed the validator'
-    );
-    expect(capturedText[1].trim()).toEqual('');
-  });
-});
-
-describe('test expected output - OpenAPI 3', function() {
-  let consoleSpy;
-
-  beforeEach(() => {
-    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    consoleSpy.mockRestore();
-  });
-
-  it('should not produce any errors or warnings from a clean file', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/oas3/clean.yml'];
-    program.default_mode = true;
-
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    const allOutput = capturedText.join('');
-
-    expect(exitCode).toEqual(0);
-    expect(allOutput).toContain(
-      './test/cli-validator/mock-files/oas3/clean.yml passed the validator'
-    );
-  });
-
-  it('should catch problems in a multi-file spec from an outside directory', async function() {
-    const program = {};
-    program.args = [
-      './test/cli-validator/mock-files/multi-file-spec/main.yaml'
-    ];
-    program.default_mode = true;
-
-    const exitCode = await commandLineValidator(program);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    const allOutput = capturedText.join('');
-
-    expect(exitCode).toEqual(1);
-    expect(allOutput).toContain('errors');
-    expect(allOutput).toContain('Object must have required property "info"');
-    expect(allOutput).toContain('warnings');
-    expect(allOutput).toContain('Operation must have "operationId"');
-    expect(allOutput).toContain(
-      'Operation "description" must be present and non-empty string'
-    );
-  });
-
-  it('should display the associated rule with each error and warning', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/oas3/err-and-warn.yaml'];
-    program.default_mode = true;
-    program.verbose = 1;
-
-    const exitCode = await commandLineValidator(program);
-    expect(exitCode).toEqual(1);
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    const messageCount = count(capturedText, /^\s*Message\s*:/);
-    const ruleCount = count(capturedText, /^\s*Rule\s*:/);
-    expect(messageCount).toEqual(ruleCount);
-  });
-
-  it('should include the associated rule with each error and warning in JSON output', async function() {
-    const program = {};
-    program.args = ['./test/cli-validator/mock-files/oas3/err-and-warn.yaml'];
-    program.default_mode = true;
-    program.json = true;
-
-    const exitCode = await commandLineValidator(program);
-    expect(exitCode).toEqual(1);
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const jsonOutput = JSON.parse(capturedText);
-
-    const msgsByType = Object.assign(
-      {},
-      jsonOutput.errors,
-      jsonOutput.warnings,
-      jsonOutput.infos,
-      jsonOutput.hints
-    );
-    const allMessages = Object.entries(msgsByType).reduce(
-      (newObj, val) => newObj.concat(val[1]),
-      []
-    );
-
-    allMessages.forEach(msg => expect(msg).toHaveProperty('rule'));
-  });
-
-  it('should include the associated rule in return value of in-memory validator', async function() {
-    const content = fs
-      .readFileSync('./test/cli-validator/mock-files/oas3/err-and-warn.yaml')
-      .toString();
-    const oas3Object = yaml.load(content);
-
-    const defaultMode = true;
-    const validationResults = await inCodeValidator(oas3Object, defaultMode);
-
-    expect(validationResults.errors.length).toBe(3);
-    expect(validationResults.warnings.length).toBe(47);
-    expect(validationResults.infos).not.toBeDefined();
-    expect(validationResults.hints).not.toBeDefined();
-
-    validationResults.errors.forEach(msg => expect(msg).toHaveProperty('rule'));
-    validationResults.warnings.forEach(msg =>
-      expect(msg).toHaveProperty('rule')
-    );
-  });
-
-  it('should include the path to the component (if it exists) when in verbose mode', async function() {
-    const program = {};
-    program.args = [
-      './test/cli-validator/mock-files/oas3/component-path-example.yaml'
-    ];
-    program.default_mode = true;
-    program.verbose = 1;
-
-    const exitCode = await commandLineValidator(program);
-    expect(exitCode).toEqual(0);
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const allText = capturedText.join();
-    expect(allText).toContain('Path');
-    expect(allText).toContain('Line');
-  });
-
-  it('should include the path to the component (if it exists) when in verbose mode and json mode', async function() {
-    const program = {};
-    program.args = [
-      './test/cli-validator/mock-files/oas3/component-path-example.yaml'
-    ];
-    program.default_mode = true;
-    program.verbose = 1;
-    program.json = true;
-
-    const exitCode = await commandLineValidator(program);
-    expect(exitCode).toEqual(0);
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-    const jsonOutput = JSON.parse(capturedText);
-    const warningToCheck = jsonOutput.warnings[0];
-
-    expect(warningToCheck.rule).toEqual('collection-array-property');
-    expect(warningToCheck.path.join('.')).toBe(
-      'components.schemas.ListOfCharacters'
-    );
-    expect(warningToCheck.line).toEqual(94);
+  describe('OpenAPI 3', function() {
+    it('should not produce any errors or warnings from a clean file', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/oas3/clean.yml'];
+      program.default_mode = true;
+
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+      const allOutput = capturedText.join('');
+
+      expect(exitCode).toEqual(0);
+      expect(allOutput).toContain(
+        './test/cli-validator/mock-files/oas3/clean.yml passed the validator'
+      );
+    });
+
+    it('should catch problems in a multi-file spec from an outside directory', async function() {
+      const program = {};
+      program.args = [
+        './test/cli-validator/mock-files/multi-file-spec/main.yaml'
+      ];
+      program.default_mode = true;
+
+      const exitCode = await commandLineValidator(program);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+      const allOutput = capturedText.join('');
+
+      expect(exitCode).toEqual(1);
+      expect(allOutput).toContain('errors');
+      expect(allOutput).toContain('Object must have required property "info"');
+      expect(allOutput).toContain('warnings');
+      expect(allOutput).toContain('Operation must have "operationId"');
+      expect(allOutput).toContain(
+        'Operation "description" must be present and non-empty string'
+      );
+    });
+
+    it('should display the associated rule with each error and warning', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/oas3/err-and-warn.yaml'];
+      program.default_mode = true;
+      program.verbose = 1;
+
+      const exitCode = await commandLineValidator(program);
+      expect(exitCode).toEqual(1);
+
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+      const messageCount = count(capturedText, /^\s*Message\s*:/);
+      const ruleCount = count(capturedText, /^\s*Rule\s*:/);
+      expect(messageCount).toEqual(ruleCount);
+    });
+
+    it('should include the associated rule with each error and warning in JSON output', async function() {
+      const program = {};
+      program.args = ['./test/cli-validator/mock-files/oas3/err-and-warn.yaml'];
+      program.default_mode = true;
+      program.json = true;
+
+      const exitCode = await commandLineValidator(program);
+      expect(exitCode).toEqual(1);
+
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      const jsonOutput = JSON.parse(capturedText);
+
+      const msgsByType = Object.assign(
+        {},
+        jsonOutput.errors,
+        jsonOutput.warnings,
+        jsonOutput.infos,
+        jsonOutput.hints
+      );
+      const allMessages = Object.entries(msgsByType).reduce(
+        (newObj, val) => newObj.concat(val[1]),
+        []
+      );
+
+      allMessages.forEach(msg => expect(msg).toHaveProperty('rule'));
+    });
+
+    it('should include the associated rule in return value of in-memory validator', async function() {
+      const content = fs
+        .readFileSync('./test/cli-validator/mock-files/oas3/err-and-warn.yaml')
+        .toString();
+      const oas3Object = yaml.load(content);
+
+      const defaultMode = true;
+      const validationResults = await inCodeValidator(oas3Object, defaultMode);
+
+      expect(validationResults.errors.length).toBe(3);
+      expect(validationResults.warnings.length).toBe(47);
+      expect(validationResults.infos).not.toBeDefined();
+      expect(validationResults.hints).not.toBeDefined();
+
+      validationResults.errors.forEach(msg =>
+        expect(msg).toHaveProperty('rule')
+      );
+      validationResults.warnings.forEach(msg =>
+        expect(msg).toHaveProperty('rule')
+      );
+    });
+
+    it('should include the path to the component (if it exists) when in verbose mode', async function() {
+      const program = {};
+      program.args = [
+        './test/cli-validator/mock-files/oas3/component-path-example.yaml'
+      ];
+      program.default_mode = true;
+      program.verbose = 1;
+
+      const exitCode = await commandLineValidator(program);
+      expect(exitCode).toEqual(0);
+
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      const allText = capturedText.join();
+      expect(allText).toContain('Path');
+      expect(allText).toContain('Line');
+    });
+
+    it('should include the path to the component (if it exists) when in verbose mode and json mode', async function() {
+      const program = {};
+      program.args = [
+        './test/cli-validator/mock-files/oas3/component-path-example.yaml'
+      ];
+      program.default_mode = true;
+      program.verbose = 1;
+      program.json = true;
+
+      const exitCode = await commandLineValidator(program);
+      expect(exitCode).toEqual(0);
+
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      // originalError('Captured text:\n', capturedText);
+      const jsonOutput = JSON.parse(capturedText);
+      const warningToCheck = jsonOutput.warnings[0];
+
+      expect(warningToCheck.rule).toEqual('collection-array-property');
+      expect(warningToCheck.path.join('.')).toBe(
+        'components.schemas.ListOfCharacters'
+      );
+      expect(warningToCheck.line).toEqual(94);
+    });
   });
 });

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -276,7 +276,7 @@ describe('cli tool - test option handling', function() {
     program.args = ['./test/cli-validator/mock-files/err-and-warn.yaml'];
     program.report_statistics = true;
     program.default_mode = true;
-    program.loglevel = ['root=error'];
+    program.logLevel = ['root=error'];
 
     await commandLineValidator(program);
     const capturedText = getCapturedText(consoleSpy.mock.calls);

--- a/packages/validator/test/cli-validator/tests/threshold-validator.test.js
+++ b/packages/validator/test/cli-validator/tests/threshold-validator.test.js
@@ -6,13 +6,22 @@ const { getCapturedText } = require('../../test-utils');
 
 describe('test the .thresholdrc limits', function() {
   let consoleSpy;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const originalInfo = console.info;
 
   beforeEach(() => {
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    console.warn = console.log;
+    console.error = console.log;
+    console.info = console.log;
   });
 
   afterEach(() => {
     consoleSpy.mockRestore();
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.info = originalInfo;
   });
 
   it('should show error and set exit code to 1 when warning limit exceeded', async function() {


### PR DESCRIPTION
## PR summary
This commit adds logging support to the validator. The validator core itself will use a "root" logger, and each validation rule will have its own logger with a name equal to its rule name (e.g. ibm-schema-description). The user can set the logging levels with the
-l/--loglevel command-line options.


Note that this PR only includes the changes to the validator core.  Changes to individual rules to support debug logging will be done as we update each rule.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
