### PR TITLE
build: add pre-release config for semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,12 @@
 {
-  "branches": "main",
+  "branches": [
+    "main",
+    {
+      "name": "1.0-prerelease",
+      channel: "v1-rc",
+      "prerelease": "rc"
+    }
+  ],
   "debug": true,
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Adding a "branch" to our semantic release configuration will allow for automated releases off of our pre-release branch, so that we can start publishing release candidates with each new change that we make.