### PR TITLE
fix: refine validation rules as part of pre-1.0 work (group 5)

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -245,12 +245,6 @@ which is not allowed.</td>
 <td>oas3</td>
 </tr>
 <tr>
-<td><a href="#ibm-sdk-operations">ibm-sdk-operations</a></td>
-<td>warn</td>
-<td>Validates the structure of each <code>x-sdk-operations</code> object</td>
-<td>oas3</td>
-</tr>
-<tr>
 <td><a href="#ibm-if-modified-since-parameter">ibm-if-modified-since-parameter</a></td>
 <td>warn</td>
 <td>Operations should avoid supporting the <code>If-Modified-Since</code> header parameter</td>
@@ -480,6 +474,12 @@ has non-form content.</td>
 <td><a href="#ibm-schema-type">ibm-schema-type</a></td>
 <td>off</td>
 <td>Schemas and schema properties should have a non-empty <code>type</code> field. <b>This rule is disabled by default.</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-sdk-operations">ibm-sdk-operations</a></td>
+<td>warn</td>
+<td>Validates the structure of each <code>x-sdk-operations</code> object</td>
 <td>oas3</td>
 </tr>
 <tr>

--- a/packages/ruleset/src/functions/disallowed-header-parameter.js
+++ b/packages/ruleset/src/functions/disallowed-header-parameter.js
@@ -35,9 +35,11 @@ module.exports = function(param, options, context) {
 // Return an error if 'param' is a header parameter named '<headerName>'.
 
 function checkHeaderParam(logger, ruleId, param, path, headerName) {
-  logger.debug(`${ruleId}: checking parameter at location: ${path.join('.')}`);
   // Don't bother enforcing the rule on parameter references.
   if (!param.$ref) {
+    logger.debug(
+      `${ruleId}: checking parameter at location: ${path.join('.')}`
+    );
     const isHeader = param.in && param.in.toLowerCase() === 'header';
     const isDisallowedHeader =
       param.name && param.name.trim().toLowerCase() === headerName;

--- a/packages/ruleset/src/rules/if-modified-since-parameter.js
+++ b/packages/ruleset/src/rules/if-modified-since-parameter.js
@@ -1,14 +1,14 @@
 const {
   parameters
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
-const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { oas3 } = require('@stoplight/spectral-formats');
 const { disallowedHeaderParameter } = require('../functions');
 
 module.exports = {
   description:
     'Operations should support the If-None-Match header parameter instead of If-Modified-Since',
   message: '{{description}}',
-  formats: [oas2, oas3],
+  formats: [oas3],
   given: parameters,
   severity: 'warn',
   resolved: true,

--- a/packages/ruleset/src/rules/if-unmodified-since-parameter.js
+++ b/packages/ruleset/src/rules/if-unmodified-since-parameter.js
@@ -1,14 +1,14 @@
 const {
   parameters
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
-const { oas2, oas3 } = require('@stoplight/spectral-formats');
+const { oas3 } = require('@stoplight/spectral-formats');
 const { disallowedHeaderParameter } = require('../functions');
 
 module.exports = {
   description:
     'Operations should support the If-Match header parameter instead of If-Unmodified-Since',
   message: '{{description}}',
-  formats: [oas2, oas3],
+  formats: [oas3],
   given: parameters,
   severity: 'warn',
   resolved: true,

--- a/packages/ruleset/test/if-modified-since-parameter.test.js
+++ b/packages/ruleset/test/if-modified-since-parameter.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.warning;
 const expectedErrorMsg =
   'Operations should support the If-None-Match header parameter instead of If-Modified-Since';
 
-describe('Spectral rule: if-modified-since-parameter', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/if-unmodified-since-parameter.test.js
+++ b/packages/ruleset/test/if-unmodified-since-parameter.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.warning;
 const expectedErrorMsg =
   'Operations should support the If-Match header parameter instead of If-Unmodified-Since';
 
-describe('Spectral rule: if-unmodified-since-parameter', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/inline-property-schema.test.js
+++ b/packages/ruleset/test/inline-property-schema.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.warning;
 const expectedMsg =
   'Nested objects should be defined as a $ref to a named schema.';
 
-describe('Spectral rule: inline-property-schema', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/inline-request-schema.test.js
+++ b/packages/ruleset/test/inline-request-schema.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.warning;
 const expectedMsg =
   'Request body schemas should be defined as a $ref to a named schema.';
 
-describe('Spectral rule: inline-request-schema', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);

--- a/packages/ruleset/test/inline-response-schema.test.js
+++ b/packages/ruleset/test/inline-response-schema.test.js
@@ -7,7 +7,7 @@ const expectedSeverity = severityCodes.warning;
 const expectedMsg =
   'Response schemas should be defined as a $ref to a named schema.';
 
-describe('Spectral rule: inline-response-schema', () => {
+describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
       const results = await testRule(ruleId, rule, rootDocument);


### PR DESCRIPTION
## PR summary
This commit covers the following rules:
- ibm-if-modified-since-parameter
- ibm-if-unmodified-since-parameter
- ibm-inline-property-schema
- ibm-inline-request-schema
- ibm-inline-response-schema

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
