### PR TITLE
Revert "build: use semantic release to control conditional deployment (#562)"

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,12 +1,5 @@
 {
-  "branches": [
-    "main",
-    {
-      "name": "1.0-prerelease",
-      channel: "v1-rc",
-      "prerelease": "rc"
-    }
-  ],
+  "branches": "main",
   "debug": true,
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ deploy:
   script: npx -p @qiwi/semrel-toolkit multi-semrel --deps.release inherit
   on:
     node: 14
-    all_branches: true
+    branch: main


### PR DESCRIPTION
This reverts commit b064d2c2a2ef4fb8a57530efe8dc165e130ead3c and db0f88d44cdcd1429a36c5c01600ae916be87b37

The pre-release config didn't work out as planned - the "multi semantic release" package didn't handle the pre-release config as expected and I wasn't able to see a clear solution. Since we have more important things to do than debug the setup, I think we should revert the change to publish on all branches and handle release candidates manually.