### PR TITLE
fix(inline-property-schema): avoid false warnings

### DIFF
--- a/packages/ruleset/src/utils/is-empty-object-schema.js
+++ b/packages/ruleset/src/utils/is-empty-object-schema.js
@@ -30,11 +30,11 @@ function isEmptyObjectSchema(schema) {
     return false;
   }
 
-  // "schema" should have only the following properties.
+  // "schema" should have only the following properties (ignoring annotations).
   // 'description' and 'additionalProperties' are optional.
   const allowableFields = ['type', 'description', 'additionalProperties'];
   for (const field of Object.keys(schema)) {
-    if (!allowableFields.includes(field)) {
+    if (!allowableFields.includes(field) && !field.startsWith('x-')) {
       return false;
     }
   }

--- a/packages/ruleset/test/inline-property-schema.test.js
+++ b/packages/ruleset/test/inline-property-schema.test.js
@@ -32,6 +32,26 @@ describe('Spectral rule: inline-property-schema', () => {
       expect(results).toHaveLength(0);
     });
 
+    it('Inline object schema w/annotation but no properties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // empty object
+      testDocument.components.schemas.Car.properties['inline_prop1'] = {
+        'type': 'object',
+        'x-foo': 'bar'
+      };
+
+      // any object
+      testDocument.components.schemas.Car.properties['inline_prop2'] = {
+        'type': 'object',
+        'additionalProperties': true,
+        'x-terraform-sensitive': 'bar'
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
     it('Ref sibling', async () => {
       const testDocument = makeCopy(rootDocument);
 

--- a/packages/ruleset/test/is-empty-object-schema.test.js
+++ b/packages/ruleset/test/is-empty-object-schema.test.js
@@ -99,5 +99,14 @@ describe('Utility function: isEmptyObjectSchema()', () => {
       };
       expect(isEmptyObjectSchema(s)).toBe(true);
     });
+
+    it('empty object schema w/annotations', async () => {
+      const s = {
+        'type': 'object',
+        'description': 'empty object schema',
+        'x-foo': 'bar'
+      };
+      expect(isEmptyObjectSchema(s)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## PR summary
This commit modifies the isEmptyObjectSchema() utility function so that it will correctly ignore annotations present on a schema when deciding whether or not a schema is an "empty object" schema (i.e. an object schema with no properties defined).


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
