### PR TITLE
build: use semantic release to control conditional deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ deploy:
   script: npx -p @qiwi/semrel-toolkit multi-semrel --deps.release inherit
   on:
     node: 14
-    branch: main
+    all_branches: true


### PR DESCRIPTION
Right now, the Travis file dictates that the deploy step will only be run for the `main` branch. However, the only command we run during the deploy step is to invoke semantic release. Semantic release also dictates that it will only run on certain branches, so it should be sufficient for controlling the conditional deployment.

We want to deploy on multiple branches in order to publish release candidates from our pre-release branch, so this commit enables Travis to run the deploy step on each branch and lets semantic release control which branches are actually deployed from.