### PR TITLE
fix: refine validation rules as part of pre-1.0 work (group 2)

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -36,7 +36,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-binary-schemas](#ibm-binary-schemas)
   * [ibm-circular-refs](#ibm-circular-refs)
   * [ibm-collection-array-property](#ibm-collection-array-property)
-  * [ibm-consecutive-path-param-segments](#ibm-consecutive-path-param-segments)
+  * [ibm-consecutive-path-segments](#ibm-consecutive-path-segments)
   * [ibm-content-entry-contains-schema](#ibm-content-entry-contains-schema)
   * [ibm-content-entry-provided](#ibm-content-entry-provided)
   * [ibm-content-type-parameter](#ibm-content-type-parameter)
@@ -171,7 +171,7 @@ within the operation's path string, which should also match the plural form of t
 <td>oas3</td>
 </tr>
 <tr>
-<td><a href="#ibm-consecutive-path-param-segments">ibm-consecutive-path-param-segments</a></td>
+<td><a href="#ibm-consecutive-path-segments">ibm-consecutive-path-segments</a></td>
 <td>error</td>
 <td>Checks each path string in the API definition to detect the presence of two or more consecutive
 path segments that contain a path parameter reference (e.g. <code>/v1/foos/{foo_id}/{bar_id}</code>), 
@@ -1248,11 +1248,11 @@ paths:
 </table>
 
 
-### ibm-consecutive-path-param-segments
+### ibm-consecutive-path-segments
 <table>
 <tr>
 <td><b>Rule id:</b></td>
-<td><b>ibm-consecutive-path-param-segments</b></td>
+<td><b>ibm-consecutive-path-segments</b></td>
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>

--- a/packages/ruleset/src/functions/array-of-arrays.js
+++ b/packages/ruleset/src/functions/array-of-arrays.js
@@ -1,14 +1,28 @@
-const { validateSubschemas } = require('@ibm-cloud/openapi-ruleset-utilities');
+const {
+  isArraySchema,
+  validateSubschemas
+} = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
 
-module.exports = function(schema, _opts, { path }) {
-  return validateSubschemas(schema, path, arrayOfArrays, true, false);
+let ruleId;
+let logger;
+module.exports = function(schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.newInstance().getLogger(ruleId);
+  }
+  return validateSubschemas(schema, context.path, arrayOfArrays, true, false);
 };
 
 function arrayOfArrays(schema, path) {
   const errors = [];
 
-  if (schema.type === 'array' && schema.items) {
-    if (schema.items.type === 'array') {
+  if (isArraySchema(schema) && schema.items) {
+    logger.debug(
+      `${ruleId}: checking array schema at location: ${path.join('.')}`
+    );
+    if (isArraySchema(schema.items)) {
+      logger.debug('Found an array of arrays!');
       errors.push({
         message: 'Array schemas should avoid having items of type array.',
         path

--- a/packages/ruleset/src/functions/collection-array-property.js
+++ b/packages/ruleset/src/functions/collection-array-property.js
@@ -3,8 +3,16 @@ const {
   isArraySchema,
   isObject
 } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
 
 module.exports = function(schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.newInstance().getLogger(ruleId);
+  }
   return collectionArrayProperty(
     schema,
     context.path,
@@ -24,7 +32,7 @@ module.exports = function(schema, _opts, context) {
  * @returns an array containing the violations found or [] if no violations
  */
 function collectionArrayProperty(schema, path, apidef) {
-  // console.log(`Invoked for path: ${path.join('.')}`);
+  logger.debug(`${ruleId}: checking schema at location: ${path.join('.')}`);
 
   // Grab the GET operation that defines "schema" as the success response schema.
   const pathString = path[1];
@@ -33,12 +41,14 @@ function collectionArrayProperty(schema, path, apidef) {
   // If this is a collection "list"-type operation, then check to make sure
   // that "schema" defines an array property named after the last path segment.
   if (isListOperation(operation, pathString, apidef)) {
+    logger.debug('Detected list-type operation');
     const pathSegments = pathString.split('/');
     const propertyName = pathSegments[pathSegments.length - 1];
     if (!checkCompositeSchemaForArrayProperty(schema, propertyName)) {
+      logger.debug(`Couldn't find array property named '${propertyName}'`);
       return [
         {
-          message: `Collection list operation response schema should define array property with name "${propertyName}"`,
+          message: `Collection list operation response schema should define array property with name '${propertyName}'`,
           path
         }
       ];

--- a/packages/ruleset/src/functions/consecutive-path-segments.js
+++ b/packages/ruleset/src/functions/consecutive-path-segments.js
@@ -1,5 +1,14 @@
-module.exports = function(pathItem, options, { path }) {
-  return consecutivePathParamSegments(path);
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function(pathItem, options, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.newInstance().getLogger(ruleId);
+  }
+  return consecutivePathSegments(context.path);
 };
 
 /**
@@ -9,13 +18,16 @@ module.exports = function(pathItem, options, { path }) {
  * pathItem within the API definition (e.g. ['paths','/v1/clouds/{id}'])
  * @returns an array containing the violations found or [] if no violations
  */
-function consecutivePathParamSegments(path) {
+function consecutivePathSegments(path) {
+  logger.debug(`${ruleId}: checking path item at location: ${path.join('.')}`);
+
   // The path string itself (e.g. '/v1/clouds/{id}') will be the last element in 'path'.
   const pathStr = path[path.length - 1].toString();
 
   // Check to see if the path string has two or more consecutive path segments
   // containing a path parameter reference (e.g. '/v1/clouds/{cloud_id}/{region_id}').
   if (/{[^/]+}\/{[^/]+}/.test(pathStr)) {
+    logger.debug(`${ruleId}: found consecutive path param references!`);
     return [
       {
         message: `Path contains two or more consecutive path parameter references: ${pathStr}`,

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -6,7 +6,7 @@ module.exports = {
   checkMajorVersion: require('./check-major-version'),
   circularRefs: require('./circular-refs'),
   collectionArrayProperty: require('./collection-array-property'),
-  consecutivePathParamSegments: require('./consecutive-path-param-segments'),
+  consecutivePathSegments: require('./consecutive-path-segments'),
   deleteBody: require('./delete-body'),
   descriptionMentionsJSON: require('./description-mentions-json'),
   disallowedHeaderParameter: require('./disallowed-header-parameter'),

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -98,8 +98,7 @@ module.exports = {
     'ibm-binary-schemas': ibmRules.binarySchemas,
     'ibm-circular-refs': ibmRules.circularRefs,
     'ibm-collection-array-property': ibmRules.collectionArrayProperty,
-    'ibm-consecutive-path-param-segments':
-      ibmRules.consecutivePathParamSegments,
+    'ibm-consecutive-path-segments': ibmRules.consecutivePathSegments,
     'ibm-content-entry-contains-schema': ibmRules.contentEntryContainsSchema,
     'ibm-content-entry-provided': ibmRules.contentEntryProvided,
     'ibm-content-type-parameter': ibmRules.contentTypeParameter,

--- a/packages/ruleset/src/rules/collection-array-property.js
+++ b/packages/ruleset/src/rules/collection-array-property.js
@@ -1,4 +1,4 @@
-const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { oas3 } = require('@stoplight/spectral-formats');
 const { collectionArrayProperty } = require('../functions');
 
 module.exports = {
@@ -8,7 +8,7 @@ module.exports = {
   given:
     '$.paths[*].get.responses[?(@property.match(/2\\d\\d/))].content[*].schema',
   severity: 'warn',
-  formats: [oas2, oas3],
+  formats: [oas3],
   resolved: true,
   then: {
     function: collectionArrayProperty

--- a/packages/ruleset/src/rules/consecutive-path-segments.js
+++ b/packages/ruleset/src/rules/consecutive-path-segments.js
@@ -1,18 +1,18 @@
 const {
   paths
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
-const { oas2, oas3 } = require('@stoplight/spectral-formats');
-const { consecutivePathParamSegments } = require('../functions');
+const { oas3 } = require('@stoplight/spectral-formats');
+const { consecutivePathSegments } = require('../functions');
 
 module.exports = {
   description:
     'Path strings should not contain two or more consecutive path parameter references',
   message: '{{error}}',
-  formats: [oas2, oas3],
+  formats: [oas3],
   given: paths,
   severity: 'error',
   resolved: true,
   then: {
-    function: consecutivePathParamSegments
+    function: consecutivePathSegments
   }
 };

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -7,7 +7,7 @@ module.exports = {
   binarySchemas: require('./binary-schemas'),
   circularRefs: require('./circular-refs'),
   collectionArrayProperty: require('./collection-array-property'),
-  consecutivePathParamSegments: require('./consecutive-path-param-segments'),
+  consecutivePathSegments: require('./consecutive-path-segments'),
   contentEntryContainsSchema: require('./content-entry-contains-schema'),
   contentEntryProvided: require('./content-entry-provided'),
   contentTypeParameter: require('./content-type-parameter'),

--- a/packages/ruleset/test/accept-parameter.test.js
+++ b/packages/ruleset/test/accept-parameter.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.warning;
 const expectedErrorMsg =
   "Operations should not explicitly define the 'Accept' header parameter";
 
-describe('Spectral rule: accept-parameter', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/array-attributes.test.js
+++ b/packages/ruleset/test/array-attributes.test.js
@@ -8,7 +8,7 @@ const expectedMsgMin = 'Array schemas should define a numeric minItems field';
 const expectedMsgMax = 'Array schemas should define a numeric maxItems field';
 const expectedMsgItems = 'Array schemas must specify the items field';
 
-describe('Spectral rule: array-boundary', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/array-of-arrays.test.js
+++ b/packages/ruleset/test/array-of-arrays.test.js
@@ -42,7 +42,7 @@ const arrayOfArrayOfInt = {
   }
 };
 
-describe('Spectral rule: array-of-arrays', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/array-responses.test.js
+++ b/packages/ruleset/test/array-responses.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.error;
 const expectedMsg =
   'Operations should not return an array as the top-level structure of a response.';
 
-describe('Spectral rule: array-responses', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/authorization-parameter.test.js
+++ b/packages/ruleset/test/authorization-parameter.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.warning;
 const expectedErrorMsg =
   "Operations should not explicitly define the 'Authorization' header parameter";
 
-describe('Spectral rule: authorization-parameter', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/binary-schemas.test.js
+++ b/packages/ruleset/test/binary-schemas.test.js
@@ -11,7 +11,7 @@ const expectedMsgReqBody =
 const expectedMsgResponse =
   'Responses with JSON content should not contain binary values (type: string, format: binary).';
 
-describe('Spectral rule: binary-schemas', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/circular-refs.test.js
+++ b/packages/ruleset/test/circular-refs.test.js
@@ -5,7 +5,7 @@ const ruleId = 'ibm-circular-refs';
 const expectedSeverity = severityCodes.warning;
 const expectedMsg = 'API definition should not contain circular references.';
 
-describe('Spectral rule: circular-refs', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   // The implementation of the circular-refs rule uses a global variable
   // to store the set of unique flagged $ref values.
   // Because the global variable's value is retained across testcases, we need to reset

--- a/packages/ruleset/test/collection-array-property.test.js
+++ b/packages/ruleset/test/collection-array-property.test.js
@@ -4,10 +4,9 @@ const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 const rule = collectionArrayProperty;
 const ruleId = 'ibm-collection-array-property';
 const expectedSeverity = severityCodes.warning;
-const expectedMsg =
-  'Collection list operation response schema should define array property with name "movies"';
+const expectedMsg = `Collection list operation response schema should define array property with name 'movies'`;
 
-describe('Spectral rule: collection-array-property', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/consecutive-path-segments.test.js
+++ b/packages/ruleset/test/consecutive-path-segments.test.js
@@ -1,11 +1,11 @@
-const { consecutivePathParamSegments } = require('../src/rules');
+const { consecutivePathSegments } = require('../src/rules');
 const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 
-const rule = consecutivePathParamSegments;
-const ruleId = 'ibm-consecutive-path-param-segments';
+const rule = consecutivePathSegments;
+const ruleId = 'ibm-consecutive-path-segments';
 const expectedSeverity = severityCodes.error;
 
-describe('Spectral rule: consecutive-path-param-segments', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);


### PR DESCRIPTION
## PR summary
    
This commit covers the following rules:
- ibm-array-of-arrays
- ibm-array-responses
- ibm-binary-schemas
- ibm-circular-refs
- ibm-collection-array-property
- ibm-consecutive-path-segments

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
