### PR TITLE
refactor: optimize logic for summary-only feature

### DIFF
--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -266,13 +266,9 @@ async function runValidator(cliArgs, parseOptions = {}) {
       const numWarnings = results.warning.summary.total;
       if (numWarnings > limitsObject.warnings) {
         exitCode = 1;
-        // add the exceeded warnings limit as an error
-        results.error.results.push({
-          line: 0,
-          rule: 'warnings-limit',
-          path: [],
-          message: `Number of warnings (${numWarnings}) exceeds warnings limit (${limitsObject.warnings}).`
-        });
+        logger.error(
+          `Number of warnings (${numWarnings}) exceeds warnings limit (${limitsObject.warnings}).`
+        );
       }
     }
 

--- a/packages/validator/src/cli-validator/utils/get-path-as-array.js
+++ b/packages/validator/src/cli-validator/utils/get-path-as-array.js
@@ -1,8 +1,0 @@
-/**
- * Copyright 2017 - 2023 IBM Corporation.
- * SPDX-License-Identifier: Apache2.0
- */
-
-module.exports = function(path) {
-  return Array.isArray(path) ? path : path.split('.');
-};

--- a/packages/validator/src/cli-validator/utils/print-results.js
+++ b/packages/validator/src/cli-validator/utils/print-results.js
@@ -15,6 +15,12 @@ module.exports = function print(
   errorsOnly
 ) {
   const types = errorsOnly ? ['error'] : ['error', 'warning', 'info', 'hint'];
+
+  if (summaryOnly) {
+    printSummary(results, types, logger, chalk, errorsOnly);
+    return;
+  }
+
   const colors = {
     error: 'bgRed',
     warning: 'bgYellow',
@@ -23,75 +29,76 @@ module.exports = function print(
   };
 
   types.forEach(type => {
-    let color = colors[type];
-    if (results[type].summary.total && !summaryOnly) {
-      logger.info(chalk[color].bold(`${type}s\n`));
+    if (!results[type].summary.total) {
+      return; // continue
     }
 
+    let color = colors[type];
+    logger.info(chalk[color].bold(`${type}s\n`));
     // convert 'color' from a background color to foreground color
     color = color.slice(2).toLowerCase(); // i.e. 'bgRed' -> 'red'
 
     each(results[type].results, result => {
       // print the path array as a dot-separated string
-      if (!summaryOnly) {
-        logger.info(chalk[color](`  Message :   ${result.message}`));
-        if (result.rule) {
-          logger.info(chalk[color](`  Rule    :   ${result.rule}`));
-        }
-        logger.info(chalk[color](`  Path    :   ${result.path.join('.')}`));
-        logger.info(chalk[color](`  Line    :   ${result.line}`));
-        logger.info('');
-      }
+      logger.info(chalk[color](`  Message :   ${result.message}`));
+      logger.info(chalk[color](`  Rule    :   ${result.rule}`));
+      logger.info(chalk[color](`  Path    :   ${result.path.join('.')}`));
+      logger.info(chalk[color](`  Line    :   ${result.line}`));
+      logger.info('');
     });
   });
 
-  // Print the summary here if we had any messages.
-  if (results.has_results) {
-    logger.info(chalk.bgCyan('summary\n'));
+  // Print the summary here
+  printSummary(results, types, logger, chalk, errorsOnly);
+};
 
-    logger.info(
-      chalk.cyan(`  Total number of errors   : ${results.error.summary.total}`)
-    );
+function printSummary(results, types, logger, chalk, errorsOnly) {
+  logger.info(chalk.bgCyan('summary\n'));
+
+  logger.info(
+    chalk.cyan(`  Total number of errors   : ${results.error.summary.total}`)
+  );
+  if (!errorsOnly) {
     logger.info(
       chalk.cyan(
         `  Total number of warnings : ${results.warning.summary.total}`
       )
     );
-    if (results.info.summary.total > 0) {
-      logger.info(
-        chalk.cyan(`  Total number of infos    : ${results.info.summary.total}`)
-      );
-    }
-    if (results.hint.summary.total > 0) {
-      logger.info(
-        chalk.cyan(`  Total number of hints    : ${results.hint.summary.total}`)
-      );
-    }
-    logger.info('');
-
-    types.forEach(type => {
-      // print the type, either error or warning
-      if (results[type].summary.total) {
-        logger.info('  ' + chalk.underline.cyan(type + 's'));
-      }
-
-      results[type].summary.entries.forEach(entry => {
-        // pad(<number>, <string>) right-aligns <string> to the <number>th column, padding with spaces.
-        // use 4, two for the appended spaces of every line and two for the number
-        //   (assuming errors/warnings won't go to triple digits)
-        const numberString = pad(4, entry.count);
-        // use 6 for largest case of '(100%)'
-        const frequencyString = pad(6, `(${entry.percentage}%)`);
-
-        logger.info(
-          chalk.cyan(
-            `${numberString} ${frequencyString} : ${entry.generalized_message}`
-          )
-        );
-      });
-      if (results[type].summary.total) {
-        logger.info('');
-      }
-    });
   }
-};
+  if (results.info.summary.total > 0) {
+    logger.info(
+      chalk.cyan(`  Total number of infos    : ${results.info.summary.total}`)
+    );
+  }
+  if (results.hint.summary.total > 0) {
+    logger.info(
+      chalk.cyan(`  Total number of hints    : ${results.hint.summary.total}`)
+    );
+  }
+  logger.info('');
+
+  types.forEach(type => {
+    // print the type, either error or warning
+    if (results[type].summary.total) {
+      logger.info('  ' + chalk.underline.cyan(type + 's'));
+    }
+
+    results[type].summary.entries.forEach(entry => {
+      // pad(<number>, <string>) right-aligns <string> to the <number>th column, padding with spaces.
+      // use 4, two for the appended spaces of every line and two for the number
+      //   (assuming errors/warnings won't go to triple digits)
+      const numberString = pad(4, entry.count);
+      // use 6 for largest case of '(100%)'
+      const frequencyString = pad(6, `(${entry.percentage}%)`);
+
+      logger.info(
+        chalk.cyan(
+          `${numberString} ${frequencyString} : ${entry.generalized_message}`
+        )
+      );
+    });
+    if (results[type].summary.total) {
+      logger.info('');
+    }
+  });
+}

--- a/packages/validator/test/cli-validator/tests/threshold-validator.test.js
+++ b/packages/validator/test/cli-validator/tests/threshold-validator.test.js
@@ -35,8 +35,11 @@ describe('test the .thresholdrc limits', function() {
 
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
-
-    expect(capturedText[0].slice(14, 32)).toEqual(`Number of warnings`);
+    expect(
+      capturedText
+        .join('')
+        .includes('Number of warnings (43) exceeds warnings limit (5).')
+    ).toEqual(true);
   });
 
   it('should print errors for unsupported limit options and invalid limit values', async function() {


### PR DESCRIPTION
Currently, we loop through all validations and check if "summary only" is enabled before we print them. It would be more efficient and readable to check once at the beginning, printing the summary and exiting if the feature is enabled.

This commit also includes some other, minor refactoring.