### PR TITLE
chore: update prettier version and adjust code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,10 +8,13 @@ module.exports = {
   },
   'parser': 'babel-eslint',
   'rules': {
-    'prettier/prettier': ['error', {'singleQuote': true}],
+    'prettier/prettier': ['error', {
+      'singleQuote': true,
+      'arrowParens': 'avoid',
+    }],
     'no-console': 0,
     'no-var': 'error',
     'prefer-const': 'error',
   },
-  'extends': ['prettier', 'eslint:recommended']
+  'extends': ['prettier', 'eslint:recommended'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-config-prettier": "^3.6.0",
         "eslint-plugin-prettier": "^2.7.0",
         "jest": "^27.4.5",
-        "prettier": "^1.19.1",
+        "prettier": "^2.8.4",
         "semantic-release": "^19.0.2"
       }
     },
@@ -10667,15 +10667,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -21168,9 +21171,9 @@
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-config-prettier": "^3.6.0",
     "eslint-plugin-prettier": "^2.7.0",
     "jest": "^27.4.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.8.4",
     "semantic-release": "^19.0.2"
   },
   "config": {

--- a/packages/ruleset/src/functions/array-attributes.js
+++ b/packages/ruleset/src/functions/array-attributes.js
@@ -6,14 +6,14 @@
 const isPlainObject = require('lodash/isPlainObject');
 const {
   validateNestedSchemas,
-  isArraySchema
+  isArraySchema,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { getCompositeSchemaAttribute, LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -41,7 +41,7 @@ function arrayAttributeErrors(schema, path) {
       logger.debug('minItems field is missing!');
       errors.push({
         message: 'Array schemas should define a numeric minItems field',
-        path
+        path,
       });
     }
 
@@ -51,7 +51,7 @@ function arrayAttributeErrors(schema, path) {
       logger.debug('maxItems field is missing!');
       errors.push({
         message: 'Array schemas should define a numeric maxItems field',
-        path
+        path,
       });
     }
 
@@ -60,7 +60,7 @@ function arrayAttributeErrors(schema, path) {
       logger.debug('minItems > maxItems!');
       errors.push({
         message: 'minItems cannot be greater than maxItems',
-        path
+        path,
       });
     }
 
@@ -71,8 +71,8 @@ function arrayAttributeErrors(schema, path) {
       return [
         {
           message: 'Array schemas must specify the items field',
-          path
-        }
+          path,
+        },
       ];
     }
   } else {
@@ -80,13 +80,13 @@ function arrayAttributeErrors(schema, path) {
     if (schema.minItems) {
       errors.push({
         message: 'minItems should not be defined for a non-array schema',
-        path: [...path, 'minItems']
+        path: [...path, 'minItems'],
       });
     }
     if (schema.maxItems) {
       errors.push({
         message: 'maxItems should not be defined for a non-array schema',
-        path: [...path, 'maxItems']
+        path: [...path, 'maxItems'],
       });
     }
   }

--- a/packages/ruleset/src/functions/array-of-arrays.js
+++ b/packages/ruleset/src/functions/array-of-arrays.js
@@ -5,13 +5,13 @@
 
 const {
   isArraySchema,
-  validateSubschemas
+  validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -30,7 +30,7 @@ function arrayOfArrays(schema, path) {
       logger.debug('Found an array of arrays!');
       errors.push({
         message: 'Array schemas should avoid having items of type array.',
-        path
+        path,
       });
     }
   }

--- a/packages/ruleset/src/functions/array-responses.js
+++ b/packages/ruleset/src/functions/array-responses.js
@@ -7,7 +7,7 @@ const { LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -50,8 +50,8 @@ function checkForArrayResponses(op, path) {
             responseCode,
             'content',
             mimeType,
-            'schema'
-          ]
+            'schema',
+          ],
         });
       }
     }

--- a/packages/ruleset/src/functions/binary-schemas.js
+++ b/packages/ruleset/src/functions/binary-schemas.js
@@ -8,13 +8,13 @@ const { isBinarySchema } = require('@ibm-cloud/openapi-ruleset-utilities');
 const {
   isJsonMimeType,
   pathMatchesRegexp,
-  LoggerFactory
+  LoggerFactory,
 } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -69,8 +69,8 @@ function binarySchemaCheck(schema, path) {
       {
         message:
           'Parameters should not contain binary values (type: string, format: binary).',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -85,8 +85,8 @@ function binarySchemaCheck(schema, path) {
       {
         message:
           'Request bodies with JSON content should not contain binary values (type: string, format: binary).',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -101,8 +101,8 @@ function binarySchemaCheck(schema, path) {
       {
         message:
           'Responses with JSON content should not contain binary values (type: string, format: binary).',
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/check-major-version.js
+++ b/packages/ruleset/src/functions/check-major-version.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(apiDef, _opts, context) {
+module.exports = function (apiDef, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -67,8 +67,8 @@ function checkMajorVersion(apiDef) {
             message:
               'Major version segments of urls in servers object do not match. Found ' +
               uniqueVersions.join(', '),
-            path: ['servers']
-          }
+            path: ['servers'],
+          },
         ];
       }
 
@@ -115,8 +115,8 @@ function checkMajorVersion(apiDef) {
           message:
             'Major version segments of paths object do not match. Found ' +
             uniqueVersions.join(', '),
-          path: ['paths']
-        }
+          path: ['paths'],
+        },
       ];
     }
 
@@ -136,8 +136,8 @@ function checkMajorVersion(apiDef) {
     return [
       {
         message:
-          'Major version segment not present in either server URLs or paths'
-      }
+          'Major version segment not present in either server URLs or paths',
+      },
     ];
   } else {
     logger.debug(
@@ -145,8 +145,9 @@ function checkMajorVersion(apiDef) {
     );
     return [
       {
-        message: 'Major version segment not present in either basePath or paths'
-      }
+        message:
+          'Major version segment not present in either basePath or paths',
+      },
     ];
   }
 }

--- a/packages/ruleset/src/functions/circular-refs.js
+++ b/packages/ruleset/src/functions/circular-refs.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function($ref, _opts, context) {
+module.exports = function ($ref, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -74,8 +74,8 @@ function checkForCircularRef($ref, path) {
     return [
       {
         message: 'API definition should not contain circular references.',
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/collection-array-property.js
+++ b/packages/ruleset/src/functions/collection-array-property.js
@@ -6,14 +6,14 @@
 const {
   schemaHasConstraint,
   isArraySchema,
-  isObject
+  isObject,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -54,8 +54,8 @@ function collectionArrayProperty(schema, path, apidef) {
       return [
         {
           message: `Collection list operation response schema should define array property with name '${propertyName}'`,
-          path
-        }
+          path,
+        },
       ];
     }
   }

--- a/packages/ruleset/src/functions/consecutive-path-segments.js
+++ b/packages/ruleset/src/functions/consecutive-path-segments.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(pathItem, options, context) {
+module.exports = function (pathItem, options, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -36,8 +36,8 @@ function consecutivePathSegments(path) {
     return [
       {
         message: `Path contains two or more consecutive path parameter references: ${pathStr}`,
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/delete-body.js
+++ b/packages/ruleset/src/functions/delete-body.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -29,8 +29,8 @@ function deleteBody(operation, path) {
     return [
       {
         message: '"delete" operation should not contain a requestBody.',
-        path: [...path, 'requestBody']
-      }
+        path: [...path, 'requestBody'],
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/description-mentions-json.js
+++ b/packages/ruleset/src/functions/description-mentions-json.js
@@ -10,7 +10,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -29,15 +29,12 @@ function descriptionMentionsJSON(schema, path) {
 
   if (
     schema.description &&
-    schema.description
-      .toString()
-      .toLowerCase()
-      .includes('json')
+    schema.description.toString().toLowerCase().includes('json')
   ) {
     logger.debug('Found JSON reference!');
     results.push({
       message: errorMsg,
-      path
+      path,
     });
   }
 

--- a/packages/ruleset/src/functions/disallowed-header-parameter.js
+++ b/packages/ruleset/src/functions/disallowed-header-parameter.js
@@ -19,7 +19,7 @@ const { LoggerFactory } = require('../utils');
  * @param {*} headerName the name of the header parameter to check for
  * @returns an array of size one if 'param' is flagged, or an empty array otherwise
  */
-module.exports = function(param, options, context) {
+module.exports = function (param, options, context) {
   const ruleId = context.rule.name;
   const logger = LoggerFactory.getInstance().getLogger(ruleId);
 
@@ -54,8 +54,8 @@ function checkHeaderParam(logger, ruleId, param, path, headerName) {
         {
           // This is a default message. We expect the rule definition to supply a message.
           message: `Header parameter "${headerName}" should not be explicitly defined.`,
-          path
-        }
+          path,
+        },
       ];
     }
   }

--- a/packages/ruleset/src/functions/discriminator-property-exists.js
+++ b/packages/ruleset/src/functions/discriminator-property-exists.js
@@ -21,7 +21,7 @@
 
 const {
   schemaHasProperty,
-  validateSubschemas
+  validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const { LoggerFactory } = require('../utils');
@@ -29,7 +29,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -55,7 +55,7 @@ function validateDiscriminators(schema, path) {
     errors.push({
       message:
         'The discriminator property name used must be defined in this schema',
-      path: [...path, 'discriminator', 'propertyName']
+      path: [...path, 'discriminator', 'propertyName'],
     });
   }
 

--- a/packages/ruleset/src/functions/duplicate-path-parameter.js
+++ b/packages/ruleset/src/functions/duplicate-path-parameter.js
@@ -11,7 +11,7 @@ const { operationMethods, LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(pathItem, _opts, context) {
+module.exports = function (pathItem, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -89,7 +89,7 @@ function duplicatePathParameter(pathItem, path) {
                 errors.push({
                   message:
                     'Common path parameters should be defined on path object',
-                  path: [...path, opKey, 'parameters', paramIndex.toString()]
+                  path: [...path, opKey, 'parameters', paramIndex.toString()],
                 });
               }
             }

--- a/packages/ruleset/src/functions/enum-casing-convention.js
+++ b/packages/ruleset/src/functions/enum-casing-convention.js
@@ -11,7 +11,7 @@ let casingConfig;
 let ruleId;
 let logger;
 
-module.exports = function(schema, options, context) {
+module.exports = function (schema, options, context) {
   // Save this rule's "functionOptions" value since we need
   // to pass it on to Spectral's "casing" function.
   casingConfig = options;

--- a/packages/ruleset/src/functions/error-response-schemas.js
+++ b/packages/ruleset/src/functions/error-response-schemas.js
@@ -7,14 +7,14 @@ const {
   isArraySchema,
   isIntegerSchema,
   isObject,
-  isStringSchema
+  isStringSchema,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -53,8 +53,8 @@ function checkErrorContainerModelSchema(schema, path) {
     return [
       {
         message: 'Error container model must be an object with properties',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -85,8 +85,8 @@ function checkTraceProperty(properties, path) {
       {
         message:
           'Error container model should contain property `trace` of type string',
-        path
-      }
+        path,
+      },
     ];
   }
   return [];
@@ -104,8 +104,8 @@ function checkStatusCodeProperty(properties, path) {
       {
         message:
           'Error container model property `status_code` must be of type integer',
-        path: [...path, 'status_code']
-      }
+        path: [...path, 'status_code'],
+      },
     ];
   }
   return [];
@@ -123,8 +123,8 @@ function checkErrorsProperty(properties, path) {
       {
         message:
           'Error container model must contain property `errors` which must be an array of error models',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -137,8 +137,8 @@ function checkErrorsProperty(properties, path) {
       {
         message:
           'Error container model `errors.items` field must be an object with properties',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -165,8 +165,8 @@ function checkCodeProperty(properties, path) {
     return [
       {
         message: 'Error model must contain property `code` of type string',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -176,8 +176,8 @@ function checkCodeProperty(properties, path) {
     return [
       {
         message: 'Error model must contain property `code` of type string',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -186,8 +186,8 @@ function checkCodeProperty(properties, path) {
       {
         message:
           'Error model property `code` must include an enumeration of the valid error codes',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -198,8 +198,8 @@ function checkCodeProperty(properties, path) {
       {
         message:
           'Error model property `code` must include an enumeration of the valid error codes',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -215,8 +215,8 @@ function checkMessageProperty(properties, path) {
     return [
       {
         message: 'Error model must contain property `message` of type string',
-        path
-      }
+        path,
+      },
     ];
   }
   return [];
@@ -232,8 +232,8 @@ function checkMoreInfoProperty(properties, path) {
       {
         message:
           'Error model should contain property `more_info` of type string',
-        path
-      }
+        path,
+      },
     ];
   }
   return [];
@@ -254,8 +254,8 @@ function checkTargetProperty(properties, path) {
       {
         message:
           'Error model property `target` must be a valid error target model object',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -269,12 +269,12 @@ function checkTargetProperty(properties, path) {
   if (!typeProp) {
     errors.push({
       message: 'Error target model must contain property `type` of type string',
-      path
+      path,
     });
   } else if (!isStringSchema(typeProp)) {
     errors.push({
       message: 'Error target model must contain property `type` of type string',
-      path: [...path, 'type']
+      path: [...path, 'type'],
     });
   } else {
     // We know that 'type' is a string property. Now make sure its enum complies.
@@ -284,19 +284,19 @@ function checkTargetProperty(properties, path) {
     if (!enumValue) {
       errors.push({
         message,
-        path: [...path, 'type']
+        path: [...path, 'type'],
       });
     } else if (!Array.isArray(enumValue)) {
       errors.push({
         message,
-        path: [...path, 'type', 'enum']
+        path: [...path, 'type', 'enum'],
       });
     } else {
       const validEnum = ['field', 'parameter', 'header'];
       if (!listsEqual(validEnum, enumValue)) {
         errors.push({
           message,
-          path: [...path, 'type', 'enum']
+          path: [...path, 'type', 'enum'],
         });
       }
     }
@@ -307,12 +307,12 @@ function checkTargetProperty(properties, path) {
   if (!nameProp) {
     errors.push({
       message: 'Error target model must contain property `name` of type string',
-      path
+      path,
     });
   } else if (!isStringSchema(nameProp)) {
     errors.push({
       message: 'Error target model must contain property `name` of type string',
-      path: [...path, 'name']
+      path: [...path, 'name'],
     });
   }
 

--- a/packages/ruleset/src/functions/etag-header-exists.js
+++ b/packages/ruleset/src/functions/etag-header-exists.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(pathItem, options, context) {
+module.exports = function (pathItem, options, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -49,8 +49,8 @@ function etagHeaderCheck(pathItem, path) {
       {
         message:
           'ETag response header is required, but no "get" operation is defined',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -84,7 +84,7 @@ function etagHeaderCheck(pathItem, path) {
           }
           errors.push({
             message: 'ETag response header is required',
-            path: errorPath
+            path: errorPath,
           });
         } else {
           logger.debug(`${ruleId}: found etag header!`);
@@ -99,7 +99,7 @@ function etagHeaderCheck(pathItem, path) {
     errors.push({
       message:
         'ETag response header is required, but "get" operation defines no success responses',
-      path: [...path, 'get']
+      path: [...path, 'get'],
     });
   }
 

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -54,5 +54,5 @@ module.exports = {
   securitySchemes: require('./securityschemes'),
   stringAttributes: require('./string-attributes'),
   unusedTags: require('./unused-tags'),
-  validatePathSegments: require('./valid-path-segments')
+  validatePathSegments: require('./valid-path-segments'),
 };

--- a/packages/ruleset/src/functions/inline-schema-rules.js
+++ b/packages/ruleset/src/functions/inline-schema-rules.js
@@ -6,20 +6,20 @@
 const {
   isArraySchema,
   isPrimitiveSchema,
-  validateSubschemas
+  validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const {
   getCompositeSchemaAttribute,
   isJsonMimeType,
   isEmptyObjectSchema,
-  isRefSiblingSchema
+  isRefSiblingSchema,
 } = require('../utils');
 
 module.exports = {
   inlinePropertySchema,
   inlineResponseSchema,
-  inlineRequestSchema
+  inlineRequestSchema,
 };
 
 /**
@@ -51,8 +51,8 @@ function inlineResponseSchema(schema, options, { path }) {
       {
         message:
           'Response schemas should be defined as a $ref to a named schema.',
-        path
-      }
+        path,
+      },
     ];
   }
 
@@ -92,8 +92,8 @@ function inlineRequestSchema(schema, options, { path }) {
       {
         message:
           'Request body schemas should be defined as a $ref to a named schema.',
-        path: errPath
-      }
+        path: errPath,
+      },
     ];
   }
 
@@ -178,8 +178,8 @@ function checkForInlineNestedObjectSchema(schema, path) {
   return [
     {
       message: 'Nested objects should be defined as a $ref to a named schema.',
-      path
-    }
+      path,
+    },
   ];
 }
 

--- a/packages/ruleset/src/functions/merge-patch-properties.js
+++ b/packages/ruleset/src/functions/merge-patch-properties.js
@@ -9,7 +9,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -39,8 +39,8 @@ function mergePatchOptionalProperties(schema, path) {
       {
         // The rule's description field is used as the error message.
         message: '',
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/operation-summary-exists.js
+++ b/packages/ruleset/src/functions/operation-summary-exists.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -27,8 +27,8 @@ function operationSummary(operation, path) {
         message: 'Each operation must have a non-empty summary.',
 
         // If the 'summary' field is defined, then include it in the error path.
-        path: 'summary' in operation ? [...path, 'summary'] : path
-      }
+        path: 'summary' in operation ? [...path, 'summary'] : path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/operationid-casing-convention.js
+++ b/packages/ruleset/src/functions/operationid-casing-convention.js
@@ -10,7 +10,7 @@ let casingConfig;
 let ruleId;
 let logger;
 
-module.exports = function(operation, options, context) {
+module.exports = function (operation, options, context) {
   // Save this rule's "functionOptions" value since we need
   // to pass it on to Spectral's "casing" function.
   casingConfig = options;

--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -9,7 +9,7 @@ const merge = require('lodash/merge');
 const each = require('lodash/each');
 const { operationMethods } = require('../utils');
 
-module.exports = function(rootDocument) {
+module.exports = function (rootDocument) {
   return operationIdNamingConvention(rootDocument);
 };
 
@@ -28,7 +28,7 @@ function operationIdNamingConvention(resolvedSpec) {
               pathKey: `${pathKey}`,
               opKey: `${opKey}`,
               path: ['paths', `${pathKey}`, `${opKey}`],
-              allPathOperations
+              allPathOperations,
             },
             op
           )
@@ -74,7 +74,7 @@ function operationIdNamingConvention(resolvedSpec) {
           message: `operationIds should follow naming convention: operationId verb should be ${verbs.join(
             ' or '
           )}`,
-          path: [...op.path, 'operationId']
+          path: [...op.path, 'operationId'],
         });
       }
     }

--- a/packages/ruleset/src/functions/optional-request-body.js
+++ b/packages/ruleset/src/functions/optional-request-body.js
@@ -5,7 +5,7 @@
 
 const { getCompositeSchemaAttribute } = require('../utils');
 
-module.exports = function(schema, _opts, { path }) {
+module.exports = function (schema, _opts, { path }) {
   return checkOptionalRequestBodySchema(schema, path);
 };
 
@@ -18,8 +18,8 @@ function checkOptionalRequestBodySchema(schema, path) {
         message: '',
 
         // Return the path to the requestBody, not the schema.
-        path: path.slice(0, 4)
-      }
+        path: path.slice(0, 4),
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/pagination-style.js
+++ b/packages/ruleset/src/functions/pagination-style.js
@@ -8,7 +8,7 @@ const { mergeAllOfSchemaProperties, LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(pathObj, _opts, context) {
+module.exports = function (pathObj, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -102,7 +102,7 @@ function paginationStyle(pathItem, path) {
     'token',
     'cursor',
     'page',
-    'page_token'
+    'page_token',
   ];
   const pageTokenParamIndex = params.findIndex(
     param =>
@@ -152,8 +152,8 @@ function paginationStyle(pathItem, path) {
           pathStr,
           'get',
           'parameters',
-          limitParamIndex.toString()
-        ]
+          limitParamIndex.toString(),
+        ],
       });
     }
   }
@@ -174,8 +174,8 @@ function paginationStyle(pathItem, path) {
           pathStr,
           'get',
           'parameters',
-          offsetParamIndex.toString()
-        ]
+          offsetParamIndex.toString(),
+        ],
       });
     }
   }
@@ -186,7 +186,7 @@ function paginationStyle(pathItem, path) {
   if (offsetParamIndex >= 0 && limitParamIndex < 0) {
     results.push({
       message: `The operation must define a "limit" query parameter if the "offset" query parameter is defined`,
-      path: ['paths', pathStr, 'get']
+      path: ['paths', pathStr, 'get'],
     });
   }
 
@@ -203,8 +203,8 @@ function paginationStyle(pathItem, path) {
           pathStr,
           'get',
           'parameters',
-          pageTokenParamIndex.toString()
-        ]
+          pageTokenParamIndex.toString(),
+        ],
       });
     }
     if (
@@ -219,8 +219,8 @@ function paginationStyle(pathItem, path) {
           pathStr,
           'get',
           'parameters',
-          pageTokenParamIndex.toString()
-        ]
+          pageTokenParamIndex.toString(),
+        ],
       });
     }
   }
@@ -245,7 +245,7 @@ function paginationStyle(pathItem, path) {
     successCode,
     'content',
     'application/json',
-    'schema'
+    'schema',
   ];
 
   // Check #5: If the operation defines the "limit" query param, then the response body must also
@@ -259,7 +259,7 @@ function paginationStyle(pathItem, path) {
       results.push({
         message:
           'A paginated list operation with a "limit" query parameter must include a "limit" property in the response body schema',
-        path: responseSchemaPath
+        path: responseSchemaPath,
       });
     } else if (
       limitProp.type !== 'integer' ||
@@ -269,7 +269,7 @@ function paginationStyle(pathItem, path) {
       results.push({
         message:
           'The "limit" property in the response body of a paginated list operation must be of type integer and required',
-        path: [...responseSchemaPath, 'properties', 'limit']
+        path: [...responseSchemaPath, 'properties', 'limit'],
       });
     }
   }
@@ -283,7 +283,7 @@ function paginationStyle(pathItem, path) {
       results.push({
         message:
           'A paginated list operation with an "offset" query parameter must include an "offset" property in the response body schema',
-        path: responseSchemaPath
+        path: responseSchemaPath,
       });
     } else if (
       offsetProp.type !== 'integer' ||
@@ -293,7 +293,7 @@ function paginationStyle(pathItem, path) {
       results.push({
         message:
           'The "offset" property in the response body of a paginated list operation must be of type integer and required',
-        path: [...responseSchemaPath, 'properties', 'offset']
+        path: [...responseSchemaPath, 'properties', 'offset'],
       });
     }
   }
@@ -327,7 +327,7 @@ function paginationStyle(pathItem, path) {
       results.push({
         message:
           'The "total_count" property in the response body of a paginated list operation must be of type integer and required',
-        path: [...responseSchemaPath, 'properties', 'total_count']
+        path: [...responseSchemaPath, 'properties', 'total_count'],
       });
     }
   }
@@ -385,13 +385,13 @@ function checkPageLink(path, responseSchema, name, isRequired) {
     ) {
       results.push({
         message: `The "${name}" property should be an object with an "href" string property`,
-        path: [...path, 'properties', name]
+        path: [...path, 'properties', name],
       });
     }
   } else if (isRequired) {
     results.push({
       message: `A paginated list operation should include a "${name}" property in the response body schema`,
-      path
+      path,
     });
   }
 

--- a/packages/ruleset/src/functions/parameter-casing-convention.js
+++ b/packages/ruleset/src/functions/parameter-casing-convention.js
@@ -10,7 +10,7 @@ const { isDeprecated, LoggerFactory } = require('../utils');
 const errorMsgPrefix = {
   query: 'Query parameter names ',
   path: 'Path parameter names ',
-  header: 'Header parameter names '
+  header: 'Header parameter names ',
 };
 
 const errorMsgNoName = 'Parameters must have a name';
@@ -19,7 +19,7 @@ const errorMsgNoIn = "Parameters must have a valid 'in' value";
 let ruleId;
 let logger;
 
-module.exports = function(param, options, context) {
+module.exports = function (param, options, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -55,7 +55,7 @@ function parameterCasingConvention(param, path, casingConfig) {
   if (!isNonEmptyString(param.name)) {
     errors.push({
       message: errorMsgNoName,
-      path
+      path,
     });
     hasName = false;
     logger.debug(`${ruleId}: param has no name!`);
@@ -63,7 +63,7 @@ function parameterCasingConvention(param, path, casingConfig) {
   if (!isNonEmptyString(param.in)) {
     errors.push({
       message: errorMsgNoIn,
-      path
+      path,
     });
     hasIn = false;
     logger.debug(`${ruleId}: param has no in!`);
@@ -71,10 +71,7 @@ function parameterCasingConvention(param, path, casingConfig) {
 
   // If we have 'name' and 'in' properties, then check for the proper casing.
   if (hasName && hasIn) {
-    const paramIn = param.in
-      .toString()
-      .trim()
-      .toLowerCase();
+    const paramIn = param.in.toString().trim().toLowerCase();
 
     // Retrieve the config for the appropriate param type and then use it
     // to invoke the casing() function.
@@ -91,7 +88,7 @@ function parameterCasingConvention(param, path, casingConfig) {
       if (result) {
         errors.push({
           message: msgPrefix + result[0].message,
-          path
+          path,
         });
         logger.debug(`${ruleId}: FAILED: ${JSON.stringify(result, null, 2)}`);
       } else {

--- a/packages/ruleset/src/functions/parameter-default.js
+++ b/packages/ruleset/src/functions/parameter-default.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(param, _opts, context) {
+module.exports = function (param, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -26,8 +26,8 @@ function parameterDefault(param, path) {
     return [
       {
         message: errorMsg,
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/parameter-description-exists.js
+++ b/packages/ruleset/src/functions/parameter-description-exists.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(param, _opts, context) {
+module.exports = function (param, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -28,8 +28,8 @@ function parameterDescription(param, path) {
     return [
       {
         message: 'Parameter should have a non-empty description',
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/parameter-order.js
+++ b/packages/ruleset/src/functions/parameter-order.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -40,7 +40,7 @@ function parameterOrder(op, path) {
           errors.push({
             message:
               'Required parameters should appear before optional parameters.',
-            path: [...path, 'parameters', index.toString()]
+            path: [...path, 'parameters', index.toString()],
           });
         }
       } else {

--- a/packages/ruleset/src/functions/patch-request-content-type.js
+++ b/packages/ruleset/src/functions/patch-request-content-type.js
@@ -6,13 +6,13 @@
 const {
   isJsonPatchMimeType,
   isMergePatchMimeType,
-  LoggerFactory
+  LoggerFactory,
 } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -63,7 +63,7 @@ function patchRequestContentType(operation, path) {
         logger.debug(`${ruleId}: unexpected content type: ${contentType}`);
         errors.push({
           message: '',
-          path: [...path, 'requestBody', 'content', contentType]
+          path: [...path, 'requestBody', 'content', contentType],
         });
       }
     }
@@ -90,8 +90,8 @@ function patchRequestContentType(operation, path) {
     return [
       {
         message: '',
-        path: errorPath
-      }
+        path: errorPath,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/path-parameter-not-crn.js
+++ b/packages/ruleset/src/functions/path-parameter-not-crn.js
@@ -5,14 +5,14 @@
 
 const {
   isStringSchema,
-  schemaHasConstraint
+  schemaHasConstraint,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(pathParam, _opts, context) {
+module.exports = function (pathParam, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -39,8 +39,8 @@ function pathParameterNotCRN(pathParam, path) {
     return [
       {
         message: 'Path parameter should not be defined as a CRN value',
-        path: [...path, ...subPath]
-      }
+        path: [...path, ...subPath],
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/path-segment-casing-convention.js
+++ b/packages/ruleset/src/functions/path-segment-casing-convention.js
@@ -10,7 +10,7 @@ let casingConfig;
 let ruleId;
 let logger;
 
-module.exports = function(pathItem, options, context) {
+module.exports = function (pathItem, options, context) {
   // Save this rule's "functionOptions" value since we need
   // to pass it on to Spectral's "casing" function.
   casingConfig = options;

--- a/packages/ruleset/src/functions/precondition-header.js
+++ b/packages/ruleset/src/functions/precondition-header.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -38,7 +38,7 @@ function preconditionHeader(operation, path) {
       'If-Match',
       'If-None-Match',
       'If-Modified-Since',
-      'If-Unmodified-Since'
+      'If-Unmodified-Since',
     ];
     let found = false;
     for (const k in operation.parameters) {
@@ -56,8 +56,8 @@ function preconditionHeader(operation, path) {
         {
           message:
             'An operation that returns a 412 status code must support at least one conditional header',
-          path: [...path, 'resonses']
-        }
+          path: [...path, 'resonses'],
+        },
       ];
     }
   }

--- a/packages/ruleset/src/functions/property-attributes.js
+++ b/packages/ruleset/src/functions/property-attributes.js
@@ -9,13 +9,13 @@ const {
   isIntegerSchema,
   isFloatSchema,
   isDoubleSchema,
-  isObjectSchema
+  isObjectSchema,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -50,7 +50,7 @@ function checkPropertyAttributes(schema, path) {
     if (schema.minimum && schema.maximum && schema.minimum > schema.maximum) {
       errors.push({
         message: 'minimum cannot be greater than maximum',
-        path: [...path, 'minimum']
+        path: [...path, 'minimum'],
       });
     }
   } else {
@@ -58,13 +58,13 @@ function checkPropertyAttributes(schema, path) {
     if (schema.minimum) {
       errors.push({
         message: 'minimum should not be defined for a non-numeric schema',
-        path: [...path, 'minimum']
+        path: [...path, 'minimum'],
       });
     }
     if (schema.maximum) {
       errors.push({
         message: 'maximum should not be defined for a non-numeric schema',
-        path: [...path, 'maximum']
+        path: [...path, 'maximum'],
       });
     }
   }
@@ -80,7 +80,7 @@ function checkPropertyAttributes(schema, path) {
     ) {
       errors.push({
         message: 'minProperties cannot be greater than maxProperties',
-        path: [...path, 'minProperties']
+        path: [...path, 'minProperties'],
       });
     }
   } else {
@@ -88,13 +88,13 @@ function checkPropertyAttributes(schema, path) {
     if (schema.minProperties) {
       errors.push({
         message: 'minProperties should not be defined for a non-object schema',
-        path: [...path, 'minProperties']
+        path: [...path, 'minProperties'],
       });
     }
     if (schema.maxProperties) {
       errors.push({
         message: 'maxProperties should not be defined for a non-object schema',
-        path: [...path, 'maxProperties']
+        path: [...path, 'maxProperties'],
       });
     }
   }

--- a/packages/ruleset/src/functions/property-casing-convention.js
+++ b/packages/ruleset/src/functions/property-casing-convention.js
@@ -11,7 +11,7 @@ let casingConfig;
 let ruleId;
 let logger;
 
-module.exports = function(schema, options, context) {
+module.exports = function (schema, options, context) {
   // Save this rule's "functionOptions" value since we need
   // to pass it on to Spectral's "casing" function.
   casingConfig = options;

--- a/packages/ruleset/src/functions/property-consistent-name-and-type.js
+++ b/packages/ruleset/src/functions/property-consistent-name-and-type.js
@@ -6,7 +6,7 @@
 const {
   getSchemaType,
   validateSubschemas,
-  SchemaType
+  SchemaType,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
@@ -19,7 +19,7 @@ let excludedProperties;
 let ruleId;
 let logger;
 
-module.exports = function(schema, options, context) {
+module.exports = function (schema, options, context) {
   excludedProperties = options.excludedProperties;
 
   if (!logger) {
@@ -62,14 +62,14 @@ function propertyConsistentNameAndType(schema, path) {
             visitedProperties[propName].flagged = true;
             errors.push({
               message: `Properties with the same name have inconsistent types: ${propName}.`,
-              path: visitedProperties[propName].path
+              path: visitedProperties[propName].path,
             });
           }
           // flag the rest of the properties that have the
           // same name but a different type as the first
           errors.push({
             message: `Properties with the same name have inconsistent types: ${propName}.`,
-            path: [...path, 'properties', propName]
+            path: [...path, 'properties', propName],
           });
         }
       } else {
@@ -80,7 +80,7 @@ function propertyConsistentNameAndType(schema, path) {
             visitedProperties[propName] = {
               type: propertyType,
               path: [...path, 'properties', propName],
-              flagged: false
+              flagged: false,
             };
             logger.debug(
               `${ruleId}: added property '${propName}' (type '${propertyType}') to cache.`

--- a/packages/ruleset/src/functions/property-description-exists.js
+++ b/packages/ruleset/src/functions/property-description-exists.js
@@ -5,14 +5,14 @@
 
 const {
   schemaHasConstraint,
-  validateSubschemas
+  validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory, pathMatchesRegexp } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -34,8 +34,8 @@ function propertyDescriptionExists(schema, path) {
     return [
       {
         message: 'Schema property should have a non-empty description',
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/property-name-collision.js
+++ b/packages/ruleset/src/functions/property-name-collision.js
@@ -9,7 +9,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -42,7 +42,7 @@ function propertyNameCollision(schema, path) {
       );
       errors.push({
         message: errorMsg,
-        path: [...path, 'properties', propName]
+        path: [...path, 'properties', propName],
       });
     } else {
       prevProps.push(caselessPropName);

--- a/packages/ruleset/src/functions/ref-pattern.js
+++ b/packages/ruleset/src/functions/ref-pattern.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function($ref, _opts, context) {
+module.exports = function ($ref, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -25,41 +25,42 @@ module.exports = function($ref, _opts, context) {
 // The entries of this object are ordered in descending order of presumed prevalence.
 const validRefPrefixes = {
   schemas: {
-    refPathRegex: /,((schema)|(properties,[^,]+)|(items)|(additionalProperties)|((allOf|anyOf|oneOf),\d+))$/,
-    prefix: '#/components/schemas/'
+    refPathRegex:
+      /,((schema)|(properties,[^,]+)|(items)|(additionalProperties)|((allOf|anyOf|oneOf),\d+))$/,
+    prefix: '#/components/schemas/',
   },
   parameters: {
     refPathRegex: /,parameters,\d+$/,
-    prefix: '#/components/parameters/'
+    prefix: '#/components/parameters/',
   },
   responses: {
     refPathRegex: /,responses,[^,]+$/,
-    prefix: '#/components/responses/'
+    prefix: '#/components/responses/',
   },
   requestBodies: {
     refPathRegex: /,requestBody$/,
-    prefix: '#/components/requestBodies/'
+    prefix: '#/components/requestBodies/',
   },
   links: {
     refPathRegex: /,links,[^,]+$/,
-    prefix: '#/components/links/'
+    prefix: '#/components/links/',
   },
   examples: {
     refPathRegex: /,examples,[^,]+$/,
-    prefix: '#/components/examples/'
+    prefix: '#/components/examples/',
   },
   headers: {
     refPathRegex: /,headers,[^,]+$/,
-    prefix: '#/components/headers/'
+    prefix: '#/components/headers/',
   },
   securitySchemes: {
     refPathRegex: /,securitySchemes,[^,]+$/,
-    prefix: '#/components/securitySchemes/'
+    prefix: '#/components/securitySchemes/',
   },
   callbacks: {
     refPathRegex: /,callbacks,[^,]+$/,
-    prefix: '#/components/callbacks/'
-  }
+    prefix: '#/components/callbacks/',
+  },
 };
 
 function checkRefPattern($ref, path) {
@@ -90,8 +91,8 @@ function checkRefPattern($ref, path) {
         return [
           {
             message: `$refs to ${refType} should start with '${entry.prefix}'`,
-            path
-          }
+            path,
+          },
         ];
       }
 

--- a/packages/ruleset/src/functions/ref-sibling-duplicate-description.js
+++ b/packages/ruleset/src/functions/ref-sibling-duplicate-description.js
@@ -9,7 +9,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -61,8 +61,8 @@ function checkDuplicateDescription(schema, path) {
     return [
       {
         message: 'Duplicate ref-sibling description is unnecessary',
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/requestbody-name-exists.js
+++ b/packages/ruleset/src/functions/requestbody-name-exists.js
@@ -9,13 +9,13 @@ const {
   isFormMimeType,
   isJsonPatchMimeType,
   isMergePatchMimeType,
-  LoggerFactory
+  LoggerFactory,
 } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -66,8 +66,8 @@ function requestBodyNameExists(op, path) {
       return [
         {
           message: `Operation with non-form requestBody should set a name with the ${EXTENSION_NAME} extension.`,
-          path
-        }
+          path,
+        },
       ];
     } else {
       logger.debug(`${ruleId}: found the extension!`);

--- a/packages/ruleset/src/functions/required-property.js
+++ b/packages/ruleset/src/functions/required-property.js
@@ -5,14 +5,14 @@
 
 const {
   schemaHasProperty,
-  validateSubschemas
+  validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -34,7 +34,7 @@ function checkRequiredProperties(schema, path) {
         '.'
       )}`
     );
-    schema.required.forEach(function(requiredPropName) {
+    schema.required.forEach(function (requiredPropName) {
       if (!schemaHasProperty(schema, requiredPropName)) {
         let message;
         if (schema.allOf) {
@@ -47,7 +47,7 @@ function checkRequiredProperties(schema, path) {
         logger.debug(`${ruleId}: Uh oh: ${message}`);
         errors.push({
           message,
-          path
+          path,
         });
       }
     });

--- a/packages/ruleset/src/functions/response-example-exists.js
+++ b/packages/ruleset/src/functions/response-example-exists.js
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-module.exports = function(response) {
+module.exports = function (response) {
   if (!responseLevelExamples(response) && !schemaLevelExample(response)) {
     return [
       {
-        message: 'Response bodies should include an example response'
-      }
+        message: 'Response bodies should include an example response',
+      },
     ];
   }
 };

--- a/packages/ruleset/src/functions/response-status-codes.js
+++ b/packages/ruleset/src/functions/response-status-codes.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(operation, _opts, context) {
+module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -58,7 +58,7 @@ function responseStatusCodes(operation, path, apidef) {
       errors.push({
         message:
           'Operation `responses` should use status code 400 instead of 422 for invalid request payloads.',
-        path: [...path, 'responses', '422']
+        path: [...path, 'responses', '422'],
       });
     }
 
@@ -67,7 +67,7 @@ function responseStatusCodes(operation, path, apidef) {
       errors.push({
         message:
           'Operation `responses` should use status code 303 or 307 instead of 302.',
-        path: [...path, 'responses', '302']
+        path: [...path, 'responses', '302'],
       });
     }
 
@@ -76,7 +76,7 @@ function responseStatusCodes(operation, path, apidef) {
       errors.push({
         message:
           'Operation `responses` should include at least one success status code (2xx).',
-        path: [...path, 'responses']
+        path: [...path, 'responses'],
       });
     }
 
@@ -85,7 +85,7 @@ function responseStatusCodes(operation, path, apidef) {
       errors.push({
         message:
           'Operation `responses` should not include status code 101 when success status codes (2xx) are present.',
-        path: [...path, 'responses', '101']
+        path: [...path, 'responses', '101'],
       });
     }
 
@@ -95,7 +95,7 @@ function responseStatusCodes(operation, path, apidef) {
       errors.push({
         message:
           'A 204 response must not include a response body. Use a different status code for responses with content.',
-        path: [...path, 'responses', '204', 'content']
+        path: [...path, 'responses', '204', 'content'],
       });
     }
 
@@ -106,7 +106,7 @@ function responseStatusCodes(operation, path, apidef) {
         errors.push({
           message:
             "A 201 or 202 status code should be returned by a 'create' operation.",
-          path: [...path, 'responses']
+          path: [...path, 'responses'],
         });
       }
     }
@@ -116,7 +116,7 @@ function responseStatusCodes(operation, path, apidef) {
       errors.push({
         message:
           'An operation that returns a 202 status code should not return any other 2xx status codes.',
-        path: [...path, 'responses']
+        path: [...path, 'responses'],
       });
     }
   }
@@ -136,20 +136,13 @@ function isCreateOperation(operation, path, apidef) {
   // 1. If operationId starts with "create", we'll assume it's a create operation.
   if (
     operation.operationId &&
-    operation.operationId
-      .toString()
-      .trim()
-      .toLowerCase()
-      .startsWith('create')
+    operation.operationId.toString().trim().toLowerCase().startsWith('create')
   ) {
     return true;
   }
 
   // 2. If not a POST, then it's not a create operation.
-  const method = path[path.length - 1]
-    .toString()
-    .trim()
-    .toLowerCase();
+  const method = path[path.length - 1].toString().trim().toLowerCase();
   if (method !== 'post') {
     return false;
   }

--- a/packages/ruleset/src/functions/schema-description-exists.js
+++ b/packages/ruleset/src/functions/schema-description-exists.js
@@ -5,14 +5,14 @@
 
 const {
   validateSubschemas,
-  schemaHasConstraint
+  schemaHasConstraint,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory, pathMatchesRegexp } = require('../utils');
 
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -46,8 +46,8 @@ function schemaDescriptionExists(schema, path) {
       return [
         {
           message: 'Schema should have a non-empty description',
-          path
-        }
+          path,
+        },
       ];
     }
   }

--- a/packages/ruleset/src/functions/schema-or-content-provided.js
+++ b/packages/ruleset/src/functions/schema-or-content-provided.js
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-module.exports = function(obj) {
+module.exports = function (obj) {
   if (!obj.schema && !obj.content) {
     return [
       {
-        message: 'Parameter must provide either a schema or content'
-      }
+        message: 'Parameter must provide either a schema or content',
+      },
     ];
   }
 };

--- a/packages/ruleset/src/functions/schema-type-exists.js
+++ b/packages/ruleset/src/functions/schema-type-exists.js
@@ -9,7 +9,7 @@ const { LoggerFactory, mergeAllOfSchemaProperties } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -40,8 +40,8 @@ function schemaTypeExists(schema, path) {
     return [
       {
         message: 'Schema should have a non-empty `type` field.',
-        path
-      }
+        path,
+      },
     ];
   }
 

--- a/packages/ruleset/src/functions/schema-type-format.js
+++ b/packages/ruleset/src/functions/schema-type-format.js
@@ -13,7 +13,7 @@ const validTypes = [
   'integer',
   'number',
   'object',
-  'string'
+  'string',
 ];
 
 // Valid format values for selected schema types.
@@ -29,7 +29,7 @@ const validStringFormats = [
   'identifier',
   'password',
   'url',
-  'uuid'
+  'uuid',
 ];
 
 // Pre-define some error messages that we can re-use later.
@@ -50,7 +50,7 @@ const stringFormatErrorMsg = `Schema of type string should use one of the follow
 let ruleId;
 let logger;
 
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -74,7 +74,7 @@ function typeFormatErrors(schema, path) {
     if (schema.format) {
       errors.push({
         message: formatButNoTypeErrorMsg,
-        path
+        path,
       });
     }
   } else if (typeof schema.type === 'string') {
@@ -86,7 +86,7 @@ function typeFormatErrors(schema, path) {
     if (!validTypes.includes(schema.type.toLowerCase())) {
       errors.push({
         message: invalidTypeErrorMsg,
-        path
+        path,
       });
     } else {
       // Type is valid, let's make sure format is valid for this type.
@@ -98,7 +98,7 @@ function typeFormatErrors(schema, path) {
           ) {
             errors.push({
               message: integerFormatErrorMsg,
-              path
+              path,
             });
           }
           break;
@@ -109,7 +109,7 @@ function typeFormatErrors(schema, path) {
           ) {
             errors.push({
               message: numberFormatErrorMsg,
-              path
+              path,
             });
           }
           break;
@@ -120,7 +120,7 @@ function typeFormatErrors(schema, path) {
           ) {
             errors.push({
               message: stringFormatErrorMsg,
-              path
+              path,
             });
           }
           break;
@@ -131,7 +131,7 @@ function typeFormatErrors(schema, path) {
           if (schema.format !== undefined) {
             errors.push({
               message: `Schema of type ${schema.type} should not have a format.`,
-              path
+              path,
             });
           }
           break;

--- a/packages/ruleset/src/functions/securityscheme-attributes.js
+++ b/packages/ruleset/src/functions/securityscheme-attributes.js
@@ -9,7 +9,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(securityScheme, _opts, context) {
+module.exports = function (securityScheme, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -58,21 +58,21 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
   if (!type) {
     errors.push({
       message: `security scheme is missing required property: type`,
-      path
+      path,
     });
   } else if (!validTypes.includes(type)) {
     errors.push({
       message: `security scheme 'type' property must be one of: ${validTypes.join(
         ', '
       )}`,
-      path: [...path, 'type']
+      path: [...path, 'type'],
     });
   } else if (type === HTTP) {
     // http validation
     if (!securityScheme.scheme) {
       errors.push({
         message: `security scheme with type '${HTTP}' is missing required property: scheme`,
-        path
+        path,
       });
     }
   } else if (type === API_KEY) {
@@ -81,21 +81,21 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
     if (!authIn) {
       errors.push({
         message: `security scheme with type '${API_KEY}' is missing required property: in`,
-        path
+        path,
       });
     } else if (!validIns.includes(authIn)) {
       errors.push({
         message: `security scheme 'in' property must be one of: ${validIns.join(
           ', '
         )}`,
-        path: [...path, 'in']
+        path: [...path, 'in'],
       });
     }
 
     if (!securityScheme.name) {
       errors.push({
         message: `security scheme with type '${API_KEY}' is missing required property: name`,
-        path
+        path,
       });
     }
   } else if (type == OPENID_CONNECT) {
@@ -104,12 +104,12 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
     if (!openIdConnectUrl) {
       errors.push({
         message: `security scheme with type '${OPENID_CONNECT}' is missing required property: openIdConnectUrl`,
-        path
+        path,
       });
     } else if (!isValidUrl(openIdConnectUrl, serviceUrl)) {
       errors.push({
         message: `security scheme 'openIdConnectUrl' property must be a valid URL`,
-        path: [...path, 'openIdConnectUrl']
+        path: [...path, 'openIdConnectUrl'],
       });
     }
   } else if (type === OAUTH2) {
@@ -118,7 +118,7 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
     if (!flows) {
       errors.push({
         message: `security scheme with type '${OAUTH2}' is missing required property: flows`,
-        path
+        path,
       });
     } else {
       // Validate the flows object.
@@ -132,7 +132,7 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
       ) {
         errors.push({
           message: `oauth2 flow object must specify one or more of the following properties: implicit, password, clientCredentials or authorizationCode`,
-          path: [...path, 'flows']
+          path: [...path, 'flows'],
         });
       }
 
@@ -142,31 +142,31 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
         if (!flow.tokenUrl) {
           errors.push({
             message: `oauth2 'authorizationCode' flow is missing required property: tokenUrl`,
-            path: [...path, 'flows', 'authorizationCode']
+            path: [...path, 'flows', 'authorizationCode'],
           });
         } else if (!isValidUrl(flow.tokenUrl, serviceUrl)) {
           errors.push({
             message: `security scheme 'tokenUrl' property must be a valid URL`,
-            path: [...path, 'flows', 'authorizationCode', 'tokenUrl']
+            path: [...path, 'flows', 'authorizationCode', 'tokenUrl'],
           });
         }
 
         if (!flow.authorizationUrl) {
           errors.push({
             message: `oauth2 'authorizationCode' flow is missing required property: authorizationUrl`,
-            path: [...path, 'flows', 'authorizationCode']
+            path: [...path, 'flows', 'authorizationCode'],
           });
         } else if (!isValidUrl(flow.authorizationUrl, serviceUrl)) {
           errors.push({
             message: `security scheme 'authorizationUrl' property must be a valid URL`,
-            path: [...path, 'flows', 'authorizationCode', 'authorizationUrl']
+            path: [...path, 'flows', 'authorizationCode', 'authorizationUrl'],
           });
         }
 
         if (!flow.scopes) {
           errors.push({
             message: `oauth2 'authorizationCode' flow is missing required property: scopes`,
-            path: [...path, 'flows', 'authorizationCode']
+            path: [...path, 'flows', 'authorizationCode'],
           });
         }
       }
@@ -177,19 +177,19 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
         if (!flow.tokenUrl) {
           errors.push({
             message: `oauth2 'password' flow is missing required property: tokenUrl`,
-            path: [...path, 'flows', 'password']
+            path: [...path, 'flows', 'password'],
           });
         } else if (!isValidUrl(flow.tokenUrl, serviceUrl)) {
           errors.push({
             message: `security scheme 'tokenUrl' property must be a valid URL`,
-            path: [...path, 'flows', 'password', 'tokenUrl']
+            path: [...path, 'flows', 'password', 'tokenUrl'],
           });
         }
 
         if (!flow.scopes) {
           errors.push({
             message: `oauth2 'password' flow is missing required property: scopes`,
-            path: [...path, 'flows', 'password']
+            path: [...path, 'flows', 'password'],
           });
         }
       }
@@ -200,19 +200,19 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
         if (!flow.tokenUrl) {
           errors.push({
             message: `oauth2 'clientCredentials' flow is missing required property: tokenUrl`,
-            path: [...path, 'flows', 'clientCredentials']
+            path: [...path, 'flows', 'clientCredentials'],
           });
         } else if (!isValidUrl(flow.tokenUrl, serviceUrl)) {
           errors.push({
             message: `security scheme 'tokenUrl' property must be a valid URL`,
-            path: [...path, 'flows', 'clientCredentials', 'tokenUrl']
+            path: [...path, 'flows', 'clientCredentials', 'tokenUrl'],
           });
         }
 
         if (!flow.scopes) {
           errors.push({
             message: `oauth2 'clientCredentials' flow is missing required property: scopes`,
-            path: [...path, 'flows', 'clientCredentials']
+            path: [...path, 'flows', 'clientCredentials'],
           });
         }
       }
@@ -223,19 +223,19 @@ function checkSecuritySchemeAttributes(securityScheme, path, doc) {
         if (!flow.authorizationUrl) {
           errors.push({
             message: `oauth2 'implicit' flow is missing required property: authorizationUrl`,
-            path: [...path, 'flows', 'implicit']
+            path: [...path, 'flows', 'implicit'],
           });
         } else if (!isValidUrl(flow.authorizationUrl, serviceUrl)) {
           errors.push({
             message: `security scheme 'authorizationUrl' property must be a valid URL`,
-            path: [...path, 'flows', 'implicit', 'authorizationUrl']
+            path: [...path, 'flows', 'implicit', 'authorizationUrl'],
           });
         }
 
         if (!flow.scopes) {
           errors.push({
             message: `oauth2 'implicit' flow is missing required property: scopes`,
-            path: [...path, 'flows', 'implicit']
+            path: [...path, 'flows', 'implicit'],
           });
         }
       }

--- a/packages/ruleset/src/functions/securityschemes.js
+++ b/packages/ruleset/src/functions/securityschemes.js
@@ -8,7 +8,7 @@ const { LoggerFactory, operationMethods } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(rootDocument, _opts, context) {
+module.exports = function (rootDocument, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -67,7 +67,7 @@ function checkSecuritySchemes(rootDocument) {
       const usageEntry = {
         used: false,
         type: scheme.type,
-        scopeUsage: {}
+        scopeUsage: {},
       };
 
       // If applicable, set up the "scopeUsage" object for any scopes that are defined.
@@ -83,7 +83,7 @@ function checkSecuritySchemes(rootDocument) {
               if (!usageEntry.scopeUsage[scope]) {
                 usageEntry.scopeUsage[scope] = {
                   used: false,
-                  flow: flowType
+                  flow: flowType,
                 };
               }
             }
@@ -129,7 +129,7 @@ function checkSecuritySchemes(rootDocument) {
               'paths',
               pathStr,
               methodName,
-              'security'
+              'security',
             ])
           );
         }
@@ -146,7 +146,7 @@ function checkSecuritySchemes(rootDocument) {
       );
       errors.push({
         message: 'A security scheme is defined but never used',
-        path: ['components', 'securitySchemes', schemeName]
+        path: ['components', 'securitySchemes', schemeName],
       });
     }
 
@@ -163,8 +163,8 @@ function checkSecuritySchemes(rootDocument) {
             'flows',
             scopeUsageEntry.flow,
             'scopes',
-            scope
-          ]
+            scope,
+          ],
         });
       }
     }
@@ -217,8 +217,8 @@ function recordUsage(securityList, usageInfo, path) {
                     ...path,
                     securityIndex.toString(),
                     schemeName,
-                    scopeIndex
-                  ]
+                    scopeIndex,
+                  ],
                 });
               }
             }
@@ -231,7 +231,7 @@ function recordUsage(securityList, usageInfo, path) {
             errors.push({
               message:
                 'For security scheme types that do not support scopes, the value must be an empty array',
-              path: [...path, securityIndex.toString(), schemeName]
+              path: [...path, securityIndex.toString(), schemeName],
             });
           }
         }
@@ -241,7 +241,7 @@ function recordUsage(securityList, usageInfo, path) {
         );
         errors.push({
           message: 'An undefined security scheme is referenced',
-          path: [...path, securityIndex.toString(), schemeName]
+          path: [...path, securityIndex.toString(), schemeName],
         });
       }
     }

--- a/packages/ruleset/src/functions/string-attributes.js
+++ b/packages/ruleset/src/functions/string-attributes.js
@@ -6,14 +6,14 @@
 const {
   schemaHasConstraint,
   isStringSchema,
-  validateNestedSchemas
+  validateNestedSchemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const { getCompositeSchemaAttribute, LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
-module.exports = function(schema, _opts, context) {
+module.exports = function (schema, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -32,7 +32,7 @@ module.exports = function(schema, _opts, context) {
 const bypassFormats = {
   pattern: ['binary', 'byte', 'date', 'date-time', 'url'],
   minLength: ['date', 'identifier', 'url'],
-  maxLength: ['date']
+  maxLength: ['date'],
 };
 
 /**
@@ -63,19 +63,19 @@ function stringBoundaryErrors(schema, path) {
       if (!isDefined(pattern) && !bypassFormats.pattern.includes(format)) {
         errors.push({
           message: 'Should define a pattern for a valid string',
-          path
+          path,
         });
       }
       if (!isDefined(minLength) && !bypassFormats.minLength.includes(format)) {
         errors.push({
           message: 'Should define a minLength for a valid string',
-          path
+          path,
         });
       }
       if (!isDefined(maxLength) && !bypassFormats.maxLength.includes(format)) {
         errors.push({
           message: 'Should define a maxLength for a valid string',
-          path
+          path,
         });
       }
       if (
@@ -85,7 +85,7 @@ function stringBoundaryErrors(schema, path) {
       ) {
         errors.push({
           message: 'minLength cannot be greater than maxLength',
-          path
+          path,
         });
       }
     }
@@ -94,19 +94,19 @@ function stringBoundaryErrors(schema, path) {
     if (schemaContainsAttribute(schema, 'pattern')) {
       errors.push({
         message: 'pattern should not be defined for a non-string schema',
-        path: [...path, 'pattern']
+        path: [...path, 'pattern'],
       });
     }
     if (schemaContainsAttribute(schema, 'minLength')) {
       errors.push({
         message: 'minLength should not be defined for a non-string schema',
-        path: [...path, 'minLength']
+        path: [...path, 'minLength'],
       });
     }
     if (schemaContainsAttribute(schema, 'maxLength')) {
       errors.push({
         message: 'maxLength should not be defined for a non-string schema',
-        path: [...path, 'maxLength']
+        path: [...path, 'maxLength'],
       });
     }
   }

--- a/packages/ruleset/src/functions/unused-tags.js
+++ b/packages/ruleset/src/functions/unused-tags.js
@@ -8,7 +8,7 @@ const { LoggerFactory, operationMethods } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(rootDocument, _opts, context) {
+module.exports = function (rootDocument, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -66,7 +66,7 @@ function checkUnusedTags(rootDocument) {
       logger.debug(`${ruleId}: tag '${globalTags[i].name} is unused!`);
       errors.push({
         message: `A tag is defined but never used: ${globalTags[i].name}`,
-        path: ['tags', i.toString()]
+        path: ['tags', i.toString()],
       });
     }
   }

--- a/packages/ruleset/src/functions/valid-path-segments.js
+++ b/packages/ruleset/src/functions/valid-path-segments.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function(pathItem, options, context) {
+module.exports = function (pathItem, options, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -50,7 +50,7 @@ function validatePathSegments(path) {
         logger.debug(`${ruleId}: path segment failed check: '${segment}'`);
         errors.push({
           message: `Invalid path parameter reference within path segment: ${segment}`,
-          path
+          path,
         });
       }
     }

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -163,6 +163,6 @@ module.exports = {
     'ibm-string-attributes': ibmRules.stringAttributes,
     'ibm-summary-sentence-style': ibmRules.summarySentenceStyle,
     'ibm-unused-tags': ibmRules.unusedTags,
-    'ibm-valid-path-segments': ibmRules.validPathSegments
-  }
+    'ibm-valid-path-segments': ibmRules.validPathSegments,
+  },
 };

--- a/packages/ruleset/src/rules/accept-header.js
+++ b/packages/ruleset/src/rules/accept-header.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { disallowedHeaderParameter } = require('../functions');
@@ -19,7 +19,7 @@ module.exports = {
   then: {
     function: disallowedHeaderParameter,
     functionOptions: {
-      headerName: 'Accept'
-    }
-  }
+      headerName: 'Accept',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/array-attributes.js
+++ b/packages/ruleset/src/rules/array-attributes.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { arrayAttributes } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   resolved: true,
   given: schemas,
   then: {
-    function: arrayAttributes
-  }
+    function: arrayAttributes,
+  },
 };

--- a/packages/ruleset/src/rules/array-of-arrays.js
+++ b/packages/ruleset/src/rules/array-of-arrays.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { arrayOfArrays } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: arrayOfArrays
-  }
+    function: arrayOfArrays,
+  },
 };

--- a/packages/ruleset/src/rules/array-responses.js
+++ b/packages/ruleset/src/rules/array-responses.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { arrayResponses } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: arrayResponses
-  }
+    function: arrayResponses,
+  },
 };

--- a/packages/ruleset/src/rules/authorization-header.js
+++ b/packages/ruleset/src/rules/authorization-header.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { disallowedHeaderParameter } = require('../functions');
@@ -19,7 +19,7 @@ module.exports = {
   then: {
     function: disallowedHeaderParameter,
     functionOptions: {
-      headerName: 'Authorization'
-    }
-  }
+      headerName: 'Authorization',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/binary-schemas.js
+++ b/packages/ruleset/src/rules/binary-schemas.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { binarySchemas } = require('../functions');
@@ -21,6 +21,6 @@ module.exports = {
   severity: 'warn',
   resolved: true,
   then: {
-    function: binarySchemas
-  }
+    function: binarySchemas,
+  },
 };

--- a/packages/ruleset/src/rules/circular-refs.js
+++ b/packages/ruleset/src/rules/circular-refs.js
@@ -14,6 +14,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: circularRefs
-  }
+    function: circularRefs,
+  },
 };

--- a/packages/ruleset/src/rules/collection-array-property.js
+++ b/packages/ruleset/src/rules/collection-array-property.js
@@ -16,6 +16,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: collectionArrayProperty
-  }
+    function: collectionArrayProperty,
+  },
 };

--- a/packages/ruleset/src/rules/consecutive-path-segments.js
+++ b/packages/ruleset/src/rules/consecutive-path-segments.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  paths
+  paths,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { consecutivePathSegments } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   severity: 'error',
   resolved: true,
   then: {
-    function: consecutivePathSegments
-  }
+    function: consecutivePathSegments,
+  },
 };

--- a/packages/ruleset/src/rules/content-contains-schema.js
+++ b/packages/ruleset/src/rules/content-contains-schema.js
@@ -11,12 +11,12 @@ module.exports = {
   formats: [oas3],
   given: [
     '$.paths[*][post,put,patch].requestBody.content[*]',
-    '$.paths[*][get,post,put,patch,delete][parameters,responses][*].content[*]'
+    '$.paths[*][get,post,put,patch,delete][parameters,responses][*].content[*]',
   ],
   severity: 'warn',
   resolved: true,
   then: {
     field: 'schema',
-    function: truthy
-  }
+    function: truthy,
+  },
 };

--- a/packages/ruleset/src/rules/content-exists.js
+++ b/packages/ruleset/src/rules/content-exists.js
@@ -11,13 +11,13 @@ module.exports = {
     'Request bodies and non-204 responses should define a content object',
   given: [
     "$.paths[*][get,post,put,patch,delete].responses[?(@property != '204' && @property != '202' && @property != '101' && @property != '304')]",
-    '$.paths[*][*].requestBody'
+    '$.paths[*][*].requestBody',
   ],
   severity: 'warn',
   formats: [oas3],
   resolved: true,
   then: {
     field: 'content',
-    function: truthy
-  }
+    function: truthy,
+  },
 };

--- a/packages/ruleset/src/rules/content-type-header.js
+++ b/packages/ruleset/src/rules/content-type-header.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { disallowedHeaderParameter } = require('../functions');
@@ -19,7 +19,7 @@ module.exports = {
   then: {
     function: disallowedHeaderParameter,
     functionOptions: {
-      headerName: 'Content-Type'
-    }
-  }
+      headerName: 'Content-Type',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/content-type-is-specific.js
+++ b/packages/ruleset/src/rules/content-type-is-specific.js
@@ -13,10 +13,10 @@ module.exports = {
   resolved: true,
   given: [
     '$.paths[*][*][parameters,responses][*].content',
-    '$.paths[*][*][requestBody].content'
+    '$.paths[*][*][requestBody].content',
   ],
   then: {
     field: '*/*',
-    function: falsy
-  }
+    function: falsy,
+  },
 };

--- a/packages/ruleset/src/rules/delete-body.js
+++ b/packages/ruleset/src/rules/delete-body.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { deleteBody } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   resolved: true,
   given: operations,
   then: {
-    function: deleteBody
-  }
+    function: deleteBody,
+  },
 };

--- a/packages/ruleset/src/rules/description-mentions-json.js
+++ b/packages/ruleset/src/rules/description-mentions-json.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { descriptionMentionsJSON } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: descriptionMentionsJSON
-  }
+    function: descriptionMentionsJSON,
+  },
 };

--- a/packages/ruleset/src/rules/discriminator-property-exists.js
+++ b/packages/ruleset/src/rules/discriminator-property-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { discriminatorPropertyExists } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: discriminatorPropertyExists
-  }
+    function: discriminatorPropertyExists,
+  },
 };

--- a/packages/ruleset/src/rules/duplicate-path-parameter.js
+++ b/packages/ruleset/src/rules/duplicate-path-parameter.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  paths
+  paths,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { duplicatePathParameter } = require('../functions');
@@ -16,6 +16,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: duplicatePathParameter
-  }
+    function: duplicatePathParameter,
+  },
 };

--- a/packages/ruleset/src/rules/enum-casing-convention.js
+++ b/packages/ruleset/src/rules/enum-casing-convention.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { enumCasingConvention } = require('../functions');
@@ -18,7 +18,7 @@ module.exports = {
   then: {
     function: enumCasingConvention,
     functionOptions: {
-      type: 'snake'
-    }
-  }
+      type: 'snake',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/error-content-type-is-json.js
+++ b/packages/ruleset/src/rules/error-content-type-is-json.js
@@ -12,10 +12,10 @@ module.exports = {
   severity: 'warn',
   resolved: true,
   given: [
-    '$.paths[*][*].responses[?(@property >= 400 && @property < 600)].content'
+    '$.paths[*][*].responses[?(@property >= 400 && @property < 600)].content',
   ],
   then: {
     field: 'application/json',
-    function: truthy
-  }
+    function: truthy,
+  },
 };

--- a/packages/ruleset/src/rules/error-response-schemas.js
+++ b/packages/ruleset/src/rules/error-response-schemas.js
@@ -16,6 +16,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: errorResponseSchemas
-  }
+    function: errorResponseSchemas,
+  },
 };

--- a/packages/ruleset/src/rules/etag-header-exists.js
+++ b/packages/ruleset/src/rules/etag-header-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  paths
+  paths,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { etagHeaderExists } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: etagHeaderExists
-  }
+    function: etagHeaderExists,
+  },
 };

--- a/packages/ruleset/src/rules/examples-name-contains-space.js
+++ b/packages/ruleset/src/rules/examples-name-contains-space.js
@@ -16,7 +16,7 @@ module.exports = {
   then: {
     function: pattern,
     functionOptions: {
-      notMatch: '^(.*\\s+.*)+$'
-    }
-  }
+      notMatch: '^(.*\\s+.*)+$',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/ibm-sdk-operations.js
+++ b/packages/ruleset/src/rules/ibm-sdk-operations.js
@@ -17,8 +17,8 @@ module.exports = {
     function: schema,
     functionOptions: {
       schema: {
-        $ref: '../schemas/x-sdk-operations.json'
-      }
-    }
-  }
+        $ref: '../schemas/x-sdk-operations.json',
+      },
+    },
+  },
 };

--- a/packages/ruleset/src/rules/if-modified-since-header.js
+++ b/packages/ruleset/src/rules/if-modified-since-header.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { disallowedHeaderParameter } = require('../functions');
@@ -20,7 +20,7 @@ module.exports = {
   then: {
     function: disallowedHeaderParameter,
     functionOptions: {
-      headerName: 'If-Modified-Since'
-    }
-  }
+      headerName: 'If-Modified-Since',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/if-unmodified-since-header.js
+++ b/packages/ruleset/src/rules/if-unmodified-since-header.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { disallowedHeaderParameter } = require('../functions');
@@ -20,7 +20,7 @@ module.exports = {
   then: {
     function: disallowedHeaderParameter,
     functionOptions: {
-      headerName: 'If-Unmodified-Since'
-    }
-  }
+      headerName: 'If-Unmodified-Since',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -69,5 +69,5 @@ module.exports = {
   summarySentenceStyle: require('./summary-sentence-style'),
   unusedTags: require('./unused-tags'),
   validPathSegments: require('./valid-path-segments'),
-  schemaTypeFormat: require('./schema-type-format')
+  schemaTypeFormat: require('./schema-type-format'),
 };

--- a/packages/ruleset/src/rules/inline-property-schema.js
+++ b/packages/ruleset/src/rules/inline-property-schema.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  unresolvedSchemas
+  unresolvedSchemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { inlinePropertySchema } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   severity: 'warn',
   resolved: false,
   then: {
-    function: inlinePropertySchema
-  }
+    function: inlinePropertySchema,
+  },
 };

--- a/packages/ruleset/src/rules/inline-request-schema.js
+++ b/packages/ruleset/src/rules/inline-request-schema.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  unresolvedRequestBodySchemas
+  unresolvedRequestBodySchemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { inlineRequestSchema } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   severity: 'warn',
   resolved: false,
   then: {
-    function: inlineRequestSchema
-  }
+    function: inlineRequestSchema,
+  },
 };

--- a/packages/ruleset/src/rules/inline-response-schema.js
+++ b/packages/ruleset/src/rules/inline-response-schema.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  unresolvedResponseSchemas
+  unresolvedResponseSchemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { inlineResponseSchema } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   severity: 'warn',
   resolved: false,
   then: {
-    function: inlineResponseSchema
-  }
+    function: inlineResponseSchema,
+  },
 };

--- a/packages/ruleset/src/rules/major-version-in-path.js
+++ b/packages/ruleset/src/rules/major-version-in-path.js
@@ -14,6 +14,6 @@ module.exports = {
   given: '$',
   severity: 'warn',
   then: {
-    function: checkMajorVersion
-  }
+    function: checkMajorVersion,
+  },
 };

--- a/packages/ruleset/src/rules/merge-patch-properties.js
+++ b/packages/ruleset/src/rules/merge-patch-properties.js
@@ -12,12 +12,12 @@ module.exports = {
   message: '{{description}}',
   given: [
     // This expression should visit the request body schema for each "merge-patch" type operation.
-    '$.paths[*][patch].requestBody.content[?(@property.match(/^application\\/merge-patch\\+json(;.*)*/))].schema'
+    '$.paths[*][patch].requestBody.content[?(@property.match(/^application\\/merge-patch\\+json(;.*)*/))].schema',
   ],
   severity: 'warn',
   formats: [oas3],
   resolved: true,
   then: {
-    function: mergePatchProperties
-  }
+    function: mergePatchProperties,
+  },
 };

--- a/packages/ruleset/src/rules/operation-summary-exists.js
+++ b/packages/ruleset/src/rules/operation-summary-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { operationSummaryExists } = require('../functions');
@@ -16,6 +16,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: operationSummaryExists
-  }
+    function: operationSummaryExists,
+  },
 };

--- a/packages/ruleset/src/rules/operationid-casing-convention.js
+++ b/packages/ruleset/src/rules/operationid-casing-convention.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { operationIdCasingConvention } = require('../functions');
@@ -18,7 +18,7 @@ module.exports = {
   then: {
     function: operationIdCasingConvention,
     functionOptions: {
-      type: 'snake'
-    }
-  }
+      type: 'snake',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/operationid-naming-convention.js
+++ b/packages/ruleset/src/rules/operationid-naming-convention.js
@@ -14,6 +14,6 @@ module.exports = {
   formats: [oas2, oas3],
   resolved: true,
   then: {
-    function: operationIdNamingConvention
-  }
+    function: operationIdNamingConvention,
+  },
 };

--- a/packages/ruleset/src/rules/optional-request-body.js
+++ b/packages/ruleset/src/rules/optional-request-body.js
@@ -16,6 +16,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: optionalRequestBody
-  }
+    function: optionalRequestBody,
+  },
 };

--- a/packages/ruleset/src/rules/pagination-style.js
+++ b/packages/ruleset/src/rules/pagination-style.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  paths
+  paths,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { paginationStyle } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: paginationStyle
-  }
+    function: paginationStyle,
+  },
 };

--- a/packages/ruleset/src/rules/parameter-casing-convention.js
+++ b/packages/ruleset/src/rules/parameter-casing-convention.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { parameterCasingConvention } = require('../functions');
@@ -33,22 +33,22 @@ module.exports = {
       query: {
         type: 'snake',
         separator: {
-          char: '.'
-        }
+          char: '.',
+        },
       },
 
       // Allow snake case for path parameter names.
       path: {
-        type: 'snake'
+        type: 'snake',
       },
 
       // Allow header parameter names to be in canonical header name form (e.g. X-My-Header).
       header: {
         type: 'pascal',
         separator: {
-          char: '-'
-        }
-      }
-    }
-  }
+          char: '-',
+        },
+      },
+    },
+  },
 };

--- a/packages/ruleset/src/rules/parameter-default.js
+++ b/packages/ruleset/src/rules/parameter-default.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas2, oas3 } = require('@stoplight/spectral-formats');
 const { parameterDefault } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas2, oas3],
   resolved: true,
   then: {
-    function: parameterDefault
-  }
+    function: parameterDefault,
+  },
 };

--- a/packages/ruleset/src/rules/parameter-description-exists.js
+++ b/packages/ruleset/src/rules/parameter-description-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  parameters
+  parameters,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { parameterDescriptionExists } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: parameterDescriptionExists
-  }
+    function: parameterDescriptionExists,
+  },
 };

--- a/packages/ruleset/src/rules/parameter-order.js
+++ b/packages/ruleset/src/rules/parameter-order.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { parameterOrder } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: parameterOrder
-  }
+    function: parameterOrder,
+  },
 };

--- a/packages/ruleset/src/rules/parameter-schema-or-content-exists.js
+++ b/packages/ruleset/src/rules/parameter-schema-or-content-exists.js
@@ -14,6 +14,6 @@ module.exports = {
   resolved: true,
   given: '$.paths[*][*].parameters[*]',
   then: {
-    function: schemaOrContentProvided
-  }
+    function: schemaOrContentProvided,
+  },
 };

--- a/packages/ruleset/src/rules/patch-request-content-type.js
+++ b/packages/ruleset/src/rules/patch-request-content-type.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  patchOperations
+  patchOperations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { patchRequestContentType } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: patchRequestContentType
-  }
+    function: patchRequestContentType,
+  },
 };

--- a/packages/ruleset/src/rules/path-parameter-not-crn.js
+++ b/packages/ruleset/src/rules/path-parameter-not-crn.js
@@ -13,11 +13,11 @@ module.exports = {
   formats: [oas3],
   given: [
     '$.paths[*].parameters[?(@.in === "path")]',
-    '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[?(@.in === "path")]'
+    '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[?(@.in === "path")]',
   ],
   severity: 'warn',
   resolved: true,
   then: {
-    function: pathParameterNotCRN
-  }
+    function: pathParameterNotCRN,
+  },
 };

--- a/packages/ruleset/src/rules/path-segment-casing-convention.js
+++ b/packages/ruleset/src/rules/path-segment-casing-convention.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  paths
+  paths,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { pathSegmentCasingConvention } = require('../functions');
@@ -18,7 +18,7 @@ module.exports = {
   then: {
     function: pathSegmentCasingConvention,
     functionOptions: {
-      type: 'snake'
-    }
-  }
+      type: 'snake',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/precondition-header.js
+++ b/packages/ruleset/src/rules/precondition-header.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { preconditionHeader } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   severity: 'error',
   resolved: true,
   then: {
-    function: preconditionHeader
-  }
+    function: preconditionHeader,
+  },
 };

--- a/packages/ruleset/src/rules/property-attributes.js
+++ b/packages/ruleset/src/rules/property-attributes.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { propertyAttributes } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: propertyAttributes
-  }
+    function: propertyAttributes,
+  },
 };

--- a/packages/ruleset/src/rules/property-casing-convention.js
+++ b/packages/ruleset/src/rules/property-casing-convention.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { propertyCasingConvention } = require('../functions');
@@ -18,7 +18,7 @@ module.exports = {
   then: {
     function: propertyCasingConvention,
     functionOptions: {
-      type: 'snake'
-    }
-  }
+      type: 'snake',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/property-consistent-name-and-type.js
+++ b/packages/ruleset/src/rules/property-consistent-name-and-type.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { propertyConsistentNameAndType } = require('../functions');
@@ -20,7 +20,7 @@ module.exports = {
   then: {
     function: propertyConsistentNameAndType,
     functionOptions: {
-      excludedProperties: ['code', 'default', 'type', 'value']
-    }
-  }
+      excludedProperties: ['code', 'default', 'type', 'value'],
+    },
+  },
 };

--- a/packages/ruleset/src/rules/property-description-exists.js
+++ b/packages/ruleset/src/rules/property-description-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { propertyDescriptionExists } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: propertyDescriptionExists
-  }
+    function: propertyDescriptionExists,
+  },
 };

--- a/packages/ruleset/src/rules/property-name-collision.js
+++ b/packages/ruleset/src/rules/property-name-collision.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { propertyNameCollision } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   severity: 'error',
   resolved: true,
   then: {
-    function: propertyNameCollision
-  }
+    function: propertyNameCollision,
+  },
 };

--- a/packages/ruleset/src/rules/ref-pattern.js
+++ b/packages/ruleset/src/rules/ref-pattern.js
@@ -14,6 +14,6 @@ module.exports = {
   formats: [oas3],
   resolved: false,
   then: {
-    function: refPattern
-  }
+    function: refPattern,
+  },
 };

--- a/packages/ruleset/src/rules/ref-sibling-duplicate-description.js
+++ b/packages/ruleset/src/rules/ref-sibling-duplicate-description.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { refSiblingDuplicateDescription } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: refSiblingDuplicateDescription
-  }
+    function: refSiblingDuplicateDescription,
+  },
 };

--- a/packages/ruleset/src/rules/requestbody-is-object.js
+++ b/packages/ruleset/src/rules/requestbody-is-object.js
@@ -14,7 +14,7 @@ module.exports = {
     field: 'type',
     function: enumeration,
     functionOptions: {
-      values: ['object']
-    }
-  }
+      values: ['object'],
+    },
+  },
 };

--- a/packages/ruleset/src/rules/requestbody-name-exists.js
+++ b/packages/ruleset/src/rules/requestbody-name-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { requestBodyNameExists } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: requestBodyNameExists
-  }
+    function: requestBodyNameExists,
+  },
 };

--- a/packages/ruleset/src/rules/required-property-missing.js
+++ b/packages/ruleset/src/rules/required-property-missing.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { requiredProperty } = require('../functions');
@@ -16,6 +16,6 @@ module.exports = {
   given: schemas,
   severity: 'error',
   then: {
-    function: requiredProperty
-  }
+    function: requiredProperty,
+  },
 };

--- a/packages/ruleset/src/rules/response-example-exists.js
+++ b/packages/ruleset/src/rules/response-example-exists.js
@@ -13,6 +13,6 @@ module.exports = {
   severity: 'warn',
   resolved: true,
   then: {
-    function: responseExampleExists
-  }
+    function: responseExampleExists,
+  },
 };

--- a/packages/ruleset/src/rules/response-status-codes.js
+++ b/packages/ruleset/src/rules/response-status-codes.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  operations
+  operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { responseStatusCodes } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   severity: 'warn',
   resolved: true,
   then: {
-    function: responseStatusCodes
-  }
+    function: responseStatusCodes,
+  },
 };

--- a/packages/ruleset/src/rules/schema-description-exists.js
+++ b/packages/ruleset/src/rules/schema-description-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { schemaDescriptionExists } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: schemaDescriptionExists
-  }
+    function: schemaDescriptionExists,
+  },
 };

--- a/packages/ruleset/src/rules/schema-type-exists.js
+++ b/packages/ruleset/src/rules/schema-type-exists.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { schemaTypeExists } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: schemaTypeExists
-  }
+    function: schemaTypeExists,
+  },
 };

--- a/packages/ruleset/src/rules/schema-type-format.js
+++ b/packages/ruleset/src/rules/schema-type-format.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  schemas
+  schemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { schemaTypeFormat } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: schemaTypeFormat
-  }
+    function: schemaTypeFormat,
+  },
 };

--- a/packages/ruleset/src/rules/securityscheme-attributes.js
+++ b/packages/ruleset/src/rules/securityscheme-attributes.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  securitySchemes
+  securitySchemes,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { securitySchemeAttributes } = require('../functions');
@@ -18,6 +18,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: securitySchemeAttributes
-  }
+    function: securitySchemeAttributes,
+  },
 };

--- a/packages/ruleset/src/rules/securityschemes.js
+++ b/packages/ruleset/src/rules/securityschemes.js
@@ -14,6 +14,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: securitySchemes
-  }
+    function: securitySchemes,
+  },
 };

--- a/packages/ruleset/src/rules/server-variable-default-value.js
+++ b/packages/ruleset/src/rules/server-variable-default-value.js
@@ -13,6 +13,6 @@ module.exports = {
   formats: [oas3],
   given: '$.servers[*][variables][*][default]',
   then: {
-    function: truthy
-  }
+    function: truthy,
+  },
 };

--- a/packages/ruleset/src/rules/string-attributes.js
+++ b/packages/ruleset/src/rules/string-attributes.js
@@ -17,9 +17,9 @@ module.exports = {
     '$.paths[*][parameters][*].content[*].schema',
     '$.paths[*][*][parameters][*].schema',
     '$.paths[*][*][parameters][*].content[*].schema',
-    '$.paths[*][*].requestBody.content[*].schema'
+    '$.paths[*][*].requestBody.content[*].schema',
   ],
   then: {
-    function: stringAttributes
-  }
+    function: stringAttributes,
+  },
 };

--- a/packages/ruleset/src/rules/summary-sentence-style.js
+++ b/packages/ruleset/src/rules/summary-sentence-style.js
@@ -15,7 +15,7 @@ module.exports = {
   then: {
     function: pattern,
     functionOptions: {
-      notMatch: '\\.$'
-    }
-  }
+      notMatch: '\\.$',
+    },
+  },
 };

--- a/packages/ruleset/src/rules/unused-tags.js
+++ b/packages/ruleset/src/rules/unused-tags.js
@@ -14,6 +14,6 @@ module.exports = {
   formats: [oas3],
   resolved: true,
   then: {
-    function: unusedTags
-  }
+    function: unusedTags,
+  },
 };

--- a/packages/ruleset/src/rules/valid-path-segments.js
+++ b/packages/ruleset/src/rules/valid-path-segments.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  paths
+  paths,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { validatePathSegments } = require('../functions');
@@ -17,6 +17,6 @@ module.exports = {
   severity: 'error',
   resolved: true,
   then: {
-    function: validatePathSegments
-  }
+    function: validatePathSegments,
+  },
 };

--- a/packages/ruleset/src/utils/constants.js
+++ b/packages/ruleset/src/utils/constants.js
@@ -12,7 +12,7 @@ const operationMethods = [
   'patch',
   'delete',
   'options',
-  'trace'
+  'trace',
 ];
 
 module.exports = operationMethods;

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -12,5 +12,5 @@ module.exports = {
   mergeAllOfSchemaProperties: require('./merge-allof-schema-properties'),
   ...require('./mimetype-utils'),
   operationMethods: require('./constants'),
-  pathMatchesRegexp: require('./path-matches-regexp')
+  pathMatchesRegexp: require('./path-matches-regexp'),
 };

--- a/packages/ruleset/src/utils/logger-factory.js
+++ b/packages/ruleset/src/utils/logger-factory.js
@@ -42,7 +42,7 @@ module.exports = class LoggerFactory {
     checkLevel(logLevel);
     this.loggerSettings.push({
       loggerName: name,
-      logLevel
+      logLevel,
     });
     this.applySettingsToAllLoggers();
   }

--- a/packages/ruleset/src/utils/merge-allof-schema-properties.js
+++ b/packages/ruleset/src/utils/merge-allof-schema-properties.js
@@ -31,7 +31,7 @@ function mergeAllOfSchemaProperties(schema) {
     // target schema, one at a time.
     // The 'customizer' function will contatenate arrays
     // instead of overwriting.
-    allOfArr.forEach(function(allOfSchema) {
+    allOfArr.forEach(function (allOfSchema) {
       mergeWith(targetSchema, allOfSchema, customizer);
     });
   }

--- a/packages/ruleset/src/utils/mimetype-utils.js
+++ b/packages/ruleset/src/utils/mimetype-utils.js
@@ -65,7 +65,7 @@ function isFormMimeType(mimeType) {
     /^multipart\/form-data(\s*;.*)?$/i,
     /^multipart\/related(\s*;.*)?$/i,
     /^multipart\/mixed(\s*;.*)?$/i,
-    /^application\/x-www-form-urlencoded(\s*;.*)?$/i
+    /^application\/x-www-form-urlencoded(\s*;.*)?$/i,
   ];
 
   return !!formMimeTypeREs.find(re => re.test(mimeType));
@@ -75,5 +75,5 @@ module.exports = {
   isFormMimeType,
   isJsonMimeType,
   isJsonPatchMimeType,
-  isMergePatchMimeType
+  isMergePatchMimeType,
 };

--- a/packages/ruleset/test/accept-header.test.js
+++ b/packages/ruleset/test/accept-header.test.js
@@ -29,9 +29,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'query',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -48,9 +48,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'path',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,9 +69,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'header',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/array-attributes.test.js
+++ b/packages/ruleset/test/array-attributes.test.js
@@ -34,17 +34,17 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 type: 'array',
                 description: 'a description',
                 items: {
-                  type: 'string'
-                }
+                  type: 'string',
+                },
               },
               {
                 type: 'array',
                 minItems: 12,
-                maxItems: 42
-              }
-            ]
-          }
-        }
+                maxItems: 42,
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -68,24 +68,24 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   {
                     type: 'array',
                     minItems: 45,
-                    maxItems: 100000
+                    maxItems: 100000,
                   },
                   {
                     type: 'array',
                     minItems: 100001,
-                    maxItems: 100500
-                  }
-                ]
+                    maxItems: 100500,
+                  },
+                ],
               },
               {
                 type: 'array',
                 items: {
-                  type: 'string'
-                }
-              }
-            ]
-          }
-        }
+                  type: 'string',
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -100,8 +100,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         minItems: 3,
         maxItems: 4,
         items: {
-          type: 'integer'
-        }
+          type: 'integer',
+        },
       };
 
       const results = await testRule(ruleId, rule, rootDocument);
@@ -116,8 +116,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         minItems: 3,
         maxItems: 3,
         items: {
-          type: 'integer'
-        }
+          type: 'integer',
+        },
       };
 
       const results = await testRule(ruleId, rule, rootDocument);
@@ -135,14 +135,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       movie2.properties['production_crew'] = {
         type: 'array',
         items: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       };
       testDocument.components.schemas['Movie2'] = movie2;
       testDocument.paths['/v1/movies'].post.responses['201'].content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Movie2'
+        $ref: '#/components/schemas/Movie2',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -177,15 +177,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description:
               'The array of error entries associated with the error response',
             items: {
-              $ref: '#/components/schemas/Error'
-            }
+              $ref: '#/components/schemas/Error',
+            },
           },
           trace: {
             description: 'The error trace information.',
             type: 'string',
-            format: 'uuid'
-          }
-        }
+            format: 'uuid',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -211,15 +211,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
               {
                 type: 'array',
                 items: {
-                  type: 'string'
-                }
+                  type: 'string',
+                },
               },
               {
-                type: 'array'
-              }
-            ]
-          }
-        }
+                type: 'array',
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -252,20 +252,20 @@ describe(`Spectral rule: ${ruleId}`, () => {
               {
                 type: 'array',
                 items: {
-                  type: 'string'
+                  type: 'string',
                 },
-                minItems: 0
+                minItems: 0,
               },
               {
                 type: 'array',
                 items: {
-                  type: 'string'
+                  type: 'string',
                 },
-                maxItems: 5
-              }
-            ]
-          }
-        }
+                maxItems: 5,
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -298,20 +298,20 @@ describe(`Spectral rule: ${ruleId}`, () => {
               {
                 type: 'array',
                 items: {
-                  type: 'string'
+                  type: 'string',
                 },
-                minItems: 0
+                minItems: 0,
               },
               {
                 type: 'array',
                 items: {
-                  type: 'string'
+                  type: 'string',
                 },
-                maxItems: 5
-              }
-            ]
-          }
-        }
+                maxItems: 5,
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -346,26 +346,26 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   {
                     type: 'array',
                     minItems: 0,
-                    maxItems: 4
+                    maxItems: 4,
                   },
                   {
                     type: 'array',
                     items: {
-                      type: 'string'
-                    }
-                  }
-                ]
+                      type: 'string',
+                    },
+                  },
+                ],
               },
               {
                 type: 'array',
                 minItems: 0,
                 items: {
-                  type: 'string'
-                }
-              }
-            ]
-          }
-        }
+                  type: 'string',
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -393,26 +393,26 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   {
                     type: 'array',
                     minItems: 0,
-                    maxItems: 4
+                    maxItems: 4,
                   },
                   {
                     type: 'array',
                     items: {
-                      type: 'string'
-                    }
-                  }
-                ]
+                      type: 'string',
+                    },
+                  },
+                ],
               },
               {
                 type: 'array',
                 maxItems: 1600,
                 items: {
-                  type: 'string'
-                }
-              }
-            ]
-          }
-        }
+                  type: 'string',
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -447,14 +447,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'allOf',
         '1',
         'properties',
-        'drinks'
+        'drinks',
       ]);
     });
     it('Response schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.MovieCollection = {
-        type: 'array'
+        type: 'array',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -470,7 +470,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '200',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
     it('Request schema without items property', async () => {
@@ -479,7 +479,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/movies'].post.requestBody.content[
         'application/json'
       ].schema = {
-        type: 'array'
+        type: 'array',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -494,7 +494,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
     it('Request schema with non-object items property', async () => {
@@ -504,7 +504,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json'
       ].schema = {
         type: 'array',
-        items: 'not a schema!'
+        items: 'not a schema!',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -519,14 +519,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
     it('additionalProperties schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Movie.additionalProperties = {
-        type: 'array'
+        type: 'array',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -544,7 +544,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'content',
         'application/json',
         'schema',
-        'additionalProperties'
+        'additionalProperties',
       ]);
       expect(results[1].path).toStrictEqual([
         'paths',
@@ -555,7 +555,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'content',
         'application/json',
         'schema',
-        'additionalProperties'
+        'additionalProperties',
       ]);
       expect(results[2].path).toStrictEqual([
         'paths',
@@ -571,7 +571,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'properties',
         'movies',
         'items',
-        'additionalProperties'
+        'additionalProperties',
       ]);
       expect(results[3].path).toStrictEqual([
         'paths',
@@ -582,7 +582,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'content',
         'application/json',
         'schema',
-        'additionalProperties'
+        'additionalProperties',
       ]);
       expect(results[4].path).toStrictEqual([
         'paths',
@@ -592,7 +592,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'content',
         'application/json',
         'schema',
-        'additionalProperties'
+        'additionalProperties',
       ]);
     });
     it('minItems > maxItems', async () => {
@@ -602,10 +602,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'array',
 
         items: {
-          type: 'integer'
+          type: 'integer',
         },
         minItems: 5,
-        maxItems: 4
+        maxItems: 4,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -614,7 +614,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count',
         'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count',
         'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count',
-        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count'
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);
@@ -630,7 +630,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas.Car.properties['wheel_count'] = {
         type: 'object',
-        minItems: 3
+        minItems: 3,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -639,7 +639,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minItems',
         'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minItems',
         'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minItems',
-        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minItems'
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minItems',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);
@@ -655,7 +655,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas.Car.properties['wheel_count'] = {
         type: 'integer',
-        maxItems: 3
+        maxItems: 3,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -664,7 +664,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.maxItems',
         'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.maxItems',
         'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.maxItems',
-        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maxItems'
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maxItems',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);

--- a/packages/ruleset/test/array-of-arrays.test.js
+++ b/packages/ruleset/test/array-of-arrays.test.js
@@ -16,15 +16,15 @@ const expectedMessage =
 const arrayOfString = {
   type: 'array',
   items: {
-    type: 'string'
-  }
+    type: 'string',
+  },
 };
 
 const arrayOfInt = {
   type: 'array',
   items: {
-    type: 'integer'
-  }
+    type: 'integer',
+  },
 };
 
 const arrayOfArrayOfString = {
@@ -32,9 +32,9 @@ const arrayOfArrayOfString = {
   items: {
     type: 'array',
     items: {
-      type: 'string'
-    }
-  }
+      type: 'string',
+    },
+  },
 };
 
 const arrayOfArrayOfInt = {
@@ -42,9 +42,9 @@ const arrayOfArrayOfInt = {
   items: {
     type: 'array',
     items: {
-      type: 'integer'
-    }
-  }
+      type: 'integer',
+    },
+  },
 };
 
 describe(`Spectral rule: ${ruleId}`, () => {
@@ -59,7 +59,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['Foo'] = arrayOfString;
       testDocument.components.schemas['Movie'].properties['array_prop'] = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -70,9 +70,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas['Foo'] = arrayOfString;
-      testDocument.components.schemas['Movie'].properties[
-        'array_prop'
-      ] = arrayOfString;
+      testDocument.components.schemas['Movie'].properties['array_prop'] =
+        arrayOfString;
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
@@ -83,7 +82,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['Foo'] = arrayOfInt;
       testDocument.components.schemas['Juice'].properties['array_prop'] = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -132,7 +131,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -141,7 +140,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['Foo'] = arrayOfArrayOfString;
       testDocument.components.schemas['Movie'].properties['array_prop'] = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -161,7 +160,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'array_prop'
+        'array_prop',
       ]);
 
       expect(results[1].path).toStrictEqual([
@@ -174,7 +173,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'array_prop'
+        'array_prop',
       ]);
 
       expect(results[2].path).toStrictEqual([
@@ -192,7 +191,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'movies',
         'items',
         'properties',
-        'array_prop'
+        'array_prop',
       ]);
 
       expect(results[3].path).toStrictEqual([
@@ -205,7 +204,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'array_prop'
+        'array_prop',
       ]);
 
       expect(results[4].path).toStrictEqual([
@@ -217,7 +216,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'array_prop'
+        'array_prop',
       ]);
     });
 
@@ -230,9 +229,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           name: 'array_param',
           in: 'query',
           schema: {
-            $ref: '#/components/schemas/Foo'
-          }
-        }
+            $ref: '#/components/schemas/Foo',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -245,7 +244,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '/v1/drinks',
         'parameters',
         '0',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -256,12 +255,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
         name: 'array_param',
         description: 'the array parameter',
         in: 'header',
-        schema: arrayOfArrayOfInt
+        schema: arrayOfArrayOfInt,
       };
       testDocument.paths['/v1/drinks'].post.parameters = [
         {
-          $ref: '#/components/parameters/ArrayParam'
-        }
+          $ref: '#/components/parameters/ArrayParam',
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -275,7 +274,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'post',
         'parameters',
         '0',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -289,14 +288,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
         schema: {
           type: 'array',
           items: {
-            $ref: '#/components/schemas/ArrayOfString'
-          }
-        }
+            $ref: '#/components/schemas/ArrayOfString',
+          },
+        },
       };
       testDocument.paths['/v1/drinks'].post.parameters = [
         {
-          $ref: '#/components/parameters/ArrayParam'
-        }
+          $ref: '#/components/parameters/ArrayParam',
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -310,7 +309,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'post',
         'parameters',
         '0',
-        'schema'
+        'schema',
       ]);
     });
   });

--- a/packages/ruleset/test/array-responses.test.js
+++ b/packages/ruleset/test/array-responses.test.js
@@ -25,40 +25,40 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].get.responses = {
-        '200': {
+        200: {
           description: 'Good response',
           content: {
             'application/json': {
               schema: {
                 type: 'array',
                 items: {
-                  $ref: '#/components/schemas/Drink'
-                }
-              }
+                  $ref: '#/components/schemas/Drink',
+                },
+              },
             },
             'someother/type': {
               schema: {
                 type: 'array',
                 items: {
-                  $ref: '#/components/schemas/Drink'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/Drink',
+                },
+              },
+            },
+          },
         },
-        '400': {
+        400: {
           description: 'Error response',
           content: {
             'application/json': {
               schema: {
                 type: 'array',
                 items: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -84,23 +84,23 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Create a named response with an array schema.
       testDocument.components.responses.DrinksResponse = {
-        '200': {
+        200: {
           description: 'Good response',
           content: {
             'application/json': {
               schema: {
                 type: 'array',
                 items: {
-                  $ref: '#/components/schemas/Drink'
-                }
-              }
-            }
-          }
-        }
+                  $ref: '#/components/schemas/Drink',
+                },
+              },
+            },
+          },
+        },
       };
 
       testDocument.paths['/v1/drinks'].get.responses = {
-        $ref: '#/components/responses/DrinksResponse'
+        $ref: '#/components/responses/DrinksResponse',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -117,18 +117,18 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].get.responses = {
-        '200': {
+        200: {
           description: 'Good response',
           content: {
             'application/json': {
               schema: {
                 items: {
-                  $ref: '#/components/schemas/Drink'
-                }
-              }
-            }
-          }
-        }
+                  $ref: '#/components/schemas/Drink',
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -147,32 +147,32 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks'].get['x-sdk-exclude'] = true;
       testDocument.paths['/v1/drinks'].get.responses = {
-        '200': {
+        200: {
           description: 'Good response',
           content: {
             'application/json': {
               schema: {
                 type: 'array',
                 items: {
-                  $ref: '#/components/schemas/Drink'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/Drink',
+                },
+              },
+            },
+          },
         },
-        '400': {
+        400: {
           description: 'Error response',
           content: {
             'application/json': {
               schema: {
                 type: 'array',
                 items: {
-                  type: 'string'
-                }
-              }
-            }
-          }
-        }
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/authorization-header.test.js
+++ b/packages/ruleset/test/authorization-header.test.js
@@ -29,9 +29,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'query',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -48,9 +48,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'path',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,9 +69,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'header',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/binary-schemas.test.js
+++ b/packages/ruleset/test/binary-schemas.test.js
@@ -33,11 +33,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
               type: 'array',
               items: {
                 type: 'string',
-                format: 'binary'
-              }
-            }
-          }
-        }
+                format: 'binary',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -48,7 +48,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/menu'].get.responses = {
-        '200': {
+        200: {
           content: {
             'application/octet-stream': {
               schema: {
@@ -57,13 +57,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   type: 'array',
                   items: {
                     type: 'string',
-                    format: 'binary'
-                  }
-                }
-              }
-            }
-          }
-        }
+                    format: 'binary',
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -77,9 +77,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/octet-stream': {
           schema: {
             type: 'string',
-            format: 'binary'
-          }
-        }
+            format: 'binary',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -95,8 +95,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'array',
         items: {
           type: 'string',
-          format: 'binary'
-        }
+          format: 'binary',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -118,8 +118,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'array',
         items: {
           type: 'string',
-          format: 'binary'
-        }
+          format: 'binary',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -140,10 +140,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'application/json; charset=utf-8': {
             schema: {
               type: 'string',
-              format: 'binary'
-            }
-          }
-        }
+              format: 'binary',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -160,16 +160,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/menu'].get.responses = {
-        '200': {
+        200: {
           content: {
             'application/json': {
               schema: {
                 type: 'string',
-                format: 'binary'
-              }
-            }
-          }
-        }
+                format: 'binary',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/circular-refs.test.js
+++ b/packages/ruleset/test/circular-refs.test.js
@@ -32,7 +32,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Movie = {
-        $ref: '#/components/schemas/Movie'
+        $ref: '#/components/schemas/Movie',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -50,7 +50,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Movie.properties.related_movie = {
-        $ref: '#/components/schemas/Movie'
+        $ref: '#/components/schemas/Movie',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,7 +69,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Movie.properties.related_movies = {
-        $ref: '#/components/schemas/MovieCollection'
+        $ref: '#/components/schemas/MovieCollection',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -93,8 +93,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.Movie.properties.related_movies = {
         type: 'array',
         items: {
-          $ref: '#/components/schemas/Movie'
-        }
+          $ref: '#/components/schemas/Movie',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -113,7 +113,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Movie.additionalProperties = {
-        $ref: '#/components/schemas/Movie'
+        $ref: '#/components/schemas/Movie',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -132,7 +132,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.DrinkCollection.allOf.push({
-        $ref: '#/components/schemas/DrinkCollection'
+        $ref: '#/components/schemas/DrinkCollection',
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -153,9 +153,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.Drink = {
         anyOf: [
           {
-            $ref: '#/components/schemas/DrinkCollection'
-          }
-        ]
+            $ref: '#/components/schemas/DrinkCollection',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -177,7 +177,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Soda.properties.next_drink = {
-        $ref: '#/components/schemas/Drink'
+        $ref: '#/components/schemas/Drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -199,7 +199,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.parameters.DrinkIdParam = {
-        $ref: '#/components/parameters/DrinkIdParam'
+        $ref: '#/components/parameters/DrinkIdParam',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -218,7 +218,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.requestBodies.CarRequest = {
-        $ref: '#/components/requestBodies/CarRequest'
+        $ref: '#/components/requestBodies/CarRequest',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -237,7 +237,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.responses.CarResponse = {
-        $ref: '#/components/responses/CarResponse'
+        $ref: '#/components/responses/CarResponse',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -256,7 +256,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.examples.CarExample = {
-        $ref: '#/components/examples/CarExample'
+        $ref: '#/components/examples/CarExample',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -275,7 +275,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.securitySchemes.CircularScheme = {
-        $ref: '#/components/securitySchemes/CircularScheme'
+        $ref: '#/components/securitySchemes/CircularScheme',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -294,7 +294,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.links.CarIdLink = {
-        $ref: '#/components/links/CarIdLink'
+        $ref: '#/components/links/CarIdLink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/collection-array-property.test.js
+++ b/packages/ruleset/test/collection-array-property.test.js
@@ -48,7 +48,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas[
         'MovieCollection'
       ].allOf[1].properties.movies = {
-        type: 'string'
+        type: 'string',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/content-contains-schema.test.js
+++ b/packages/ruleset/test/content-contains-schema.test.js
@@ -24,29 +24,29 @@ describe(`Spectral rule: ${ruleId}`, () => {
         requestBody: {
           content: {
             'application/json': {
-              description: 'should have a schema'
-            }
-          }
-        }
+              description: 'should have a schema',
+            },
+          },
+        },
       },
       put: {
         requestBody: {
           content: {
             'application/json': {
-              description: 'should have a schema'
-            }
-          }
-        }
+              description: 'should have a schema',
+            },
+          },
+        },
       },
       patch: {
         requestBody: {
           content: {
             'application/json': {
-              description: 'should have a schema'
-            }
-          }
-        }
-      }
+              description: 'should have a schema',
+            },
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -65,7 +65,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'post',
       'requestBody',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[1].path).toStrictEqual([
@@ -74,7 +74,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'put',
       'requestBody',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[2].path).toStrictEqual([
@@ -83,7 +83,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'patch',
       'requestBody',
       'content',
-      'application/json'
+      'application/json',
     ]);
   });
 
@@ -98,11 +98,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             in: 'header',
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        ]
+                description: 'this should have a schema',
+              },
+            },
+          },
+        ],
       },
       put: {
         parameters: [
@@ -111,11 +111,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             in: 'header',
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        ]
+                description: 'this should have a schema',
+              },
+            },
+          },
+        ],
       },
       patch: {
         parameters: [
@@ -124,11 +124,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             in: 'header',
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        ]
+                description: 'this should have a schema',
+              },
+            },
+          },
+        ],
       },
       get: {
         parameters: [
@@ -137,11 +137,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             in: 'header',
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        ]
+                description: 'this should have a schema',
+              },
+            },
+          },
+        ],
       },
       delete: {
         parameters: [
@@ -150,12 +150,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
             in: 'header',
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        ]
-      }
+                description: 'this should have a schema',
+              },
+            },
+          },
+        ],
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -175,7 +175,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'parameters',
       '0',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[1].path).toStrictEqual([
@@ -185,7 +185,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'parameters',
       '0',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[2].path).toStrictEqual([
@@ -195,7 +195,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'parameters',
       '0',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[3].path).toStrictEqual([
@@ -205,7 +205,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'parameters',
       '0',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[4].path).toStrictEqual([
@@ -215,7 +215,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'parameters',
       '0',
       'content',
-      'application/json'
+      'application/json',
     ]);
   });
 
@@ -225,59 +225,59 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.paths['/v1/books'] = {
       post: {
         responses: {
-          '200': {
+          200: {
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        }
+                description: 'this should have a schema',
+              },
+            },
+          },
+        },
       },
       put: {
         responses: {
-          '200': {
+          200: {
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        }
+                description: 'this should have a schema',
+              },
+            },
+          },
+        },
       },
       patch: {
         responses: {
-          '200': {
+          200: {
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        }
+                description: 'this should have a schema',
+              },
+            },
+          },
+        },
       },
       get: {
         responses: {
-          '200': {
+          200: {
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        }
+                description: 'this should have a schema',
+              },
+            },
+          },
+        },
       },
       delete: {
         responses: {
-          '200': {
+          200: {
             content: {
               'application/json': {
-                description: 'this should have a schema'
-              }
-            }
-          }
-        }
-      }
+                description: 'this should have a schema',
+              },
+            },
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -297,7 +297,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'responses',
       '200',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[1].path).toStrictEqual([
@@ -307,7 +307,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'responses',
       '200',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[2].path).toStrictEqual([
@@ -317,7 +317,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'responses',
       '200',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[3].path).toStrictEqual([
@@ -327,7 +327,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'responses',
       '200',
       'content',
-      'application/json'
+      'application/json',
     ]);
 
     expect(results[4].path).toStrictEqual([
@@ -337,7 +337,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'responses',
       '200',
       'content',
-      'application/json'
+      'application/json',
     ]);
   });
 });

--- a/packages/ruleset/test/content-exists.test.js
+++ b/packages/ruleset/test/content-exists.test.js
@@ -20,10 +20,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].delete = {
       responses: {
-        '204': {
-          description: 'No content'
-        }
-      }
+        204: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -35,10 +35,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].delete = {
       responses: {
-        '202': {
-          description: 'No content'
-        }
-      }
+        202: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -50,10 +50,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].delete = {
       responses: {
-        '101': {
-          description: 'No content'
-        }
-      }
+        101: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -65,10 +65,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].delete = {
       responses: {
-        '304': {
-          description: 'No content'
-        }
-      }
+        304: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -80,10 +80,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].head = {
       responses: {
-        '200': {
-          description: 'No content'
-        }
-      }
+        200: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -95,10 +95,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].options = {
       responses: {
-        '200': {
-          description: 'No content'
-        }
-      }
+        200: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -110,10 +110,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].trace = {
       responses: {
-        '200': {
-          description: 'No content'
-        }
-      }
+        200: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -125,10 +125,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].post = {
       responses: {
-        '201': {
-          description: 'No content'
-        }
-      }
+        201: {
+          description: 'No content',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -145,7 +145,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       '/v1/movies',
       'post',
       'responses',
-      '201'
+      '201',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });
@@ -154,8 +154,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].post = {
       requestBody: {
-        description: 'No content'
-      }
+        description: 'No content',
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -171,7 +171,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'paths',
       '/v1/movies',
       'post',
-      'requestBody'
+      'requestBody',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });

--- a/packages/ruleset/test/content-type-header.test.js
+++ b/packages/ruleset/test/content-type-header.test.js
@@ -29,9 +29,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'query',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -48,9 +48,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'path',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,9 +69,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'header',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/content-type-is-specific.test.js
+++ b/packages/ruleset/test/content-type-is-specific.test.js
@@ -24,10 +24,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
         in: 'header',
         content: {
           '*/*': {
-            description: 'maybe not *all* content types'
-          }
-        }
-      }
+            description: 'maybe not *all* content types',
+          },
+        },
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -46,7 +46,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'parameters',
       '0',
       'content',
-      '*/*'
+      '*/*',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });
@@ -56,9 +56,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.paths['/v1/movies'].post.requestBody = {
       content: {
         '*/*': {
-          description: 'maybe not *all* content types'
-        }
-      }
+          description: 'maybe not *all* content types',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -76,7 +76,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'post',
       'requestBody',
       'content',
-      '*/*'
+      '*/*',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });
@@ -84,13 +84,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
   it('should error if a responses content has a wildcard content type', async () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['/v1/movies'].post.responses = {
-      '201': {
+      201: {
         content: {
           '*/*': {
-            description: 'maybe not *all* content types'
-          }
-        }
-      }
+            description: 'maybe not *all* content types',
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -109,7 +109,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'responses',
       '201',
       'content',
-      '*/*'
+      '*/*',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });

--- a/packages/ruleset/test/delete-body.test.js
+++ b/packages/ruleset/test/delete-body.test.js
@@ -32,19 +32,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
           content: {
             'text/html': {
               schema: {
-                type: 'string'
-              }
-            }
-          }
+                type: 'string',
+              },
+            },
+          },
         },
         responses: {
-          '204': {
-            description: 'Drink successfully poured!'
+          204: {
+            description: 'Drink successfully poured!',
           },
-          '400': {
-            $ref: '#/components/responses/BarIsClosed'
-          }
-        }
+          400: {
+            $ref: '#/components/responses/BarIsClosed',
+          },
+        },
       };
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);

--- a/packages/ruleset/test/description-mentions-json.test.js
+++ b/packages/ruleset/test/description-mentions-json.test.js
@@ -27,9 +27,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'text/html': {
           schema: {
             type: 'string',
-            description: 'Not a JSON object.'
-          }
-        }
+            description: 'Not a JSON object.',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -44,7 +44,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'text/html',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -68,7 +68,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
       expect(results[1].path).toStrictEqual([
         'paths',
@@ -78,7 +78,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '201',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
       expect(results[2].path).toStrictEqual([
         'paths',
@@ -93,7 +93,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '1',
         'properties',
         'drinks',
-        'items'
+        'items',
       ]);
       expect(results[3].path).toStrictEqual([
         'paths',
@@ -103,7 +103,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '200',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -123,15 +123,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description:
               'The array of error entries associated with the error response',
             items: {
-              $ref: '#/components/schemas/Error'
-            }
+              $ref: '#/components/schemas/Error',
+            },
           },
           trace: {
             description: 'The error trace information.',
             type: 'string',
-            format: 'uuid'
-          }
-        }
+            format: 'uuid',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -147,7 +147,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '400',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -162,7 +162,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/drinks'].post.responses['201'].content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Soda'
+        $ref: '#/components/schemas/Soda',
       };
 
       // We should get back a warning ONLY due to the Soda reference in the response (not the oneOf).
@@ -182,7 +182,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'oneOf',
-        '1'
+        '1',
       ]);
       expect(results[1].path).toStrictEqual([
         'paths',
@@ -192,7 +192,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '201',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
       expect(results[2].path).toStrictEqual([
         'paths',
@@ -209,7 +209,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'drinks',
         'items',
         'oneOf',
-        '1'
+        '1',
       ]);
       expect(results[3].path).toStrictEqual([
         'paths',
@@ -221,7 +221,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'oneOf',
-        '1'
+        '1',
       ]);
     });
 
@@ -247,7 +247,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'id'
+        'id',
       ]);
       expect(results[1].path).toStrictEqual([
         'paths',
@@ -259,7 +259,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'id'
+        'id',
       ]);
       expect(results[2].path).toStrictEqual([
         'paths',
@@ -276,7 +276,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'movies',
         'items',
         'properties',
-        'id'
+        'id',
       ]);
       expect(results[3].path).toStrictEqual([
         'paths',
@@ -288,7 +288,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'id'
+        'id',
       ]);
       expect(results[4].path).toStrictEqual([
         'paths',
@@ -298,7 +298,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '200',
         'headers',
         'ETag',
-        'schema'
+        'schema',
       ]);
       expect(results[5].path).toStrictEqual([
         'paths',
@@ -309,7 +309,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'id'
+        'id',
       ]);
     });
 
@@ -326,7 +326,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'x-not-an-extension'
       ] = {
         type: 'string',
-        description: 'This is not a JsOn object!'
+        description: 'This is not a JsOn object!',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -345,7 +345,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'x-not-an-extension'
+        'x-not-an-extension',
       ]);
       expect(results[1].path).toStrictEqual([
         'paths',
@@ -357,7 +357,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'x-not-an-extension'
+        'x-not-an-extension',
       ]);
       expect(results[2].path).toStrictEqual([
         'paths',
@@ -374,7 +374,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'movies',
         'items',
         'properties',
-        'x-not-an-extension'
+        'x-not-an-extension',
       ]);
       expect(results[3].path).toStrictEqual([
         'paths',
@@ -386,7 +386,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'x-not-an-extension'
+        'x-not-an-extension',
       ]);
       expect(results[4].path).toStrictEqual([
         'paths',
@@ -397,7 +397,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'x-not-an-extension'
+        'x-not-an-extension',
       ]);
     });
   });

--- a/packages/ruleset/test/discriminator-property-exists.test.js
+++ b/packages/ruleset/test/discriminator-property-exists.test.js
@@ -25,19 +25,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
+              type: 'string',
+            },
+          },
         },
         {
           type: 'object',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
-        }
-      ]
+              type: 'string',
+            },
+          },
+        },
+      ],
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -53,19 +53,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
+              type: 'string',
+            },
+          },
         },
         {
           type: 'object',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
-        }
-      ]
+              type: 'string',
+            },
+          },
+        },
+      ],
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -81,19 +81,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             name: {
-              type: 'string'
-            }
-          }
+              type: 'string',
+            },
+          },
         },
         {
           type: 'object',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
-        }
-      ]
+              type: 'string',
+            },
+          },
+        },
+      ],
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -106,15 +106,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.components.schemas.Drink = {
       anyOf: [
         {
-          $ref: '#/components/schemas/Juice'
+          $ref: '#/components/schemas/Juice',
         },
         {
-          $ref: '#/components/schemas/Soda'
-        }
+          $ref: '#/components/schemas/Soda',
+        },
       ],
       discriminator: {
-        propertyName: 'type'
-      }
+        propertyName: 'type',
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -129,9 +129,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       required: ['name'],
       properties: {
         name: {
-          $ref: '#/components/schemas/NormalString'
-        }
-      }
+          $ref: '#/components/schemas/NormalString',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -154,7 +154,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json',
       'schema',
       'discriminator',
-      'propertyName'
+      'propertyName',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });
@@ -164,15 +164,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.components.schemas.Drink = {
       anyOf: [
         {
-          $ref: '#/components/schemas/Juice'
+          $ref: '#/components/schemas/Juice',
         },
         {
-          $ref: '#/components/schemas/Soda'
-        }
+          $ref: '#/components/schemas/Soda',
+        },
       ],
       discriminator: {
-        propertyName: 'type'
-      }
+        propertyName: 'type',
+      },
     };
 
     testDocument.components.schemas.Juice = {
@@ -180,9 +180,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       required: ['fruit'],
       properties: {
         fruit: {
-          $ref: '#/components/schemas/NormalString'
-        }
-      }
+          $ref: '#/components/schemas/NormalString',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -202,7 +202,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json',
       'schema',
       'discriminator',
-      'propertyName'
+      'propertyName',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });
@@ -215,19 +215,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             brand: {
-              type: 'string'
-            }
-          }
+              type: 'string',
+            },
+          },
         },
         {
           type: 'object',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
-        }
-      ]
+              type: 'string',
+            },
+          },
+        },
+      ],
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -247,7 +247,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json',
       'schema',
       'discriminator',
-      'propertyName'
+      'propertyName',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });
@@ -260,19 +260,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             brand: {
-              type: 'string'
-            }
-          }
+              type: 'string',
+            },
+          },
         },
         {
           type: 'object',
           properties: {
             type: {
-              type: 'string'
-            }
-          }
-        }
-      ]
+              type: 'string',
+            },
+          },
+        },
+      ],
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -292,7 +292,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json',
       'schema',
       'discriminator',
-      'propertyName'
+      'propertyName',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });
@@ -305,19 +305,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             brand: {
-              type: 'string'
-            }
-          }
+              type: 'string',
+            },
+          },
         },
         {
           type: 'object',
           properties: {
             flavor: {
-              type: 'string'
-            }
-          }
-        }
-      ]
+              type: 'string',
+            },
+          },
+        },
+      ],
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -337,7 +337,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json',
       'schema',
       'discriminator',
-      'propertyName'
+      'propertyName',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });

--- a/packages/ruleset/test/duplicate-path-parameter.test.js
+++ b/packages/ruleset/test/duplicate-path-parameter.test.js
@@ -24,8 +24,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}'].get.parameters = [
         {
-          $ref: '#/components/parameters/DrinkIdParam'
-        }
+          $ref: '#/components/parameters/DrinkIdParam',
+        },
       ];
       delete testDocument.paths['/v1/drinks/{drink_id}'].parameters;
 
@@ -47,9 +47,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'string',
             pattern: '[a-zA-Z0-9 ]+',
             minLength: 1,
-            maxLength: 30
-          }
-        }
+            maxLength: 30,
+          },
+        },
       ];
       testDocument.paths['/v1/drinks/{drink_id}'].delete = {
         operationId: 'delete_drink',
@@ -63,10 +63,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
               type: 'string',
               pattern: '[a-zA-Z0-9 ]+',
               minLength: 3,
-              maxLength: 60
-            }
-          }
-        ]
+              maxLength: 60,
+            },
+          },
+        ],
       };
       delete testDocument.paths['/v1/drinks/{drink_id}'].parameters;
 
@@ -82,16 +82,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // Add same path param to two operations and remove from path item.
       testDocument.paths['/v1/drinks/{drink_id}'].get.parameters = [
         {
-          $ref: '#/components/parameters/DrinkIdParam'
-        }
+          $ref: '#/components/parameters/DrinkIdParam',
+        },
       ];
       testDocument.paths['/v1/drinks/{drink_id}'].delete = {
         operationId: 'delete_drink',
         parameters: [
           {
-            $ref: '#/components/parameters/DrinkIdParam'
-          }
-        ]
+            $ref: '#/components/parameters/DrinkIdParam',
+          },
+        ],
       };
       delete testDocument.paths['/v1/drinks/{drink_id}'].parameters;
 
@@ -115,13 +115,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // Add redundant path parm to the get operation.
       testDocument.paths['/v1/drinks/{drink_id}'].get.parameters = [
         {
-          $ref: '#/components/parameters/DrinkIdParam'
-        }
+          $ref: '#/components/parameters/DrinkIdParam',
+        },
       ];
 
       // Add a second operation to this path with no path params.
       testDocument.paths['/v1/drinks/{drink_id}'].delete = {
-        operationId: 'delete_drink'
+        operationId: 'delete_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/enum-casing-convention.test.js
+++ b/packages/ruleset/test/enum-casing-convention.test.js
@@ -22,7 +22,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/movies'].get.parameters[0].schema.enum = [
-        'snake_case_value'
+        'snake_case_value',
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -37,7 +37,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/movies'].get.parameters[0].schema.enum = [
         'valueOne',
         'valueTwo',
-        'value_three'
+        'value_three',
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -62,7 +62,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Juice'].properties['type'].enum = [
         'juicyJuice',
         'not_enough_juice',
-        'orangeJuice'
+        'orangeJuice',
       ];
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/error-content-type-is-json.test.js
+++ b/packages/ruleset/test/error-content-type-is-json.test.js
@@ -20,9 +20,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.paths['/v1/movies'].post.responses['500'] = {
       content: {
         'text/plain': {
-          description: 'just error text'
-        }
-      }
+          description: 'just error text',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -40,7 +40,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'post',
       'responses',
       '500',
-      'content'
+      'content',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });

--- a/packages/ruleset/test/error-response-schemas.test.js
+++ b/packages/ruleset/test/error-response-schemas.test.js
@@ -44,9 +44,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/movies'].get.responses['400'] = {
         content: {
           'application/json': {
-            schema: {}
-          }
-        }
+            schema: {},
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -86,7 +86,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.ErrorContainer.properties.trace = {
-        type: 'integer'
+        type: 'integer',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -185,7 +185,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('errors array items not an object', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.components.schemas.ErrorContainer.properties.errors.items = {};
+      testDocument.components.schemas.ErrorContainer.properties.errors.items =
+        {};
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(10);
@@ -224,7 +225,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Error.properties.code = {
-        type: 'integer'
+        type: 'integer',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -302,7 +303,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Error.properties.message = {
-        type: 'integer'
+        type: 'integer',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -342,7 +343,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Error.properties.more_info = {
-        type: 'integer'
+        type: 'integer',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -363,7 +364,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Error.properties.target = {
-        type: 'integer'
+        type: 'integer',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -403,7 +404,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.ErrorTarget.properties.type = {
-        type: 'integer'
+        type: 'integer',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -445,7 +446,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.ErrorTarget.properties.type.enum = [
         'property',
         'queryParam',
-        'headerParam'
+        'headerParam',
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -485,7 +486,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.ErrorTarget.properties.name = {
-        type: 'integer'
+        type: 'integer',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/examples-name-contains-space.test.js
+++ b/packages/ruleset/test/examples-name-contains-space.test.js
@@ -21,7 +21,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.paths['v1/books'] = {
       post: {
         responses: {
-          '201': {
+          201: {
             description: 'The created book',
             content: {
               'application/json': {
@@ -29,27 +29,27 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   type: 'object',
                   properties: {
                     title: {
-                      type: 'string'
+                      type: 'string',
                     },
                     author: {
-                      type: 'string'
+                      type: 'string',
                     },
                     length: {
-                      type: 'integer'
-                    }
-                  }
+                      type: 'integer',
+                    },
+                  },
                 },
                 examples: {
                   'create book response example': {
                     value:
-                      '{"title": "Dune", "author": "Frank Herbert", length: 412 }'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                      '{"title": "Dune", "author": "Frank Herbert", length: 412 }',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -68,7 +68,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'content',
       'application/json',
       'examples',
-      'create book response example'
+      'create book response example',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });

--- a/packages/ruleset/test/get-composite-schema-attribute.test.js
+++ b/packages/ruleset/test/get-composite-schema-attribute.test.js
@@ -16,7 +16,7 @@ describe('Utility function: getCompositeSchemaAttribute()', () => {
   it('Should return attribute within non-composed schema', async () => {
     const schema = {
       type: 'string',
-      format: 'date-time'
+      format: 'date-time',
     };
     expect(getCompositeSchemaAttribute(schema, 'format')).toBe('date-time');
     expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
@@ -41,12 +41,12 @@ describe('Utility function: getCompositeSchemaAttribute()', () => {
     const schema = {
       allOf: [
         {
-          type: 'string'
+          type: 'string',
         },
         {
-          format: 'byte'
-        }
-      ]
+          format: 'byte',
+        },
+      ],
     };
     expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
     expect(getCompositeSchemaAttribute(schema, 'format')).toBe('byte');
@@ -57,12 +57,12 @@ describe('Utility function: getCompositeSchemaAttribute()', () => {
       anyOf: [
         {
           type: 'string',
-          format: 'byte'
+          format: 'byte',
         },
         {
-          type: 'string'
-        }
-      ]
+          type: 'string',
+        },
+      ],
     };
     expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
     expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
@@ -73,12 +73,12 @@ describe('Utility function: getCompositeSchemaAttribute()', () => {
       oneOf: [
         {
           type: 'string',
-          format: 'byte'
+          format: 'byte',
         },
         {
-          type: 'string'
-        }
-      ]
+          type: 'string',
+        },
+      ],
     };
     expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
     expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
@@ -88,12 +88,12 @@ describe('Utility function: getCompositeSchemaAttribute()', () => {
     const schema = {
       oneOf: [
         {
-          allOf: [{ type: 'string' }, { format: 'byte' }]
+          allOf: [{ type: 'string' }, { format: 'byte' }],
         },
         {
-          type: 'string'
-        }
-      ]
+          type: 'string',
+        },
+      ],
     };
     expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
     expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
@@ -103,12 +103,12 @@ describe('Utility function: getCompositeSchemaAttribute()', () => {
     const schema = {
       anyOf: [
         {
-          allOf: [{ type: 'string' }, { format: 'byte' }]
+          allOf: [{ type: 'string' }, { format: 'byte' }],
         },
         {
-          type: 'string'
-        }
-      ]
+          type: 'string',
+        },
+      ],
     };
     expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
     expect(getCompositeSchemaAttribute(schema, 'format')).toBe(undefined);
@@ -118,12 +118,12 @@ describe('Utility function: getCompositeSchemaAttribute()', () => {
     const schema = {
       allOf: [
         {
-          oneOf: [{ type: 'string', format: 'uri' }, { type: 'string' }]
+          oneOf: [{ type: 'string', format: 'uri' }, { type: 'string' }],
         },
         {
-          format: 'byte'
-        }
-      ]
+          format: 'byte',
+        },
+      ],
     };
     expect(getCompositeSchemaAttribute(schema, 'type')).toBe('string');
     expect(getCompositeSchemaAttribute(schema, 'format')).toBe('byte');

--- a/packages/ruleset/test/if-modified-since-header.test.js
+++ b/packages/ruleset/test/if-modified-since-header.test.js
@@ -29,9 +29,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'query',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -48,9 +48,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'path',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,9 +69,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'header',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/if-unmodified-since-header.test.js
+++ b/packages/ruleset/test/if-unmodified-since-header.test.js
@@ -29,9 +29,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'query',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -48,9 +48,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'path',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,9 +69,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: true,
           in: 'header',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/inline-property-schema.test.js
+++ b/packages/ruleset/test/inline-property-schema.test.js
@@ -24,13 +24,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // empty object
       testDocument.components.schemas.Car.properties['inline_prop1'] = {
-        type: 'object'
+        type: 'object',
       };
 
       // any object
       testDocument.components.schemas.Car.properties['inline_prop2'] = {
         type: 'object',
-        additionalProperties: true
+        additionalProperties: true,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -43,14 +43,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // empty object
       testDocument.components.schemas.Car.properties['inline_prop1'] = {
         'type': 'object',
-        'x-foo': 'bar'
+        'x-foo': 'bar',
       };
 
       // any object
       testDocument.components.schemas.Car.properties['inline_prop2'] = {
         'type': 'object',
         'additionalProperties': true,
-        'x-terraform-sensitive': 'bar'
+        'x-terraform-sensitive': 'bar',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -63,12 +63,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.Car.properties['inline_prop'] = {
         allOf: [
           {
-            $ref: '#/components/schemas/CarPatch'
+            $ref: '#/components/schemas/CarPatch',
           },
           {
-            description: 'An instance of a patched car.'
-          }
-        ]
+            description: 'An instance of a patched car.',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -81,12 +81,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.Car.properties['inline_prop'] = {
         oneOf: [
           {
-            type: 'string'
+            type: 'string',
           },
           {
-            type: 'string'
-          }
-        ]
+            type: 'string',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -102,9 +102,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'object',
         properties: {
           nested_prop: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -126,14 +126,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
           {
             properties: {
               nested_prop: {
-                type: 'string'
-              }
-            }
+                type: 'string',
+              },
+            },
           },
           {
-            description: 'A nested property.'
-          }
-        ]
+            description: 'A nested property.',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -156,15 +156,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description: 'A nested property.',
             properties: {
               nested_prop: {
-                type: 'string'
-              }
-            }
+                type: 'string',
+              },
+            },
           },
           {
             description: 'An alternative string representation.',
-            type: 'string'
-          }
-        ]
+            type: 'string',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -190,17 +190,17 @@ describe(`Spectral rule: ${ruleId}`, () => {
         oneOf: [
           {
             description: 'An alternative string representation.',
-            type: 'string'
+            type: 'string',
           },
           {
             description: 'A nested property.',
             properties: {
               nested_prop: {
-                type: 'string'
-              }
-            }
-          }
-        ]
+                type: 'string',
+              },
+            },
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -228,10 +228,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             element: {
-              type: 'string'
-            }
-          }
-        }
+              type: 'string',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -252,9 +252,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         description: 'Inline object schema within additionalProperties',
         properties: {
           prop1: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -274,12 +274,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.Car.properties['inline_prop'] = {
         allOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
-            $ref: '#/components/schemas/Car'
-          }
-        ]
+            $ref: '#/components/schemas/Car',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -299,13 +299,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.Car.additionalProperties = {
         oneOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
             description:
-              'This is an alternate description for the Drink schema.'
-          }
-        ]
+              'This is an alternate description for the Drink schema.',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -330,12 +330,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.Car.additionalProperties = {
         allOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
-            required: ['type']
-          }
-        ]
+            required: ['type'],
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/inline-request-schema.test.js
+++ b/packages/ruleset/test/inline-request-schema.test.js
@@ -25,7 +25,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/drinks'].post.requestBody.content[
         'application/json'
       ].schema = {
-        type: 'string'
+        type: 'string',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -43,11 +43,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'object',
             properties: {
               test_prop: {
-                type: 'string'
-              }
-            }
-          }
-        }
+                type: 'string',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -65,11 +65,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'object',
             properties: {
               test_prop: {
-                type: 'string'
-              }
-            }
-          }
-        }
+                type: 'string',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -84,8 +84,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         type: 'array',
         items: {
-          type: 'integer'
-        }
+          type: 'integer',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -100,13 +100,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
             description:
-              'This is an alternate description for the Drink schema.'
-          }
-        ]
+              'This is an alternate description for the Drink schema.',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -121,12 +121,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         oneOf: [
           {
-            type: 'string'
+            type: 'string',
           },
           {
-            type: 'string'
-          }
-        ]
+            type: 'string',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -164,18 +164,18 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'object',
             properties: {
               prop1: {
-                type: 'string'
-              }
-            }
+                type: 'string',
+              },
+            },
           },
           {
             properties: {
               prop2: {
-                type: 'string'
-              }
-            }
-          }
-        ]
+                type: 'string',
+              },
+            },
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -200,18 +200,18 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'object',
             properties: {
               prop1: {
-                type: 'string'
-              }
-            }
+                type: 'string',
+              },
+            },
           },
           {
             properties: {
               prop2: {
-                type: 'string'
-              }
-            }
-          }
-        ]
+                type: 'string',
+              },
+            },
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -233,14 +233,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
             type: 'object',
             description:
-              'This is an alternate description for the Drink schema.'
-          }
-        ]
+              'This is an alternate description for the Drink schema.',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -262,12 +262,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
-            $ref: '#/components/schemas/Car'
-          }
-        ]
+            $ref: '#/components/schemas/Car',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -289,13 +289,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         oneOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
             description:
-              'This is an alternate description for the Drink schema.'
-          }
-        ]
+              'This is an alternate description for the Drink schema.',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -317,12 +317,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Drink'
+            $ref: '#/components/schemas/Drink',
           },
           {
-            required: ['type']
-          }
-        ]
+            required: ['type'],
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -343,7 +343,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json'
       ].schema = {
         type: 'array',
-        items: testDocument.components.schemas.Drink
+        items: testDocument.components.schemas.Drink,
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/inline-response-schema.test.js
+++ b/packages/ruleset/test/inline-response-schema.test.js
@@ -26,7 +26,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/movies'].post.responses['201'].content[
         'application/json'
       ].schema = {
-        type: 'string'
+        type: 'string',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -45,11 +45,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'object',
             properties: {
               test_prop: {
-                type: 'string'
-              }
-            }
-          }
-        }
+                type: 'string',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -77,8 +77,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         type: 'array',
         items: {
-          type: 'integer'
-        }
+          type: 'integer',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -93,8 +93,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         type: 'array',
         items: {
-          $ref: '#/components/schemas/Error'
-        }
+          $ref: '#/components/schemas/Error',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -109,14 +109,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Movie'
+            $ref: '#/components/schemas/Movie',
           },
           {
             description: 'The create_movie operation returns a Movie instance.',
             nullable: false,
-            example: 'foo'
-          }
-        ]
+            example: 'foo',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -131,12 +131,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Movie'
-          }
+            $ref: '#/components/schemas/Movie',
+          },
         ],
         description: 'The create_movie operation returns a Movie instance.',
         nullable: false,
-        example: 'foo'
+        example: 'foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -151,12 +151,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         oneOf: [
           {
-            type: 'string'
+            type: 'string',
           },
           {
-            type: 'string'
-          }
-        ]
+            type: 'string',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -182,15 +182,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description:
               'The array of error entries associated with the error response',
             items: {
-              $ref: '#/components/schemas/Error'
-            }
+              $ref: '#/components/schemas/Error',
+            },
           },
           trace: {
             description: 'The error trace information.',
             type: 'string',
-            format: 'uuid'
-          }
-        }
+            format: 'uuid',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -288,13 +288,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Movie'
+            $ref: '#/components/schemas/Movie',
           },
           {
             description: 'Not a ref-sibling!',
-            minProperties: 1
-          }
-        ]
+            minProperties: 1,
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -316,11 +316,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ].schema = {
         allOf: [
           {
-            $ref: '#/components/schemas/Movie'
-          }
+            $ref: '#/components/schemas/Movie',
+          },
         ],
         description: 'Still not a ref-sibling!',
-        pattern: '.*'
+        pattern: '.*',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/is-empty-object-schema.test.js
+++ b/packages/ruleset/test/is-empty-object-schema.test.js
@@ -29,21 +29,21 @@ describe('Utility function: isEmptyObjectSchema()', () => {
 
     it('empty allOf list', async () => {
       const s = {
-        allOf: []
+        allOf: [],
       };
       expect(isEmptyObjectSchema(s)).toBe(false);
     });
 
     it('empty anyOf list', async () => {
       const s = {
-        anyOf: []
+        anyOf: [],
       };
       expect(isEmptyObjectSchema(s)).toBe(false);
     });
 
     it('empty oneOf list', async () => {
       const s = {
-        oneOf: []
+        oneOf: [],
       };
       expect(isEmptyObjectSchema(s)).toBe(false);
     });
@@ -53,9 +53,9 @@ describe('Utility function: isEmptyObjectSchema()', () => {
         type: 'object',
         properties: {
           foo: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       };
       expect(isEmptyObjectSchema(s)).toBe(false);
     });
@@ -65,7 +65,7 @@ describe('Utility function: isEmptyObjectSchema()', () => {
         type: 'object',
         description: 'almost empty object schema',
         additionalProperties: true,
-        minLength: 1
+        minLength: 1,
       };
       expect(isEmptyObjectSchema(s)).toBe(false);
     });
@@ -74,7 +74,7 @@ describe('Utility function: isEmptyObjectSchema()', () => {
       const s = {
         type: 'object',
         description: 'nearly an object schema',
-        additionalProperties: false
+        additionalProperties: false,
       };
       expect(isEmptyObjectSchema(s)).toBe(false);
     });
@@ -85,14 +85,14 @@ describe('Utility function: isEmptyObjectSchema()', () => {
       const s = {
         type: 'object',
         description: 'empty object schema',
-        additionalProperties: true
+        additionalProperties: true,
       };
       expect(isEmptyObjectSchema(s)).toBe(true);
     });
 
     it('empty object schema w/only type', async () => {
       const s = {
-        type: 'object'
+        type: 'object',
       };
       expect(isEmptyObjectSchema(s)).toBe(true);
     });
@@ -100,7 +100,7 @@ describe('Utility function: isEmptyObjectSchema()', () => {
     it('empty object schema w/only type,description', async () => {
       const s = {
         type: 'object',
-        description: 'empty object schema'
+        description: 'empty object schema',
       };
       expect(isEmptyObjectSchema(s)).toBe(true);
     });
@@ -109,7 +109,7 @@ describe('Utility function: isEmptyObjectSchema()', () => {
       const s = {
         'type': 'object',
         'description': 'empty object schema',
-        'x-foo': 'bar'
+        'x-foo': 'bar',
       };
       expect(isEmptyObjectSchema(s)).toBe(true);
     });

--- a/packages/ruleset/test/is-ref-sibling-schema.test.js
+++ b/packages/ruleset/test/is-ref-sibling-schema.test.js
@@ -35,7 +35,7 @@ describe('Utility function: isRefSiblingSchema()', () => {
 
     it('empty allOf list', async () => {
       const s = {
-        allOf: []
+        allOf: [],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -44,12 +44,12 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            description: 'non-ref schema'
+            description: 'non-ref schema',
           },
           {
-            example: 'foo'
-          }
-        ]
+            example: 'foo',
+          },
+        ],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -58,12 +58,12 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
+            $ref: '#/components/schemas/Foo',
           },
           {
-            minLength: 1
-          }
-        ]
+            minLength: 1,
+          },
+        ],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -72,15 +72,15 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
+            $ref: '#/components/schemas/Foo',
           },
           {
-            description: 'this is starting to look like a ref-sibling'
+            description: 'this is starting to look like a ref-sibling',
           },
           {
-            description: 'nope not a ref-sibling now'
-          }
-        ]
+            description: 'nope not a ref-sibling now',
+          },
+        ],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -89,13 +89,13 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
+            $ref: '#/components/schemas/Foo',
           },
           {
-            description: 'Overridden description'
-          }
+            description: 'Overridden description',
+          },
         ],
-        oneOf: []
+        oneOf: [],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -104,13 +104,13 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
+            $ref: '#/components/schemas/Foo',
           },
           {
-            description: 'Overridden description'
-          }
+            description: 'Overridden description',
+          },
         ],
-        anyOf: []
+        anyOf: [],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -119,15 +119,15 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
+            $ref: '#/components/schemas/Foo',
           },
           {
             description: 'Overridden description',
             nullable: true,
             example: 'foo',
-            minProperties: 1
-          }
-        ]
+            minProperties: 1,
+          },
+        ],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -136,11 +136,11 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
-          }
+            $ref: '#/components/schemas/Foo',
+          },
         ],
         description: 'Overridden description',
-        minProperties: 1
+        minProperties: 1,
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -149,9 +149,9 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
-          }
-        ]
+            $ref: '#/components/schemas/Foo',
+          },
+        ],
       };
       expect(isRefSiblingSchema(s)).toBe(false);
     });
@@ -162,12 +162,12 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
+            $ref: '#/components/schemas/Foo',
           },
           {
-            description: 'Overridden description'
-          }
-        ]
+            description: 'Overridden description',
+          },
+        ],
       };
       expect(isRefSiblingSchema(s)).toBe(true);
     });
@@ -176,14 +176,14 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
+            $ref: '#/components/schemas/Foo',
           },
           {
             description: 'Overridden description',
             nullable: true,
-            example: 'foo'
-          }
-        ]
+            example: 'foo',
+          },
+        ],
       };
       expect(isRefSiblingSchema(s)).toBe(true);
     });
@@ -192,10 +192,10 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
-          }
+            $ref: '#/components/schemas/Foo',
+          },
         ],
-        description: 'Overridden description'
+        description: 'Overridden description',
       };
       expect(isRefSiblingSchema(s)).toBe(true);
     });
@@ -204,12 +204,12 @@ describe('Utility function: isRefSiblingSchema()', () => {
       const s = {
         allOf: [
           {
-            $ref: '#/components/schemas/Foo'
-          }
+            $ref: '#/components/schemas/Foo',
+          },
         ],
         description: 'Overridden description',
         nullable: false,
-        example: 'foo'
+        example: 'foo',
       };
       expect(isRefSiblingSchema(s)).toBe(true);
     });

--- a/packages/ruleset/test/major-version-in-path.test.js
+++ b/packages/ruleset/test/major-version-in-path.test.js
@@ -23,16 +23,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
         url: 'https://some-madeup-url.com:{port}/api/{apiVersion}',
         variables: {
           port: {
-            default: '443'
+            default: '443',
           },
           apiVersion: {
-            default: 'v1'
-          }
-        }
+            default: 'v1',
+          },
+        },
       },
       {
-        url: 'https://some-madeup-url.com:443/api/v1'
-      }
+        url: 'https://some-madeup-url.com:443/api/v1',
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -47,13 +47,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
         url: 'https://some-madeup-url.com:{port}/api/{apiVersion}',
         variables: {
           port: {
-            description: 'No default value for this one'
+            description: 'No default value for this one',
           },
           apiVersion: {
-            default: 'v1'
-          }
-        }
-      }
+            default: 'v1',
+          },
+        },
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -65,11 +65,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.servers = [
       {
-        url: 'https://some-madeup-url.com/api/v1'
+        url: 'https://some-madeup-url.com/api/v1',
       },
       {
-        url: 'https://some-madeup-url.com/api/v2'
-      }
+        url: 'https://some-madeup-url.com/api/v2',
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -106,7 +106,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
     delete testDocument.paths;
     testDocument.paths = {
-      '/movies': {}
+      '/movies': {},
     };
 
     const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/merge-allof-schema-properties.test.js
+++ b/packages/ruleset/test/merge-allof-schema-properties.test.js
@@ -13,9 +13,9 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
       required: ['prop1'],
       properties: {
         prop1: {
-          type: 'string'
-        }
-      }
+          type: 'string',
+        },
+      },
     };
     expect(mergeAllOfSchemaProperties(schema)).toStrictEqual(schema);
   });
@@ -27,10 +27,10 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
       required: ['prop1'],
       properties: {
         prop1: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
-      allOf: []
+      allOf: [],
     };
 
     const result = mergeAllOfSchemaProperties(schema);
@@ -45,8 +45,8 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
       required: ['prop1'],
       properties: {
         prop1: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       allOf: [
         {
@@ -55,20 +55,20 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
           required: ['prop2'],
           properties: {
             prop2: {
-              type: 'integer'
-            }
-          }
+              type: 'integer',
+            },
+          },
         },
         {
           type: 'object',
           description: 'allOf[1]',
           properties: {
             prop3: {
-              type: 'boolean'
-            }
-          }
-        }
-      ]
+              type: 'boolean',
+            },
+          },
+        },
+      ],
     };
 
     const expectedResult = {
@@ -77,15 +77,15 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
       required: ['prop2', 'prop1'],
       properties: {
         prop1: {
-          type: 'string'
+          type: 'string',
         },
         prop2: {
-          type: 'integer'
+          type: 'integer',
         },
         prop3: {
-          type: 'boolean'
-        }
-      }
+          type: 'boolean',
+        },
+      },
     };
 
     expect(mergeAllOfSchemaProperties(schema)).toStrictEqual(expectedResult);
@@ -102,17 +102,17 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
             href: {
               type: 'string',
               description: 'the href property',
-              example: 'the wrong href example'
-            }
-          }
-        }
+              example: 'the wrong href example',
+            },
+          },
+        },
       ],
       description: 'a link to the first page of results',
       properties: {
         href: {
-          example: 'the correct href example'
-        }
-      }
+          example: 'the correct href example',
+        },
+      },
     };
 
     const expectedResult = {
@@ -123,9 +123,9 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
         href: {
           type: 'string',
           description: 'the href property',
-          example: 'the correct href example'
-        }
-      }
+          example: 'the correct href example',
+        },
+      },
     };
 
     expect(mergeAllOfSchemaProperties(schema)).toStrictEqual(expectedResult);
@@ -144,15 +144,15 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
               type: 'integer',
               default: 10,
               minimum: 1,
-              maximum: 100
+              maximum: 100,
             },
             offset: {
               description: 'The offset.',
               type: 'integer',
               default: 0,
-              minimum: 0
-            }
-          }
+              minimum: 0,
+            },
+          },
         },
         {
           type: 'object',
@@ -163,12 +163,12 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
               description: 'The resources contained in a page of list results.',
               type: 'array',
               items: {
-                type: 'string'
-              }
-            }
-          }
-        }
-      ]
+                type: 'string',
+              },
+            },
+          },
+        },
+      ],
     };
 
     const expectedResult = {
@@ -181,22 +181,22 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
           type: 'integer',
           default: 10,
           minimum: 1,
-          maximum: 100
+          maximum: 100,
         },
         offset: {
           description: 'The offset.',
           type: 'integer',
           default: 0,
-          minimum: 0
+          minimum: 0,
         },
         resources: {
           description: 'The resources contained in a page of list results.',
           type: 'array',
           items: {
-            type: 'string'
-          }
-        }
-      }
+            type: 'string',
+          },
+        },
+      },
     };
 
     expect(mergeAllOfSchemaProperties(schema)).toStrictEqual(expectedResult);
@@ -209,8 +209,8 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
       required: ['prop1'],
       properties: {
         prop1: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       },
       allOf: [
         {
@@ -219,48 +219,48 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
           required: ['prop2'],
           properties: {
             prop2: {
-              type: 'integer'
-            }
+              type: 'integer',
+            },
           },
           allOf: [
             {
               description: 'allOf[0][0]',
               properties: {
                 prop2a: {
-                  type: 'string'
-                }
+                  type: 'string',
+                },
               },
               allOf: [
                 {
                   description: 'allOf[0][0][0]',
                   properties: {
                     prop2aa: {
-                      type: 'string'
-                    }
-                  }
-                }
-              ]
+                      type: 'string',
+                    },
+                  },
+                },
+              ],
             },
             {
               description: 'allOf[0][1]',
               properties: {
                 prop2b: {
-                  type: 'integer'
-                }
-              }
-            }
-          ]
+                  type: 'integer',
+                },
+              },
+            },
+          ],
         },
         {
           type: 'object',
           description: 'allOf[1]',
           properties: {
             prop3: {
-              type: 'boolean'
-            }
-          }
-        }
-      ]
+              type: 'boolean',
+            },
+          },
+        },
+      ],
     };
 
     const expectedResult = {
@@ -269,24 +269,24 @@ describe('Utility function: mergeAllOfSchemaProperties()', () => {
       required: ['prop2', 'prop1'],
       properties: {
         prop1: {
-          type: 'string'
+          type: 'string',
         },
         prop2: {
-          type: 'integer'
+          type: 'integer',
         },
         prop2a: {
-          type: 'string'
+          type: 'string',
         },
         prop2aa: {
-          type: 'string'
+          type: 'string',
         },
         prop2b: {
-          type: 'integer'
+          type: 'integer',
         },
         prop3: {
-          type: 'boolean'
-        }
-      }
+          type: 'boolean',
+        },
+      },
     };
 
     expect(mergeAllOfSchemaProperties(schema)).toStrictEqual(expectedResult);

--- a/packages/ruleset/test/merge-patch-properties.test.js
+++ b/packages/ruleset/test/merge-patch-properties.test.js
@@ -24,14 +24,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.requestBodies.UpdateCarRequest.content = {
         'application/json': {
           schema: {
-            $ref: '#/components/schemas/Car'
+            $ref: '#/components/schemas/Car',
           },
           examples: {
             RequestExample: {
-              $ref: '#/components/examples/CarExample'
-            }
-          }
-        }
+              $ref: '#/components/examples/CarExample',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -46,14 +46,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.requestBodies.UpdateCarRequest.content = {
         'application/merge-patch+json; charset=utf-8': {
           schema: {
-            $ref: '#/components/schemas/Car'
+            $ref: '#/components/schemas/Car',
           },
           examples: {
             RequestExample: {
-              $ref: '#/components/examples/CarExample'
-            }
-          }
-        }
+              $ref: '#/components/examples/CarExample',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -91,12 +91,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['CarPatch'] = {
         allOf: [
           {
-            $ref: '#/components/schemas/CarPatchProperties'
+            $ref: '#/components/schemas/CarPatchProperties',
           },
           {
-            required: ['make', 'model']
-          }
-        ]
+            required: ['make', 'model'],
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -118,12 +118,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['CarPatch'] = {
         allOf: [
           {
-            $ref: '#/components/schemas/CarPatchProperties'
+            $ref: '#/components/schemas/CarPatchProperties',
           },
           {
-            minProperties: 1
-          }
-        ]
+            minProperties: 1,
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -145,20 +145,20 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['CarPatch'] = {
         allOf: [
           {
-            $ref: '#/components/schemas/CarPatchProperties'
+            $ref: '#/components/schemas/CarPatchProperties',
           },
           {
             allOf: [
               {
                 allOf: [
                   {
-                    required: ['make', 'model']
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+                    required: ['make', 'model'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -180,20 +180,20 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['CarPatch'] = {
         allOf: [
           {
-            $ref: '#/components/schemas/CarPatchProperties'
+            $ref: '#/components/schemas/CarPatchProperties',
           },
           {
             allOf: [
               {
                 allOf: [
                   {
-                    minProperties: 1
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+                    minProperties: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/meta/spectral-depedencies.test.js
+++ b/packages/ruleset/test/meta/spectral-depedencies.test.js
@@ -9,16 +9,16 @@ describe('Spectral behavior dependencies', () => {
           Parent: {
             properties: {
               one: {
-                $ref: '#/components/schemas/Same'
+                $ref: '#/components/schemas/Same',
               },
               two: {
-                $ref: '#/components/schemas/Same'
-              }
-            }
+                $ref: '#/components/schemas/Same',
+              },
+            },
           },
-          Same: {}
-        }
-      }
+          Same: {},
+        },
+      },
     };
 
     let ruleWasExecuted = false;
@@ -37,8 +37,8 @@ describe('Spectral behavior dependencies', () => {
       resolved: true,
       given: '$.components.schemas.Parent',
       then: {
-        function: checkReferencesFunction
-      }
+        function: checkReferencesFunction,
+      },
     };
 
     await testRule('resolved-references', resolvedRefsRule, twoRefsDocument);

--- a/packages/ruleset/test/mimetype-utils.test.js
+++ b/packages/ruleset/test/mimetype-utils.test.js
@@ -7,7 +7,7 @@ const {
   isJsonMimeType,
   isJsonPatchMimeType,
   isMergePatchMimeType,
-  isFormMimeType
+  isFormMimeType,
 } = require('../src/utils');
 
 describe('MimeType utility functions', () => {

--- a/packages/ruleset/test/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/operationid-naming-convention.test.js
@@ -9,7 +9,8 @@ const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 const rule = operationIdNamingConvention;
 const ruleId = 'ibm-operation-id-naming-convention';
 const expectedSeverity = severityCodes.warning;
-const expectedMsgPrefix = /^operationIds should follow naming convention: operationId verb should be.*$/;
+const expectedMsgPrefix =
+  /^operationIds should follow naming convention: operationId verb should be.*$/;
 
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
@@ -24,7 +25,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
       newGet.operationId = 'check_glass';
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
-        get: newGet
+        get: newGet,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -37,7 +38,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
       newGet.operationId = 'get_glass';
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
-        get: newGet
+        get: newGet,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -50,7 +51,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
       newGet.operationId = 'anything_goes';
       testDocument.paths['/v1/drinks/{drink_id}/glass'] = {
-        get: newGet
+        get: newGet,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -61,7 +62,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].post = {
-        operationId: 'create_drink'
+        operationId: 'create_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -72,7 +73,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].put = {
-        operationId: 'replace_drinks'
+        operationId: 'replace_drinks',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -83,7 +84,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].put = {
-        operationId: 'replace_drink'
+        operationId: 'replace_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -96,8 +97,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // This should not fail as it is not considered to be "resource-oriented".
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         put: {
-          operationId: 'replace_glasses'
-        }
+          operationId: 'replace_glasses',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -109,8 +110,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         put: {
-          operationId: 'set_drink_glass'
-        }
+          operationId: 'set_drink_glass',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -122,8 +123,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         put: {
-          operationId: 'add_drink_glass'
-        }
+          operationId: 'add_drink_glass',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -134,7 +135,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].delete = {
-        operationId: 'delete_drink'
+        operationId: 'delete_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -146,8 +147,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         delete: {
-          operationId: 'unset_glasses'
-        }
+          operationId: 'unset_glasses',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -159,15 +160,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         delete: {
-          operationId: 'delete_drink_glasses'
-        }
+          operationId: 'delete_drink_glasses',
+        },
       };
 
       // Add another path so this API will be resource-oriented.
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         get: {
-          operationId: 'get_drink_glass'
-        }
+          operationId: 'get_drink_glass',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -179,8 +180,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         delete: {
-          operationId: 'remove_drink_glass'
-        }
+          operationId: 'remove_drink_glass',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -228,7 +229,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
       newGet.operationId = 'empty_glass';
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
-        get: newGet
+        get: newGet,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -261,7 +262,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].post = {
-        operationId: 'top_off_drink'
+        operationId: 'top_off_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -280,7 +281,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].patch = {
-        operationId: 'refill_drink'
+        operationId: 'refill_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -299,7 +300,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].put = {
-        operationId: 'stole_my_drink'
+        operationId: 'stole_my_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -318,7 +319,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].put = {
-        operationId: 'move_drinks'
+        operationId: 'move_drinks',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -335,7 +336,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].put = {
-        operationId: 'take_a_drink'
+        operationId: 'take_a_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -355,8 +356,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         put: {
-          operationId: 'smash_drink_glasses'
-        }
+          operationId: 'smash_drink_glasses',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -376,8 +377,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         put: {
-          operationId: 'smash_drink_glass'
-        }
+          operationId: 'smash_drink_glass',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -396,7 +397,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].delete = {
-        operationId: 'eliminate_drink'
+        operationId: 'eliminate_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -416,8 +417,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         delete: {
-          operationId: 'remove_drink_glass'
-        }
+          operationId: 'remove_drink_glass',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -437,8 +438,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         delete: {
-          operationId: 'smash_drink_glass'
-        }
+          operationId: 'smash_drink_glass',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/optional-request-body.test.js
+++ b/packages/ruleset/test/optional-request-body.test.js
@@ -64,17 +64,17 @@ describe(`Spectral rule: ${ruleId}`, () => {
             schema: {
               allOf: [
                 {
-                  $ref: '#/components/schemas/Car'
-                }
-              ]
+                  $ref: '#/components/schemas/Car',
+                },
+              ],
             },
             examples: {
               RequestExample: {
-                $ref: '#/components/examples/CarExample'
-              }
-            }
-          }
-        }
+                $ref: '#/components/examples/CarExample',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/pagination-style.test.js
+++ b/packages/ruleset/test/pagination-style.test.js
@@ -45,12 +45,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
           description: 'An invalid limit param',
           required: true,
           schema: {
-            type: 'boolean'
-          }
-        }
+            type: 'boolean',
+          },
+        },
       ];
       testDocument.paths['/v1/drinks/limitcheck'] = {
-        post: newPost
+        post: newPost,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -65,7 +65,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Next, add this invalid get operation to a new path that will be excluded.
       testDocument.paths['/v1/drinks/invalid/{path_param}'] = {
-        get: invalidGet
+        get: invalidGet,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -120,8 +120,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'text/plain'
       ] = {
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       };
       delete testDocument.paths['/v1/drinks'].get.responses['200'].content[
         'application/json'
@@ -141,7 +141,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json'
       ].schema = {
         type: 'object',
-        additionalProperties: true
+        additionalProperties: true,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -160,9 +160,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'object',
         properties: {
           not_an_array: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -181,9 +181,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           description: 'An invalid limit param',
           required: true,
           schema: {
-            type: 'boolean'
-          }
-        }
+            type: 'boolean',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -224,7 +224,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.paths['/v1/drinks'].get.parameters[1].schema = {
-          type: 'boolean'
+          type: 'boolean',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -282,7 +282,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.paths['/v1/drinks'].get.parameters[0].schema = {
-          type: 'string'
+          type: 'string',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -328,7 +328,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.paths['/v1/movies'].get.parameters[1].schema = {
-          type: 'integer'
+          type: 'integer',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -393,7 +393,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas[
           'OffsetPaginationBase'
         ].properties.limit = {
-          type: 'string'
+          type: 'string',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -412,7 +412,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         // Remove "limit" from required list.
         testDocument.components.schemas['OffsetPaginationBase'].required = [
           'offset',
-          'total_count'
+          'total_count',
         ];
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -449,7 +449,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas[
           'OffsetPaginationBase'
         ].properties.offset = {
-          type: 'boolean'
+          type: 'boolean',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -468,7 +468,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         // Remove "offset" from required list.
         testDocument.components.schemas['OffsetPaginationBase'].required = [
           'limit',
-          'total_count'
+          'total_count',
         ];
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -489,7 +489,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas[
           'OffsetPaginationBase'
         ].properties.total_count = {
-          type: 'boolean'
+          type: 'boolean',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -508,7 +508,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         // Remove "total_count" from required list.
         testDocument.components.schemas['OffsetPaginationBase'].required = [
           'limit',
-          'offset'
+          'offset',
         ];
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -554,19 +554,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         // Define new pagelink properties as strings.
         const stringSchema = {
-          type: 'string'
+          type: 'string',
         };
         const newPageLinks = {
           first: stringSchema,
           last: stringSchema,
           previous: stringSchema,
-          next: stringSchema
+          next: stringSchema,
         };
 
         // Overlay the new pagelink properties onto the schema.
         testDocument.components.schemas['OffsetPaginationBase'].properties = {
           ...paginationProps,
-          ...newPageLinks
+          ...newPageLinks,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -588,19 +588,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         // Define pagelink properties as objects with no properties.
         const pageLinkSchema = {
-          type: 'object'
+          type: 'object',
         };
         const newPageLinks = {
           first: pageLinkSchema,
           last: pageLinkSchema,
           previous: pageLinkSchema,
-          next: pageLinkSchema
+          next: pageLinkSchema,
         };
 
         // Overlay the new pagelink properties onto the schema.
         testDocument.components.schemas['OffsetPaginationBase'].properties = {
           ...paginationProps,
-          ...newPageLinks
+          ...newPageLinks,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -625,21 +625,21 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             not_href: {
-              type: 'string'
-            }
-          }
+              type: 'string',
+            },
+          },
         };
         const newPageLinks = {
           first: pageLinkSchema,
           last: pageLinkSchema,
           previous: pageLinkSchema,
-          next: pageLinkSchema
+          next: pageLinkSchema,
         };
 
         // Overlay the new pagelink properties onto the schema.
         testDocument.components.schemas['OffsetPaginationBase'].properties = {
           ...paginationProps,
-          ...newPageLinks
+          ...newPageLinks,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -664,21 +664,21 @@ describe(`Spectral rule: ${ruleId}`, () => {
           type: 'object',
           properties: {
             not_href: {
-              type: 'boolean'
-            }
-          }
+              type: 'boolean',
+            },
+          },
         };
         const newPageLinks = {
           first: pageLinkSchema,
           last: pageLinkSchema,
           previous: pageLinkSchema,
-          next: pageLinkSchema
+          next: pageLinkSchema,
         };
 
         // Overlay the new pagelink properties onto the schema.
         testDocument.components.schemas['OffsetPaginationBase'].properties = {
           ...paginationProps,
-          ...newPageLinks
+          ...newPageLinks,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -717,5 +717,7 @@ const expectedMsgStartParamName =
   'The "page_token" parameter should be named "start"';
 const expectedMsgTotalCountProp =
   'The "total_count" property in the response body of a paginated list operation must be of type integer and required';
-const expectedMsgPagelinkRE = /A paginated list operation should include a ".*" property in the response body schema/;
-const expectedMsgPagelinkObjectRE = /The ".*" property should be an object with an "href" string property/;
+const expectedMsgPagelinkRE =
+  /A paginated list operation should include a ".*" property in the response body schema/;
+const expectedMsgPagelinkObjectRE =
+  /The ".*" property should be an object with an "href" string property/;

--- a/packages/ruleset/test/parameter-casing-convention.test.js
+++ b/packages/ruleset/test/parameter-casing-convention.test.js
@@ -32,8 +32,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         required: false,
         in: 'query',
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -49,8 +49,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         required: false,
         in: 'query',
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -67,9 +67,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           required: false,
           in: 'path',
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -85,8 +85,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         required: false,
         in: 'header',
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -103,8 +103,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         in: 'query',
         deprecated: true,
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -121,8 +121,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         in: 'path',
         deprecated: true,
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -139,8 +139,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         in: 'header',
         deprecated: true,
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -188,8 +188,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         name: 'moveRating',
         in: 'query',
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -241,8 +241,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         name: 'moveRating',
         in: 'header',
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       });
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/parameter-order.test.js
+++ b/packages/ruleset/test/parameter-order.test.js
@@ -32,8 +32,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
           description: 'A string used to filter the results.',
           required: true,
           schema: {
-            type: 'string'
-          }
+            type: 'string',
+          },
         },
         {
           name: 'max_pages',
@@ -41,9 +41,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           description: 'The max number of pages to return.',
           required: true,
           schema: {
-            type: 'integer'
-          }
-        }
+            type: 'integer',
+          },
+        },
       ];
       testDocument.paths['/v1/drinks'].get.parameters.push(...newParams);
 
@@ -72,12 +72,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
         description: 'A string used to filter the results.',
         required: true,
         schema: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       };
 
       testDocument.paths['/v1/drinks'].get.parameters.push({
-        $ref: '#/components/parameters/FilterParam'
+        $ref: '#/components/parameters/FilterParam',
       });
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/parameter-schema-or-content-exists.test.js
+++ b/packages/ruleset/test/parameter-schema-or-content-exists.test.js
@@ -23,9 +23,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         name: 'filter',
         in: 'query',
         schema: {
-          type: 'string'
-        }
-      }
+          type: 'string',
+        },
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -41,11 +41,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
         content: {
           'application/json': {
             schema: {
-              type: 'object'
-            }
-          }
-        }
-      }
+              type: 'object',
+            },
+          },
+        },
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -57,8 +57,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.paths['/v1/movies'].post.parameters = [
       {
         name: 'filter',
-        in: 'query'
-      }
+        in: 'query',
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -74,7 +74,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       '/v1/movies',
       'post',
       'parameters',
-      '0'
+      '0',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });

--- a/packages/ruleset/test/patch-request-content-type.test.js
+++ b/packages/ruleset/test/patch-request-content-type.test.js
@@ -25,14 +25,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.requestBodies.UpdateCarRequest.content = {
         'application/json-patch+json; blah': {
           schema: {
-            $ref: '#/components/schemas/Car'
+            $ref: '#/components/schemas/Car',
           },
           examples: {
             RequestExample: {
-              $ref: '#/components/examples/CarExample'
-            }
-          }
-        }
+              $ref: '#/components/examples/CarExample',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -47,14 +47,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.requestBodies.UpdateCarRequest.content = {
         'application/json': {
           schema: {
-            $ref: '#/components/schemas/Car'
+            $ref: '#/components/schemas/Car',
           },
           examples: {
             RequestExample: {
-              $ref: '#/components/examples/CarExample'
-            }
-          }
-        }
+              $ref: '#/components/examples/CarExample',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/path-matches-regexp.test.js
+++ b/packages/ruleset/test/path-matches-regexp.test.js
@@ -15,7 +15,7 @@ describe('Test pathMatchesRegexp() function', () => {
       '200',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ];
     const path2 = ['components', 'schemas', 'Foo', 'properties', 'foo_prop'];
     const path3 = [
@@ -25,7 +25,7 @@ describe('Test pathMatchesRegexp() function', () => {
       'allOf',
       '0',
       'properties',
-      'foo_prop'
+      'foo_prop',
     ];
     const path4 = [
       'components',
@@ -33,7 +33,7 @@ describe('Test pathMatchesRegexp() function', () => {
       'FooRequest',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ];
     const path5 = ['paths', '/v1/drinks', 'get', 'parameters', '0', 'schema'];
 

--- a/packages/ruleset/test/path-parameter-not-crn.test.js
+++ b/packages/ruleset/test/path-parameter-not-crn.test.js
@@ -114,12 +114,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.parameters.MovieIdParam.examples = {
         good: {
           description: 'A good example',
-          value: '88adez-01abdfe'
+          value: '88adez-01abdfe',
         },
         bad: {
           description: 'A bad example',
-          value: 'crn:88adez-01abdfe'
-        }
+          value: 'crn:88adez-01abdfe',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/property-attributes.test.js
+++ b/packages/ruleset/test/property-attributes.test.js
@@ -23,7 +23,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'integer',
-          minimum: 3
+          minimum: 3,
         };
 
         const results = await testRule(ruleId, rule, rootDocument);
@@ -34,7 +34,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'integer',
-          maximum: 3
+          maximum: 3,
         };
 
         const results = await testRule(ruleId, rule, rootDocument);
@@ -46,7 +46,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'integer',
           minimum: 3,
-          maximum: 4
+          maximum: 4,
         };
 
         const results = await testRule(ruleId, rule, rootDocument);
@@ -60,7 +60,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'object',
-          minProperties: 3
+          minProperties: 3,
         };
 
         const results = await testRule(ruleId, rule, rootDocument);
@@ -71,7 +71,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'object',
-          maxProperties: 3
+          maxProperties: 3,
         };
 
         const results = await testRule(ruleId, rule, rootDocument);
@@ -83,7 +83,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'object',
           minProperties: 3,
-          maxProperties: 10
+          maxProperties: 10,
         };
 
         const results = await testRule(ruleId, rule, rootDocument);
@@ -100,7 +100,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'integer',
           minimum: 4,
-          maximum: 3
+          maximum: 3,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -109,7 +109,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minimum',
-          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minimum'
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minimum',
         ];
         for (let i = 0; i < results.length; i++) {
           expect(results[i].code).toBe(ruleId);
@@ -125,7 +125,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'string',
-          minimum: 4
+          minimum: 4,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -134,7 +134,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minimum',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minimum',
-          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minimum'
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minimum',
         ];
         for (let i = 0; i < results.length; i++) {
           expect(results[i].code).toBe(ruleId);
@@ -150,7 +150,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'object',
-          maximum: 4
+          maximum: 4,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -159,7 +159,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.maximum',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.maximum',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.maximum',
-          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maximum'
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maximum',
         ];
         for (let i = 0; i < results.length; i++) {
           expect(results[i].code).toBe(ruleId);
@@ -179,7 +179,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'object',
           minProperties: 5,
-          maxProperties: 4
+          maxProperties: 4,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -188,7 +188,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minProperties',
-          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minProperties'
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minProperties',
         ];
         for (let i = 0; i < results.length; i++) {
           expect(results[i].code).toBe(ruleId);
@@ -204,7 +204,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'integer',
-          minProperties: 3
+          minProperties: 3,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -213,7 +213,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.minProperties',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.minProperties',
-          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minProperties'
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.minProperties',
         ];
         for (let i = 0; i < results.length; i++) {
           expect(results[i].code).toBe(ruleId);
@@ -230,7 +230,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'number',
           format: 'double',
-          maxProperties: 3
+          maxProperties: 3,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -239,7 +239,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'paths./v1/cars.post.requestBody.content.application/json.schema.properties.wheel_count.maxProperties',
           'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.maxProperties',
           'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.maxProperties',
-          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maxProperties'
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.maxProperties',
         ];
         for (let i = 0; i < results.length; i++) {
           expect(results[i].code).toBe(ruleId);

--- a/packages/ruleset/test/property-casing-convention.test.js
+++ b/packages/ruleset/test/property-casing-convention.test.js
@@ -27,9 +27,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         plotSummary: {
           type: 'string',
           description: 'Synopsis of the movie',
-          deprecated: true
-        }
-      }
+          deprecated: true,
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -46,9 +46,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       properties: {
         plotSummary: {
           type: 'string',
-          description: 'Synopsis of the movie'
-        }
-      }
+          description: 'Synopsis of the movie',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/property-consistent-name-and-type.test.js
+++ b/packages/ruleset/test/property-consistent-name-and-type.test.js
@@ -47,9 +47,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           message: {
             type: 'integer',
             description: 'Main message of the movie.',
-            deprecated: true
-          }
-        }
+            deprecated: true,
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,14 +69,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     code: {
                       type: 'integer',
-                      description: 'Integer code'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Integer code',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       testDocument.paths['/v1/songs'] = {
@@ -90,14 +90,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     code: {
                       type: 'boolean',
-                      description: 'Boolean code'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Boolean code',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -118,14 +118,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     default: {
                       type: 'integer',
-                      description: 'Integer default'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Integer default',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       testDocument.paths['/v1/songs'] = {
@@ -139,14 +139,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     default: {
                       type: 'boolean',
-                      description: 'Boolean default'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Boolean default',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -167,14 +167,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     type: {
                       type: 'integer',
-                      description: 'Integer type'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Integer type',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       testDocument.paths['/v1/songs'] = {
@@ -188,14 +188,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     type: {
                       type: 'boolean',
-                      description: 'Boolean type'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Boolean type',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -216,14 +216,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     value: {
                       type: 'integer',
-                      description: 'Integer value'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Integer value',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       testDocument.paths['/v1/songs'] = {
@@ -237,14 +237,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     value: {
                       type: 'boolean',
-                      description: 'Boolean value'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Boolean value',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -267,14 +267,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     running_time: {
                       type: 'string',
-                      description: 'Running time of the audiobook form.'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Running time of the audiobook form.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -315,14 +315,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     running_time: {
                       type: 'string',
-                      description: 'Running time of the audiobook form.'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Running time of the audiobook form.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       testDocument.paths['/v1/songs'] = {
@@ -336,14 +336,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   properties: {
                     running_time: {
                       type: 'boolean',
-                      description: 'Running time of the song.'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+                      description: 'Running time of the song.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/property-description-exists.test.js
+++ b/packages/ruleset/test/property-description-exists.test.js
@@ -33,21 +33,21 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 properties: {
                   prop1: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               },
               {
                 properties: {
                   prop2: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -73,32 +73,32 @@ describe(`Spectral rule: ${ruleId}`, () => {
                     properties: {
                       prop1: {
                         description: 'a description',
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   {
                     description: 'a description',
                     properties: {
                       prop2: {
                         description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
+                        type: 'string',
+                      },
+                    },
+                  },
+                ],
               },
               {
                 properties: {
                   prop3: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -114,13 +114,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // for the create operation only.
       const movie2 = makeCopy(testDocument.components.schemas['Movie']);
       movie2.properties['director'] = {
-        type: 'string'
+        type: 'string',
       };
       testDocument.components.schemas['Movie2'] = movie2;
       testDocument.paths['/v1/movies'].post.responses['201'].content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Movie2'
+        $ref: '#/components/schemas/Movie2',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -149,15 +149,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description:
               'The array of error entries associated with the error response',
             items: {
-              $ref: '#/components/schemas/Error'
-            }
+              $ref: '#/components/schemas/Error',
+            },
           },
           trace: {
             description: '   ',
             type: 'string',
-            format: 'uuid'
-          }
-        }
+            format: 'uuid',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -213,21 +213,21 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 properties: {
                   prop1: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               },
               {
                 properties: {
                   prop2: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -254,22 +254,22 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 properties: {
                   prop1: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               },
               {
                 description: 'a description',
                 properties: {
                   prop2: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -296,22 +296,22 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 properties: {
                   prop1: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               },
               {
                 description: 'a description',
                 properties: {
                   prop2: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -340,32 +340,32 @@ describe(`Spectral rule: ${ruleId}`, () => {
                     properties: {
                       prop1a: {
                         description: 'a description',
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   {
                     properties: {
                       prop1b: {
                         description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
+                        type: 'string',
+                      },
+                    },
+                  },
+                ],
               },
               {
                 description: 'a description',
                 properties: {
                   prop2: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -394,32 +394,32 @@ describe(`Spectral rule: ${ruleId}`, () => {
                     properties: {
                       prop1a: {
                         description: 'a description',
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   {
                     properties: {
                       prop1b: {
                         description: 'a description',
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
+                        type: 'string',
+                      },
+                    },
+                  },
+                ],
               },
               {
                 description: 'a description',
                 properties: {
                   prop2: {
                     description: 'a description',
-                    type: 'string'
-                  }
-                }
-              }
-            ]
-          }
-        }
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/property-name-collision.test.js
+++ b/packages/ruleset/test/property-name-collision.test.js
@@ -21,10 +21,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     testDocument.components.schemas.Movie.properties.IMDBRating = {
       type: 'string',
-      deprecated: true
+      deprecated: true,
     };
     testDocument.components.schemas.Movie.properties.IDMB_rating = {
-      type: 'string'
+      type: 'string',
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -36,10 +36,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const testDocument = makeCopy(rootDocument);
 
     testDocument.components.schemas.Movie.properties.IMDBRating = {
-      type: 'string'
+      type: 'string',
     };
     testDocument.components.schemas.Movie.properties.IMDB_rating = {
-      type: 'string'
+      type: 'string',
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -60,7 +60,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json',
       'schema',
       'properties',
-      'IMDB_rating'
+      'IMDB_rating',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });

--- a/packages/ruleset/test/ref-pattern.test.js
+++ b/packages/ruleset/test/ref-pattern.test.js
@@ -22,7 +22,7 @@ const expectedMsgs = {
   responses: "$refs to responses should start with '#/components/responses/'",
   schemas: "$refs to schemas should start with '#/components/schemas/'",
   securitySchemes:
-    "$refs to securitySchemes should start with '#/components/securitySchemes/'"
+    "$refs to securitySchemes should start with '#/components/securitySchemes/'",
 };
 
 describe(`Spectral rule: ${ruleId}`, () => {
@@ -40,7 +40,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // Move the CarIdParam from components.parameters to
       // components.params.
       testDocument.components.params = {
-        CarIdParam: testDocument.components.parameters.CarIdParam
+        CarIdParam: testDocument.components.parameters.CarIdParam,
       };
       delete testDocument.components.parameters.CarIdParam;
 
@@ -63,7 +63,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Create a simple schema under "components.definitions".
       testDocument.components.definitions = {
-        StringType: testDocument.components.schemas.IdString
+        StringType: testDocument.components.schemas.IdString,
       };
 
       // Create a reference to this mis-located schema.
@@ -85,7 +85,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Move a named response from "components.responses" to "components.answers".
       testDocument.components.answers = {
-        CarResponse: testDocument.components.responses.CarResponse
+        CarResponse: testDocument.components.responses.CarResponse,
       };
 
       // Create a reference to this mis-located response.
@@ -107,7 +107,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Move a named requestBody from "components.requestBodies" to "components.requests".
       testDocument.components.requests = {
-        CarRequest: testDocument.components.requestBodies.CarRequest
+        CarRequest: testDocument.components.requestBodies.CarRequest,
       };
 
       // Create a reference to this mis-located response.
@@ -129,7 +129,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Move a named example from "components.examples" to "samples".
       testDocument.samples = {
-        CarSample: testDocument.components.examples.CarExample
+        CarSample: testDocument.components.examples.CarExample,
       };
 
       // Create a reference to this mis-located example.
@@ -152,7 +152,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Move a named link from "components.links" to "relationships".
       testDocument.relationships = {
-        CarIdLinkage: testDocument.components.links.CarIdLink
+        CarIdLinkage: testDocument.components.links.CarIdLink,
       };
 
       // Create a reference to this mis-located link.
@@ -178,13 +178,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
           in: 'header',
           name: 'Protected',
           type: 'http',
-          scheme: 'MobRule'
-        }
+          scheme: 'MobRule',
+        },
       };
 
       // Create a reference to this mis-located security scheme.
       testDocument.components.securitySchemes.VinnysCrew = {
-        $ref: '#/components/protection/VinnysCrew'
+        $ref: '#/components/protection/VinnysCrew',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/ref-sibling-duplicate-description.test.js
+++ b/packages/ruleset/test/ref-sibling-duplicate-description.test.js
@@ -23,15 +23,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.TokenPaginationBase.properties.last = {
         allOf: [
           {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           {
-            description: testDocument.components.schemas.PageLink.description
+            description: testDocument.components.schemas.PageLink.description,
           },
           {
-            description: 'Not a duplicate'
-          }
-        ]
+            description: 'Not a duplicate',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -46,12 +46,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.TokenPaginationBase.properties.last = {
         allOf: [
           {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           {
-            description: testDocument.components.schemas.PageLink.description
-          }
-        ]
+            description: testDocument.components.schemas.PageLink.description,
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -69,15 +69,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.TokenPaginationBase.properties.last = {
         allOf: [
           {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           {
-            description: 'foo'
+            description: 'foo',
           },
           {
-            description: testDocument.components.schemas.PageLink.description
-          }
-        ]
+            description: testDocument.components.schemas.PageLink.description,
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -95,10 +95,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas.TokenPaginationBase.properties.last = {
         allOf: [
           {
-            $ref: '#/components/schemas/PageLink'
-          }
+            $ref: '#/components/schemas/PageLink',
+          },
         ],
-        description: testDocument.components.schemas.PageLink.description
+        description: testDocument.components.schemas.PageLink.description,
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/requestbody-is-object.test.js
+++ b/packages/ruleset/test/requestbody-is-object.test.js
@@ -24,9 +24,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       description: 'this is implicitly an object',
       properties: {
         foo: {
-          type: 'string'
-        }
-      }
+          type: 'string',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -40,9 +40,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json; charset=utf-8': {
         schema: {
           type: 'array',
-          description: 'this should be an object'
-        }
-      }
+          description: 'this should be an object',
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -62,7 +62,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'content',
       'application/json; charset=utf-8',
       'schema',
-      'type'
+      'type',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });

--- a/packages/ruleset/test/requestbody-name-exists.test.js
+++ b/packages/ruleset/test/requestbody-name-exists.test.js
@@ -30,8 +30,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/octet-stream'
       ] = {
         schema: {
-          $ref: '#/components/schemas/Movie'
-        }
+          $ref: '#/components/schemas/Movie',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -55,7 +55,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/movies'].post['x-codegen-request-body-name'] =
         'movie';
       testDocument.components.schemas.Movie.discriminator = {
-        propertyName: 'type'
+        propertyName: 'type',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -71,9 +71,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/octet-stream': {
           schema: {
             type: 'string',
-            format: 'binary'
-          }
-        }
+            format: 'binary',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -90,10 +90,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
           schema: {
             type: 'array',
             items: {
-              type: 'string'
-            }
-          }
-        }
+              type: 'string',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -109,18 +109,18 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'object',
             properties: {
               form_param_1: {
-                $ref: '#/components/schemas/NormalString'
+                $ref: '#/components/schemas/NormalString',
               },
               form_param_2: {
-                $ref: '#/components/schemas/NormalString'
+                $ref: '#/components/schemas/NormalString',
               },
               form_param_3: {
                 type: 'string',
-                format: 'binary'
-              }
-            }
-          }
-        }
+                format: 'binary',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -137,8 +137,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/octet-stream'
       ] = {
         schema: {
-          $ref: '#/components/schemas/Movie'
-        }
+          $ref: '#/components/schemas/Movie',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -183,7 +183,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas.Movie.discriminator = {
-        propertyName: 'type'
+        propertyName: 'type',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -201,9 +201,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/octet-stream': {
           schema: {
             type: 'string',
-            format: 'binary'
-          }
-        }
+            format: 'binary',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -222,10 +222,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
           schema: {
             type: 'array',
             items: {
-              type: 'string'
-            }
-          }
-        }
+              type: 'string',
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/required-property-missing.test.js
+++ b/packages/ruleset/test/required-property-missing.test.js
@@ -34,23 +34,23 @@ describe(`Spectral rule: ${ruleId}`, () => {
                       type: 'object',
                       properties: {
                         foo: {
-                          type: 'string'
-                        }
-                      }
+                          type: 'string',
+                        },
+                      },
                     },
                     {
                       type: 'object',
                       properties: {
                         bar: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
         ],
         requestBody: {
           content: {
@@ -63,31 +63,31 @@ describe(`Spectral rule: ${ruleId}`, () => {
                     type: 'object',
                     properties: {
                       foo: {
-                        type: 'string'
+                        type: 'string',
                       },
                       bar: {
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   {
                     type: 'object',
                     properties: {
                       foo: {
-                        type: 'string'
+                        type: 'string',
                       },
                       baz: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
+                        type: 'string',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
         },
         responses: {
-          '201': {
+          201: {
             content: {
               'application/json': {
                 schema: {
@@ -98,31 +98,31 @@ describe(`Spectral rule: ${ruleId}`, () => {
                       type: 'object',
                       properties: {
                         foo: {
-                          type: 'string'
+                          type: 'string',
                         },
                         bar: {
-                          type: 'string'
-                        }
-                      }
+                          type: 'string',
+                        },
+                      },
                     },
                     {
                       type: 'object',
                       properties: {
                         foo: {
-                          type: 'string'
+                          type: 'string',
                         },
                         baz: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -147,16 +147,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
                     required: ['foo'],
                     properties: {
                       baz: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        ]
-      }
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -183,25 +183,25 @@ describe(`Spectral rule: ${ruleId}`, () => {
                       type: 'object',
                       properties: {
                         baz: {
-                          type: 'string'
-                        }
-                      }
+                          type: 'string',
+                        },
+                      },
                     },
                     {
                       type: 'object',
                       properties: {
                         bar: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -221,7 +221,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       '0',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });
@@ -242,27 +242,27 @@ describe(`Spectral rule: ${ruleId}`, () => {
                     type: 'object',
                     properties: {
                       foo: {
-                        type: 'string'
+                        type: 'string',
                       },
                       bar: {
-                        type: 'string'
-                      }
-                    }
+                        type: 'string',
+                      },
+                    },
                   },
                   {
                     type: 'object',
                     properties: {
                       baz: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        }
-      }
+                        type: 'string',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -281,7 +281,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'requestBody',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });
@@ -291,7 +291,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     testDocument.paths['v1/books'] = {
       post: {
         responses: {
-          '201': {
+          201: {
             content: {
               'application/json': {
                 schema: {
@@ -303,28 +303,28 @@ describe(`Spectral rule: ${ruleId}`, () => {
                       type: 'object',
                       properties: {
                         foo: {
-                          type: 'string'
+                          type: 'string',
                         },
                         bar: {
-                          type: 'string'
-                        }
-                      }
+                          type: 'string',
+                        },
+                      },
                     },
                     {
                       type: 'object',
                       properties: {
                         baz: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
+                          type: 'string',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -344,7 +344,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       '201',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ]);
     expect(validation.severity).toBe(severityCodes.error);
   });
@@ -362,11 +362,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 schema: {
                   type: 'object',
                   required: ['foo'],
-                  properties: {}
-                }
-              }
-            }
-          }
+                  properties: {},
+                },
+              },
+            },
+          },
         ],
         requestBody: {
           content: {
@@ -374,25 +374,25 @@ describe(`Spectral rule: ${ruleId}`, () => {
               schema: {
                 type: 'object',
                 required: ['foo'],
-                properties: {}
-              }
-            }
-          }
+                properties: {},
+              },
+            },
+          },
         },
         responses: {
-          '201': {
+          201: {
             content: {
               'application/json': {
                 schema: {
                   type: 'object',
                   required: ['foo'],
-                  properties: {}
-                }
-              }
-            }
-          }
-        }
-      }
+                  properties: {},
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -413,7 +413,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       '0',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ]);
 
     expect(results[1].path).toStrictEqual([
@@ -423,7 +423,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'requestBody',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ]);
 
     expect(results[2].path).toStrictEqual([
@@ -434,7 +434,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       '201',
       'content',
       'application/json',
-      'schema'
+      'schema',
     ]);
   });
 });

--- a/packages/ruleset/test/response-example-exists.test.js
+++ b/packages/ruleset/test/response-example-exists.test.js
@@ -38,8 +38,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'application/json'
     ] = {
       schema: {
-        type: 'object'
-      }
+        type: 'object',
+      },
     };
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -58,7 +58,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'responses',
       '201',
       'content',
-      'application/json'
+      'application/json',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });

--- a/packages/ruleset/test/response-status-codes.test.js
+++ b/packages/ruleset/test/response-status-codes.test.js
@@ -21,9 +21,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].get.responses = {
-        '101': {
-          description: 'protocol-switching response'
-        }
+        101: {
+          description: 'protocol-switching response',
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -44,7 +44,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks'].post.operationId = 'pour_drink';
       testDocument.paths['/v1/drinks'].post.responses['202'] = {
-        description: 'Request to create new resource was accepted'
+        description: 'Request to create new resource was accepted',
       };
       delete testDocument.paths['/v1/drinks'].post.responses['201'];
 
@@ -95,7 +95,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks'].get.operationId = 'create_drink';
       testDocument.paths['/v1/drinks'].get.responses['202'] = {
-        description: 'Request to create new resource was accepted'
+        description: 'Request to create new resource was accepted',
       };
       delete testDocument.paths['/v1/drinks'].get.responses['200'];
 
@@ -129,7 +129,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].post.responses['302'] = {
-        description: 'response for "Found"'
+        description: 'response for "Found"',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -149,7 +149,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].post.responses['101'] = {
-        description: 'protocol switcheroo'
+        description: 'protocol switcheroo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/schema-description-exists.test.js
+++ b/packages/ruleset/test/schema-description-exists.test.js
@@ -34,12 +34,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Drink'] = {
         oneOf: [
           {
-            $ref: '#/components/schemas/Juice'
+            $ref: '#/components/schemas/Juice',
           },
           {
-            $ref: '#/components/schemas/Soda'
-          }
-        ]
+            $ref: '#/components/schemas/Soda',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -53,12 +53,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Drink'] = {
         anyOf: [
           {
-            $ref: '#/components/schemas/Juice'
+            $ref: '#/components/schemas/Juice',
           },
           {
-            $ref: '#/components/schemas/Soda'
-          }
-        ]
+            $ref: '#/components/schemas/Soda',
+          },
+        ],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -76,16 +76,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description: 'List of movie names.',
             type: 'array',
             items: {
-              type: 'string'
-            }
-          }
-        }
+              type: 'string',
+            },
+          },
+        },
       };
 
       testDocument.paths['/v1/movies'].get.responses['200'].content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/MovieNameList'
+        $ref: '#/components/schemas/MovieNameList',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -100,9 +100,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/drinks'].post.requestBody.content = {
         'text/html': {
           schema: {
-            type: 'string'
-          }
-        }
+            type: 'string',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -131,15 +131,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description:
               'The array of error entries associated with the error response',
             items: {
-              $ref: '#/components/schemas/Error'
-            }
+              $ref: '#/components/schemas/Error',
+            },
           },
           trace: {
             description: 'The error trace information.',
             type: 'string',
-            format: 'uuid'
-          }
-        }
+            format: 'uuid',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -162,7 +162,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/drinks'].post.responses['201'].content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Soda'
+        $ref: '#/components/schemas/Soda',
       };
 
       // We should get back a warning ONLY due to the Soda reference in the response (not the oneOf).

--- a/packages/ruleset/test/schema-type-exists.test.js
+++ b/packages/ruleset/test/schema-type-exists.test.js
@@ -40,19 +40,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
               {
                 allOf: [
                   {
-                    description: 'nested allOf definition'
+                    description: 'nested allOf definition',
                   },
                   {
-                    type: 'string'
-                  }
-                ]
+                    type: 'string',
+                  },
+                ],
               },
               {
-                description: 'overridden description, but no type'
-              }
-            ]
-          }
-        }
+                description: 'overridden description, but no type',
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -67,9 +67,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/drinks'].post.requestBody.content = {
         'text/html': {
           schema: {
-            description: 'a string schema, obviously'
-          }
-        }
+            description: 'a string schema, obviously',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -97,15 +97,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description:
               'The array of error entries associated with the error response',
             items: {
-              $ref: '#/components/schemas/Error'
-            }
+              $ref: '#/components/schemas/Error',
+            },
           },
           trace: {
             description: 'The error trace information.',
             type: 'string',
-            format: 'uuid'
-          }
-        }
+            format: 'uuid',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -128,11 +128,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
             description: 'under-specified request body object',
             properties: {
               important_property: {
-                description: 'what type am i?'
-              }
-            }
-          }
-        }
+                description: 'what type am i?',
+              },
+            },
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -158,16 +158,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 description: 'no type in allOf element',
                 properties: {
                   has_a_type: {
-                    type: 'string'
-                  }
-                }
+                    type: 'string',
+                  },
+                },
               },
               {
-                description: 'overridden description, but no type'
-              }
-            ]
-          }
-        }
+                description: 'overridden description, but no type',
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -192,16 +192,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
               {
                 allOf: [
                   {
-                    description: 'nested allOf definition'
-                  }
-                ]
+                    description: 'nested allOf definition',
+                  },
+                ],
               },
               {
-                description: 'overridden description, but no type'
-              }
-            ]
-          }
-        }
+                description: 'overridden description, but no type',
+              },
+            ],
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/schema-type-format.test.js
+++ b/packages/ruleset/test/schema-type-format.test.js
@@ -11,9 +11,12 @@ const ruleId = 'ibm-schema-type-format';
 const expectedSeverity = severityCodes.error;
 
 const errorMsgInvalidType = /^Invalid type. Valid types are:.*$/;
-const errorMsgStringFormat = /^Schema of type string should use one of the following formats:.*$/;
-const errorMsgIntegerFormat = /^Schema of type integer should use one of the following formats:.*$/;
-const errorMsgNumberFormat = /^Schema of type number should use one of the following formats:.*$/;
+const errorMsgStringFormat =
+  /^Schema of type string should use one of the following formats:.*$/;
+const errorMsgIntegerFormat =
+  /^Schema of type integer should use one of the following formats:.*$/;
+const errorMsgNumberFormat =
+  /^Schema of type number should use one of the following formats:.*$/;
 const errorMsgNoFormat = /^Schema of type .* should not have a format.*$/;
 const errorMsgFormatButNoType = /^Format defined without a type.$/;
 
@@ -22,94 +25,94 @@ const validPropertiesNoFormat = {
   array_prop: {
     type: 'array',
     items: {
-      type: 'string'
-    }
+      type: 'string',
+    },
   },
   bool_prop: {
-    type: 'boolean'
+    type: 'boolean',
   },
   int_prop: {
-    type: 'integer'
+    type: 'integer',
   },
   number_prop: {
-    type: 'number'
+    type: 'number',
   },
   object_prop: {
     type: 'object',
     properties: {
       prop1: {
-        type: 'string'
-      }
-    }
+        type: 'string',
+      },
+    },
   },
   string_prop: {
-    type: 'string'
-  }
+    type: 'string',
+  },
 };
 
 const validStringProperties = {
   binary_prop: {
     type: 'string',
-    format: 'binary'
+    format: 'binary',
   },
   byte_prop: {
     type: 'string',
-    format: 'byte'
+    format: 'byte',
   },
   crn_prop: {
     type: 'string',
-    format: 'crn'
+    format: 'crn',
   },
   date_prop: {
     type: 'string',
-    format: 'date'
+    format: 'date',
   },
   datetime_prop: {
     type: 'string',
-    format: 'date-time'
+    format: 'date-time',
   },
   email_prop: {
     type: 'string',
-    format: 'email'
+    format: 'email',
   },
   id_prop: {
     type: 'string',
-    format: 'identifier'
+    format: 'identifier',
   },
   pw: {
     type: 'string',
-    format: 'password'
+    format: 'password',
   },
   url_prop: {
     type: 'string',
-    format: 'url'
+    format: 'url',
   },
   uuid_prop: {
     type: 'string',
-    format: 'uuid'
-  }
+    format: 'uuid',
+  },
 };
 
 const validIntegerProperties = {
   int_prop: {
     type: 'integer',
-    format: 'int32'
+    format: 'int32',
   },
   long_prop: {
     type: 'integer',
-    format: 'int64'
-  }
+    format: 'int64',
+  },
 };
 
 const validNumberProperties = {
   float_prop: {
     type: 'number',
-    format: 'float'
+    format: 'float',
   },
   double_prop: {
     type: 'number',
-    format: 'double'
-  }
+    format: 'double',
+  },
 };
 
 describe(`Spectral rule: ${ruleId}`, () => {
@@ -124,12 +127,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['Foo'] = {
         type: 'object',
-        properties: validPropertiesNoFormat
+        properties: validPropertiesNoFormat,
       };
       testDocument.paths['/v1/drinks'].post.requestBody.content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -143,7 +146,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json'
       ].schema = {
         type: 'object',
-        properties: validPropertiesNoFormat
+        properties: validPropertiesNoFormat,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -157,7 +160,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json'
       ].schema = {
         type: 'object',
-        properties: validStringProperties
+        properties: validStringProperties,
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -169,12 +172,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['Foo'] = {
         type: 'object',
-        properties: validIntegerProperties
+        properties: validIntegerProperties,
       };
       testDocument.paths['/v1/drinks'].post.responses['201'].content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -186,10 +189,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['Foo'] = {
         type: 'object',
-        properties: validNumberProperties
+        properties: validNumberProperties,
       };
       testDocument.components.schemas['Movie'].properties['foo_prop'] = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -202,11 +205,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'array',
         items: {
           type: 'number',
-          format: 'double'
-        }
+          format: 'double',
+        },
       };
       testDocument.components.schemas['Movie'].properties['foo_prop'] = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -221,7 +224,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/drinks'].post.requestBody.content[
         'application/json'
       ].schema = {
-        type: 'invalid_type'
+        type: 'invalid_type',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -236,7 +239,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -249,9 +252,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'object',
         properties: {
           invalid_prop: {
-            type: 'invalid_type'
-          }
-        }
+            type: 'invalid_type',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -269,7 +272,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'invalid_prop'
+        'invalid_prop',
       ]);
     });
 
@@ -279,13 +282,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Foo'] = {
         type: 'array',
         items: {
-          type: 'invalid_type'
-        }
+          type: 'invalid_type',
+        },
       };
       testDocument.paths['/v1/drinks'].post.requestBody.content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -301,7 +304,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'content',
         'application/json',
         'schema',
-        'items'
+        'items',
       ]);
     });
 
@@ -312,7 +315,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json'
       ].schema = {
         type: 'object',
-        format: 'notanobject'
+        format: 'notanobject',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -327,7 +330,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -338,13 +341,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
         type: 'array',
         format: 'notanarray',
         items: {
-          type: 'string'
-        }
+          type: 'string',
+        },
       };
       testDocument.paths['/v1/drinks'].post.requestBody.content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -359,7 +362,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -368,12 +371,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['Foo'] = {
         type: 'boolean',
-        format: 'notaboolean'
+        format: 'notaboolean',
       };
       testDocument.paths['/v1/drinks'].post.responses['201'].content[
         'application/json'
       ].schema = {
-        $ref: '#/components/schemas/Foo'
+        $ref: '#/components/schemas/Foo',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -389,7 +392,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '201',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -397,17 +400,17 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.components.schemas['Foo'] = {
-        format: 'date'
+        format: 'date',
       };
       testDocument.components.responses.FooResponse = {
         schema: {
-          $ref: '#/components/schemas/Foo'
-        }
+          $ref: '#/components/schemas/Foo',
+        },
       };
       testDocument.paths['/v1/drinks'].post.responses['201'].content[
         'application/json'
       ] = {
-        $ref: '#/components/responses/FooResponse'
+        $ref: '#/components/responses/FooResponse',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -423,7 +426,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         '201',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -435,13 +438,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
           'application/json': {
             schema: {
               type: 'string',
-              format: 'notastring'
-            }
-          }
-        }
+              format: 'notastring',
+            },
+          },
+        },
       };
       testDocument.paths['/v1/drinks'].post.requestBody = {
-        $ref: '#/components/requestBodies/FooRequestBody'
+        $ref: '#/components/requestBodies/FooRequestBody',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -456,7 +459,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'requestBody',
         'content',
         'application/json',
-        'schema'
+        'schema',
       ]);
     });
 
@@ -465,11 +468,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['BadIntProp'] = {
         type: 'integer',
-        format: 'notaninteger'
+        format: 'notaninteger',
       };
 
       testDocument.components.schemas['Movie'].properties['bad_int_prop'] = {
-        $ref: '#/components/schemas/BadIntProp'
+        $ref: '#/components/schemas/BadIntProp',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -488,7 +491,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'bad_int_prop'
+        'bad_int_prop',
       ]);
       expect(results[1].path).toStrictEqual([
         'paths',
@@ -500,7 +503,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'bad_int_prop'
+        'bad_int_prop',
       ]);
       expect(results[2].path).toStrictEqual([
         'paths',
@@ -517,7 +520,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'movies',
         'items',
         'properties',
-        'bad_int_prop'
+        'bad_int_prop',
       ]);
       expect(results[3].path).toStrictEqual([
         'paths',
@@ -529,7 +532,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'bad_int_prop'
+        'bad_int_prop',
       ]);
       expect(results[4].path).toStrictEqual([
         'paths',
@@ -540,7 +543,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'bad_int_prop'
+        'bad_int_prop',
       ]);
     });
     it('Number schema with invalid format - inline response schema', async () => {
@@ -553,9 +556,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
         properties: {
           bad_number_prop: {
             type: 'number',
-            format: 'notanumber'
-          }
-        }
+            format: 'notanumber',
+          },
+        },
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -573,7 +576,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'application/json',
         'schema',
         'properties',
-        'bad_number_prop'
+        'bad_number_prop',
       ]);
     });
   });

--- a/packages/ruleset/test/securityscheme-attributes.test.js
+++ b/packages/ruleset/test/securityscheme-attributes.test.js
@@ -63,7 +63,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.components.securitySchemes.MovieScheme = {
-          name: 'Authorization'
+          name: 'Authorization',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -81,7 +81,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.components.securitySchemes.MovieScheme = {
-          type: 'bad type'
+          type: 'bad type',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -101,7 +101,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.components.securitySchemes.Basic = {
-          type: 'http'
+          type: 'http',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -122,7 +122,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.securitySchemes.IAM = {
           type: 'apiKey',
-          name: 'Authorization'
+          name: 'Authorization',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -142,7 +142,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         testDocument.components.securitySchemes.IAM = {
           type: 'apiKey',
           name: 'Authorization',
-          in: 'bad-value'
+          in: 'bad-value',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -161,7 +161,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.securitySchemes.IAM = {
           type: 'apiKey',
-          in: 'header'
+          in: 'header',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -181,7 +181,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.components.securitySchemes.OpenIdScheme = {
-          type: 'openIdConnect'
+          type: 'openIdConnect',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -200,7 +200,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.securitySchemes.OpenIdScheme = {
           type: 'openIdConnect',
-          openIdConnectUrl: 'not a valid URL'
+          openIdConnectUrl: 'not a valid URL',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -220,7 +220,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.components.securitySchemes.DrinkScheme = {
-          type: 'oauth2'
+          type: 'oauth2',
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -239,7 +239,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
         testDocument.components.securitySchemes.DrinkScheme = {
           type: 'oauth2',
-          flows: {}
+          flows: {},
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -257,7 +257,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         it('Empty implicit flow', async () => {
           const testDocument = makeCopy(rootDocument);
 
-          testDocument.components.securitySchemes.DrinkScheme.flows.implicit = {};
+          testDocument.components.securitySchemes.DrinkScheme.flows.implicit =
+            {};
 
           const results = await testRule(ruleId, rule, testDocument);
           expect(results).toHaveLength(2);
@@ -281,8 +282,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
           testDocument.components.securitySchemes.DrinkScheme.flows.implicit = {
             authorizationUrl: 'bad url',
             scopes: {
-              mixologist: 'Can create Drinks'
-            }
+              mixologist: 'Can create Drinks',
+            },
           };
 
           const results = await testRule(ruleId, rule, testDocument);
@@ -301,7 +302,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         it('Empty authorizationCode flow', async () => {
           const testDocument = makeCopy(rootDocument);
 
-          testDocument.components.securitySchemes.DrinkScheme.flows.authorizationCode = {};
+          testDocument.components.securitySchemes.DrinkScheme.flows.authorizationCode =
+            {};
 
           const results = await testRule(ruleId, rule, testDocument);
           expect(results).toHaveLength(3);
@@ -325,13 +327,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
         it('Invalid authorizationCode flow', async () => {
           const testDocument = makeCopy(rootDocument);
 
-          testDocument.components.securitySchemes.DrinkScheme.flows.authorizationCode = {
-            authorizationUrl: 'bad url',
-            tokenUrl: 'bad url',
-            scopes: {
-              mixologist: 'Can create Drinks'
-            }
-          };
+          testDocument.components.securitySchemes.DrinkScheme.flows.authorizationCode =
+            {
+              authorizationUrl: 'bad url',
+              tokenUrl: 'bad url',
+              scopes: {
+                mixologist: 'Can create Drinks',
+              },
+            };
 
           const results = await testRule(ruleId, rule, testDocument);
           expect(results).toHaveLength(2);
@@ -357,7 +360,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         it('Empty clientCredentials flow', async () => {
           const testDocument = makeCopy(rootDocument);
 
-          testDocument.components.securitySchemes.DrinkScheme.flows.clientCredentials = {};
+          testDocument.components.securitySchemes.DrinkScheme.flows.clientCredentials =
+            {};
 
           const results = await testRule(ruleId, rule, testDocument);
           expect(results).toHaveLength(2);
@@ -378,12 +382,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
         it('Invalid clientCredentials flow', async () => {
           const testDocument = makeCopy(rootDocument);
 
-          testDocument.components.securitySchemes.DrinkScheme.flows.clientCredentials = {
-            tokenUrl: 'bad url',
-            scopes: {
-              mixologist: 'Can create Drinks'
-            }
-          };
+          testDocument.components.securitySchemes.DrinkScheme.flows.clientCredentials =
+            {
+              tokenUrl: 'bad url',
+              scopes: {
+                mixologist: 'Can create Drinks',
+              },
+            };
 
           const results = await testRule(ruleId, rule, testDocument);
           expect(results).toHaveLength(1);
@@ -401,7 +406,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
         it('Empty password flow', async () => {
           const testDocument = makeCopy(rootDocument);
 
-          testDocument.components.securitySchemes.DrinkScheme.flows.password = {};
+          testDocument.components.securitySchemes.DrinkScheme.flows.password =
+            {};
 
           const results = await testRule(ruleId, rule, testDocument);
           expect(results).toHaveLength(2);
@@ -425,8 +431,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
           testDocument.components.securitySchemes.DrinkScheme.flows.password = {
             tokenUrl: 'bad url',
             scopes: {
-              mixologist: 'Can create Drinks'
-            }
+              mixologist: 'Can create Drinks',
+            },
           };
 
           const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/securityschemes.test.js
+++ b/packages/ruleset/test/securityschemes.test.js
@@ -67,7 +67,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/movies/{movie_id}.put.security.0.MovieScheme',
         'paths./v1/cars.post.security.0.IAM',
         'paths./v1/cars/{car_id}.get.security.0.IAM',
-        'paths./v1/cars/{car_id}.patch.security.0.IAM'
+        'paths./v1/cars/{car_id}.patch.security.0.IAM',
       ];
 
       for (let i = 0; i < results.length; i++) {
@@ -83,7 +83,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Add "InvalidScheme" to the global security list.
       testDocument.security.push({
-        InvalidScheme: []
+        InvalidScheme: [],
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -99,7 +99,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Add "InvalidScheme" to an existing security list.
       testDocument.paths['/v1/drinks'].get.security.push({
-        InvalidScheme: []
+        InvalidScheme: [],
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -117,7 +117,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       // Reference undefined scope in global security requirement object.
       testDocument.security.push({
-        DrinkScheme: ['brewer']
+        DrinkScheme: ['brewer'],
       });
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -154,7 +154,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         in: 'header',
         name: 'Authorization',
         type: 'http',
-        scheme: 'Basic'
+        scheme: 'Basic',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/server-variable-default-value.test.js
+++ b/packages/ruleset/test/server-variable-default-value.test.js
@@ -24,10 +24,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
         variables: {
           name: {
             description: 'this variable should have a non-empty default value',
-            default: ''
-          }
-        }
-      }
+            default: '',
+          },
+        },
+      },
     ];
 
     const results = await testRule(ruleId, rule, testDocument);
@@ -44,7 +44,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       '0',
       'variables',
       'name',
-      'default'
+      'default',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });

--- a/packages/ruleset/test/string-attributes.test.js
+++ b/packages/ruleset/test/string-attributes.test.js
@@ -25,9 +25,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           in: 'query',
           schema: {
             type: 'string',
-            enum: ['fiction', 'nonfiction']
-          }
-        }
+            enum: ['fiction', 'nonfiction'],
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -43,10 +43,10 @@ describe(`Spectral rule: ${ruleId}`, () => {
           schema: {
             type: 'integer',
             not: {
-              type: 'string'
-            }
-          }
-        }
+              type: 'string',
+            },
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -63,8 +63,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'string',
             format: 'binary',
             minLength: 0,
-            maxLength: 15
-          }
+            maxLength: 15,
+          },
         },
         {
           name: 'trailer',
@@ -73,16 +73,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'string',
             format: 'byte',
             minLength: 0,
-            maxLength: 1024
-          }
+            maxLength: 1024,
+          },
         },
         {
           name: 'before_date',
           in: 'query',
           schema: {
             type: 'string',
-            format: 'date'
-          }
+            format: 'date',
+          },
         },
         {
           name: 'after_date',
@@ -91,8 +91,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
             type: 'string',
             format: 'date-time',
             minLength: 1,
-            maxLength: 15
-          }
+            maxLength: 15,
+          },
         },
         {
           name: 'imdb_url',
@@ -100,9 +100,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           schema: {
             type: 'string',
             format: 'url',
-            maxLength: 1024
-          }
-        }
+            maxLength: 1024,
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -116,9 +116,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           name: 'ruleTester',
           in: 'query',
           schema: {
-            $ref: '#/components/schemas/RuleTester'
-          }
-        }
+            $ref: '#/components/schemas/RuleTester',
+          },
+        },
       ];
 
       testDocument.components.schemas['RuleTester'] = {
@@ -128,16 +128,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
         maxLength: 38,
         oneOf: [
           {
-            pattern: 'pattern1'
+            pattern: 'pattern1',
           },
           {
-            pattern: 'pattern2'
+            pattern: 'pattern2',
           },
           {
-            pattern: 'pattern3'
-          }
+            pattern: 'pattern3',
+          },
         ],
-        example: 'example string'
+        example: 'example string',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -151,9 +151,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           name: 'ruleTester',
           in: 'query',
           schema: {
-            $ref: '#/components/schemas/RuleTester'
-          }
-        }
+            $ref: '#/components/schemas/RuleTester',
+          },
+        },
       ];
 
       testDocument.components.schemas['RuleTester'] = {
@@ -163,16 +163,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
         maxLength: 38,
         allOf: [
           {
-            minLength: 1
+            minLength: 1,
           },
           {
-            maxLength: 38
+            maxLength: 38,
           },
           {
-            pattern: 'id:.*'
-          }
+            pattern: 'id:.*',
+          },
         ],
-        example: 'example string'
+        example: 'example string',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -190,9 +190,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           schema: {
             type: 'string',
             minLength: 1,
-            maxLength: 15
-          }
-        }
+            maxLength: 15,
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -219,11 +219,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
               schema: {
                 type: 'string',
                 pattern: '[a-zA-Z0-9]+',
-                maxLength: 15
-              }
-            }
-          }
-        }
+                maxLength: 15,
+              },
+            },
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -241,15 +241,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     it('String schema is missing a `maxLength` field', async () => {
       const testDocument = makeCopy(rootDocument);
-      testDocument.paths['/v1/movies'].post.requestBody.content[
-        'text/plain'
-      ] = {
-        schema: {
-          type: 'string',
-          pattern: '[a-zA-Z0-9]+',
-          minLength: 15
-        }
-      };
+      testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] =
+        {
+          schema: {
+            type: 'string',
+            pattern: '[a-zA-Z0-9]+',
+            minLength: 15,
+          },
+        };
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -266,14 +265,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     it('Non-string schema defines a `pattern` field', async () => {
       const testDocument = makeCopy(rootDocument);
-      testDocument.paths['/v1/movies'].post.requestBody.content[
-        'text/plain'
-      ] = {
-        schema: {
-          type: 'integer',
-          pattern: '.*'
-        }
-      };
+      testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] =
+        {
+          schema: {
+            type: 'integer',
+            pattern: '.*',
+          },
+        };
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -290,14 +288,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     it('Non-string schema defines a `minLength` field', async () => {
       const testDocument = makeCopy(rootDocument);
-      testDocument.paths['/v1/movies'].post.requestBody.content[
-        'text/plain'
-      ] = {
-        schema: {
-          type: 'integer',
-          minLength: 15
-        }
-      };
+      testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] =
+        {
+          schema: {
+            type: 'integer',
+            minLength: 15,
+          },
+        };
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -314,14 +311,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     it('Non-string schema defines a `maxLength` field', async () => {
       const testDocument = makeCopy(rootDocument);
-      testDocument.paths['/v1/movies'].post.requestBody.content[
-        'text/plain'
-      ] = {
-        schema: {
-          type: 'integer',
-          maxLength: 15
-        }
-      };
+      testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] =
+        {
+          schema: {
+            type: 'integer',
+            maxLength: 15,
+          },
+        };
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -338,16 +334,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     it('String schema has a `minLength` value greater than the `maxLength` value', async () => {
       const testDocument = makeCopy(rootDocument);
-      testDocument.paths['/v1/movies'].post.requestBody.content[
-        'text/plain'
-      ] = {
-        schema: {
-          type: 'string',
-          pattern: '[a-zA-Z0-9]+',
-          maxLength: 10,
-          minLength: 15
-        }
-      };
+      testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] =
+        {
+          schema: {
+            type: 'string',
+            pattern: '[a-zA-Z0-9]+',
+            maxLength: 10,
+            minLength: 15,
+          },
+        };
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -364,37 +359,36 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     it('Invalid string schema is part of a composed schema', async () => {
       const testDocument = makeCopy(rootDocument);
-      testDocument.paths['/v1/movies'].post.requestBody.content[
-        'text/plain'
-      ] = {
-        schema: {
-          allOf: [
-            {
-              type: 'string',
-              maxLength: 10,
-              minLength: 1
-            },
-            {
-              anyOf: [
-                {
-                  type: 'string',
-                  maxLength: 10,
-                  minLength: 1
-                },
-                {
-                  oneOf: [
-                    {
-                      type: 'string',
-                      maxLength: 10,
-                      minLength: 1
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      };
+      testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] =
+        {
+          schema: {
+            allOf: [
+              {
+                type: 'string',
+                maxLength: 10,
+                minLength: 1,
+              },
+              {
+                anyOf: [
+                  {
+                    type: 'string',
+                    maxLength: 10,
+                    minLength: 1,
+                  },
+                  {
+                    oneOf: [
+                      {
+                        type: 'string',
+                        maxLength: 10,
+                        minLength: 1,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        };
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(1);
@@ -417,9 +411,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           schema: {
             type: 'string',
             minLength: 1,
-            maxLength: 15
-          }
-        }
+            maxLength: 15,
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -442,9 +436,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           name: 'ruleTester',
           in: 'query',
           schema: {
-            $ref: '#/components/schemas/RuleTester'
-          }
-        }
+            $ref: '#/components/schemas/RuleTester',
+          },
+        },
       ];
 
       testDocument.components.schemas['RuleTester'] = {
@@ -454,16 +448,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
         pattern: '.*',
         oneOf: [
           {
-            maxLength: 38
+            maxLength: 38,
           },
           {
-            maxLength: 74
+            maxLength: 74,
           },
           {
-            description: 'No maxLength field in this schema'
-          }
+            description: 'No maxLength field in this schema',
+          },
         ],
-        example: 'example string'
+        example: 'example string',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -486,9 +480,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           name: 'ruleTester',
           in: 'query',
           schema: {
-            $ref: '#/components/schemas/RuleTester'
-          }
-        }
+            $ref: '#/components/schemas/RuleTester',
+          },
+        },
       ];
 
       testDocument.components.schemas['RuleTester'] = {
@@ -498,16 +492,16 @@ describe(`Spectral rule: ${ruleId}`, () => {
         maxLength: 38,
         oneOf: [
           {
-            pattern: '.*'
+            pattern: '.*',
           },
           {
-            pattern: 'id-[0-9]+.*'
+            pattern: 'id-[0-9]+.*',
           },
           {
-            description: 'No pattern field in this schema'
-          }
+            description: 'No pattern field in this schema',
+          },
         ],
-        example: 'example string'
+        example: 'example string',
       };
 
       const results = await testRule(ruleId, rule, testDocument);

--- a/packages/ruleset/test/summary-sentence-style.test.js
+++ b/packages/ruleset/test/summary-sentence-style.test.js
@@ -31,7 +31,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       'paths',
       '/v1/movies',
       'post',
-      'summary'
+      'summary',
     ]);
     expect(validation.severity).toBe(severityCodes.warning);
   });

--- a/packages/ruleset/test/utils/all-schemas-document.js
+++ b/packages/ruleset/test/utils/all-schemas-document.js
@@ -11,18 +11,18 @@ module.exports = {
       'A collection of schemas with various kinds of subschemas for testing.',
     version: '0.0.1',
     contact: {
-      email: 'example@example.com'
-    }
+      email: 'example@example.com',
+    },
   },
   tags: [
     {
-      name: 'Index'
-    }
+      name: 'Index',
+    },
   ],
   servers: [
     {
-      url: '/api/v3'
-    }
+      url: '/api/v3',
+    },
   ],
   paths: {
     '/schema': {
@@ -32,18 +32,18 @@ module.exports = {
         description: 'Get the index.',
         operationId: 'get_index',
         responses: {
-          '200': {
+          200: {
             description: "Here's the index.",
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Index'
-                }
-              }
-            }
-          }
-        }
-      }
+                  $ref: '#/components/schemas/Index',
+                },
+              },
+            },
+          },
+        },
+      },
     },
     '/every_flavor': {
       get: {
@@ -52,19 +52,19 @@ module.exports = {
         description: 'Get every flavor.',
         operationId: 'get_every_flavor',
         responses: {
-          '200': {
+          200: {
             description: "Here's every flavor.",
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/EveryFlavor'
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+                  $ref: '#/components/schemas/EveryFlavor',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   components: {
     schemas: {
@@ -72,144 +72,144 @@ module.exports = {
         type: 'object',
         properties: {
           schema_with_property_schema: {
-            $ref: '#/components/schemas/SchemaWithPropertySchema'
+            $ref: '#/components/schemas/SchemaWithPropertySchema',
           },
           schema_with_additional_properties_schema: {
-            $ref: '#/components/schemas/SchemaWithAdditionalPropertiesSchema'
+            $ref: '#/components/schemas/SchemaWithAdditionalPropertiesSchema',
           },
           schema_with_items_schema: {
-            $ref: '#/components/schemas/SchemaWithItemsSchema'
+            $ref: '#/components/schemas/SchemaWithItemsSchema',
           },
           schema_with_all_of_schema: {
-            $ref: '#/components/schemas/SchemaWithAllOfSchema'
+            $ref: '#/components/schemas/SchemaWithAllOfSchema',
           },
           schema_with_one_of_schema: {
-            $ref: '#/components/schemas/SchemaWithOneOfSchema'
+            $ref: '#/components/schemas/SchemaWithOneOfSchema',
           },
           schema_with_any_of_schema: {
-            $ref: '#/components/schemas/SchemaWithAnyOfSchema'
+            $ref: '#/components/schemas/SchemaWithAnyOfSchema',
           },
           schema_with_not_schema: {
-            $ref: '#/components/schemas/SchemaWithNotSchema'
-          }
-        }
+            $ref: '#/components/schemas/SchemaWithNotSchema',
+          },
+        },
       },
       EveryFlavor: {
         properties: {
           property_schema: {
-            $ref: '#/components/schemas/SchemaWithPropertySchema'
-          }
+            $ref: '#/components/schemas/SchemaWithPropertySchema',
+          },
         },
         additionalProperties: {
-          $ref: '#/components/schemas/AdditionalPropertiesSchema'
+          $ref: '#/components/schemas/AdditionalPropertiesSchema',
         },
         items: {
-          $ref: '#/components/schemas/ItemsSchema'
+          $ref: '#/components/schemas/ItemsSchema',
         },
         allOf: [
           {
-            $ref: '#/components/schemas/AllOfSchema'
-          }
+            $ref: '#/components/schemas/AllOfSchema',
+          },
         ],
         oneOf: [
           {
-            $ref: '#/components/schemas/OneOfSchema'
-          }
+            $ref: '#/components/schemas/OneOfSchema',
+          },
         ],
         anyOf: [
           {
-            $ref: '#/components/schemas/AnyOfSchema'
-          }
+            $ref: '#/components/schemas/AnyOfSchema',
+          },
         ],
         not: {
-          $ref: '#/components/schemas/NotSchema'
-        }
+          $ref: '#/components/schemas/NotSchema',
+        },
       },
       SchemaWithPropertySchema: {
         type: 'object',
         properties: {
           property_schema: {
-            $ref: '#/components/schemas/PropertySchema'
-          }
-        }
+            $ref: '#/components/schemas/PropertySchema',
+          },
+        },
       },
       PropertySchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithPropertySchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithPropertySchema`.',
       },
       SchemaWithAdditionalPropertiesSchema: {
         type: 'object',
         additionalProperties: {
-          $ref: '#/components/schemas/AdditionalPropertiesSchema'
-        }
+          $ref: '#/components/schemas/AdditionalPropertiesSchema',
+        },
       },
       AdditionalPropertiesSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithAdditionalPropertiesSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithAdditionalPropertiesSchema`.',
       },
       SchemaWithItemsSchema: {
         type: 'array',
         items: {
-          $ref: '#/components/schemas/ItemsSchema'
-        }
+          $ref: '#/components/schemas/ItemsSchema',
+        },
       },
       ItemsSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithItemsSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithItemsSchema`.',
       },
       SchemaWithAllOfSchema: {
         type: 'string',
         allOf: [
           {
-            $ref: '#/components/schemas/AllOfSchema'
-          }
-        ]
+            $ref: '#/components/schemas/AllOfSchema',
+          },
+        ],
       },
       AllOfSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithAllOfSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithAllOfSchema`.',
       },
       SchemaWithOneOfSchema: {
         type: 'string',
         oneOf: [
           {
-            $ref: '#/components/schemas/OneOfSchema'
-          }
-        ]
+            $ref: '#/components/schemas/OneOfSchema',
+          },
+        ],
       },
       OneOfSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithOneOfSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithOneOfSchema`.',
       },
       SchemaWithAnyOfSchema: {
         type: 'string',
         anyOf: [
           {
-            $ref: '#/components/schemas/AnyOfSchema'
-          }
-        ]
+            $ref: '#/components/schemas/AnyOfSchema',
+          },
+        ],
       },
       AnyOfSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithAnyOfSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithAnyOfSchema`.',
       },
       SchemaWithNotSchema: {
         type: 'string',
         not: {
-          $ref: '#/components/schemas/NotSchema'
-        }
+          $ref: '#/components/schemas/NotSchema',
+        },
       },
       NotSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithNotSchema`.'
-      }
-    }
-  }
+          'This schema is reachable from `EveryFlavor` and `SchemaWithNotSchema`.',
+      },
+    },
+  },
 };

--- a/packages/ruleset/test/utils/index.js
+++ b/packages/ruleset/test/utils/index.js
@@ -14,5 +14,5 @@ module.exports = {
   makeCopy,
   rootDocument,
   testRule,
-  severityCodes
+  severityCodes,
 };

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -8,26 +8,26 @@ module.exports = {
   info: {
     title: 'Root Test Definition',
     description: 'API definition for testing custom Spectral rules.',
-    version: '1.0.0'
+    version: '1.0.0',
   },
   servers: [
     {
-      url: 'https://some-madeup-url.com/api'
-    }
+      url: 'https://some-madeup-url.com/api',
+    },
   ],
   security: [
     {
-      IAM: []
+      IAM: [],
     },
     {
-      OpenIdScheme: ['openid:admin']
-    }
+      OpenIdScheme: ['openid:admin'],
+    },
   ],
   tags: [
     {
       name: 'TestTag',
-      description: 'A tag used for testing.'
-    }
+      description: 'A tag used for testing.',
+    },
   ],
   paths: {
     '/v1/drinks': {
@@ -38,8 +38,8 @@ module.exports = {
         tags: ['TestTag'],
         security: [
           {
-            DrinkScheme: ['mixologist']
-          }
+            DrinkScheme: ['mixologist'],
+          },
         ],
         'x-codegen-request-body-name': 'drink',
         requestBody: {
@@ -47,33 +47,33 @@ module.exports = {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/schemas/Drink'
-              }
-            }
-          }
+                $ref: '#/components/schemas/Drink',
+              },
+            },
+          },
         },
         responses: {
-          '201': {
+          201: {
             description: 'Success!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Drink'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/Drink',
+                },
+              },
+            },
           },
-          '400': {
+          400: {
             description: 'Error!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/ErrorContainer'
-                }
-              }
-            }
-          }
-        }
+                  $ref: '#/components/schemas/ErrorContainer',
+                },
+              },
+            },
+          },
+        },
       },
       get: {
         operationId: 'list_drinks',
@@ -83,8 +83,8 @@ module.exports = {
         security: [
           {
             Basic: [],
-            DrinkScheme: ['drinker']
-          }
+            DrinkScheme: ['drinker'],
+          },
         ],
         parameters: [
           {
@@ -95,8 +95,8 @@ module.exports = {
             schema: {
               type: 'integer',
               format: 'int32',
-              minimum: 0
-            }
+              minimum: 0,
+            },
           },
           {
             name: 'limit',
@@ -108,39 +108,39 @@ module.exports = {
               format: 'int32',
               minimum: 0,
               maximum: 100,
-              default: 10
-            }
-          }
+              default: 10,
+            },
+          },
         ],
         responses: {
-          '200': {
+          200: {
             description: 'Success!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/DrinkCollection'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/DrinkCollection',
+                },
+              },
+            },
           },
-          '400': {
+          400: {
             description: 'Error!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/ErrorContainer'
-                }
-              }
-            }
-          }
-        }
-      }
+                  $ref: '#/components/schemas/ErrorContainer',
+                },
+              },
+            },
+          },
+        },
+      },
     },
     '/v1/drinks/{drink_id}': {
       parameters: [
         {
-          $ref: '#/components/parameters/DrinkIdParam'
-        }
+          $ref: '#/components/parameters/DrinkIdParam',
+        },
       ],
       get: {
         operationId: 'get_drink',
@@ -149,23 +149,23 @@ module.exports = {
         tags: ['TestTag'],
         security: [
           {
-            DrinkScheme: []
-          }
+            DrinkScheme: [],
+          },
         ],
         parameters: [
           {
-            $ref: '#/components/parameters/VerboseParam'
-          }
+            $ref: '#/components/parameters/VerboseParam',
+          },
         ],
         responses: {
-          '200': {
-            $ref: '#/components/responses/ConsumedDrink'
+          200: {
+            $ref: '#/components/responses/ConsumedDrink',
           },
-          '400': {
-            $ref: '#/components/responses/BarIsClosed'
-          }
-        }
-      }
+          400: {
+            $ref: '#/components/responses/BarIsClosed',
+          },
+        },
+      },
     },
     '/v1/drinks/menu': {
       get: {
@@ -174,7 +174,7 @@ module.exports = {
         description: 'Retrieve a document containing the drinks menu.',
         tags: ['TestTag'],
         responses: {
-          '200': {
+          200: {
             content: {
               'application/octet-stream': {
                 schema: {
@@ -182,12 +182,12 @@ module.exports = {
                   type: 'string',
                   format: 'binary',
                   minLength: 0,
-                  maxLength: 1024000
-                }
-              }
-            }
-          }
-        }
+                  maxLength: 1024000,
+                },
+              },
+            },
+          },
+        },
       },
       put: {
         operationId: 'replace_menu',
@@ -205,8 +205,8 @@ module.exports = {
               type: 'string',
               pattern: '[a-z0-9]*.pdf',
               minLength: 0,
-              maxLength: 1024000
-            }
+              maxLength: 1024000,
+            },
           },
           {
             in: 'query',
@@ -217,11 +217,11 @@ module.exports = {
                 schema: {
                   description: 'valid document types',
                   type: 'string',
-                  enum: ['pdf', 'odt', 'doc']
-                }
-              }
-            }
-          }
+                  enum: ['pdf', 'odt', 'doc'],
+                },
+              },
+            },
+          },
         ],
         requestBody: {
           required: true,
@@ -232,13 +232,13 @@ module.exports = {
                 type: 'string',
                 format: 'binary',
                 minLength: 0,
-                maxLength: 1024000
-              }
-            }
-          }
+                maxLength: 1024000,
+              },
+            },
+          },
         },
         responses: {
-          '200': {
+          200: {
             description: 'Upload confirmed!',
             content: {
               'text/plain': {
@@ -246,13 +246,13 @@ module.exports = {
                   description: 'String response for upload request.',
                   type: 'string',
                   minLength: 0,
-                  maxLength: 512
-                }
-              }
-            }
-          }
-        }
-      }
+                  maxLength: 512,
+                },
+              },
+            },
+          },
+        },
+      },
     },
     '/v1/movies': {
       post: {
@@ -262,41 +262,41 @@ module.exports = {
         tags: ['TestTag'],
         security: [
           {
-            MovieScheme: ['director']
-          }
+            MovieScheme: ['director'],
+          },
         ],
         requestBody: {
           required: true,
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/schemas/Movie'
-              }
-            }
-          }
+                $ref: '#/components/schemas/Movie',
+              },
+            },
+          },
         },
         responses: {
-          '201': {
+          201: {
             description: 'Success!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Movie'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/Movie',
+                },
+              },
+            },
           },
-          '400': {
+          400: {
             description: 'Error!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/ErrorContainer'
-                }
-              }
-            }
-          }
-        }
+                  $ref: '#/components/schemas/ErrorContainer',
+                },
+              },
+            },
+          },
+        },
       },
       get: {
         operationId: 'list_movies',
@@ -306,8 +306,8 @@ module.exports = {
         tags: ['TestTag'],
         security: [
           {
-            MovieScheme: ['moviegoer']
-          }
+            MovieScheme: ['moviegoer'],
+          },
         ],
         parameters: [
           {
@@ -317,8 +317,8 @@ module.exports = {
             in: 'query',
             schema: {
               type: 'string',
-              enum: ['comedy', 'drama', 'action', 'musical', 'documentary']
-            }
+              enum: ['comedy', 'drama', 'action', 'musical', 'documentary'],
+            },
           },
           {
             name: 'start',
@@ -329,8 +329,8 @@ module.exports = {
               type: 'string',
               pattern: '[a-zA-Z0-9 ]+',
               minLength: 1,
-              maxLength: 128
-            }
+              maxLength: 128,
+            },
           },
           {
             name: 'limit',
@@ -342,44 +342,44 @@ module.exports = {
               format: 'int32',
               minimum: 0,
               maximum: 100,
-              default: 10
-            }
-          }
+              default: 10,
+            },
+          },
         ],
         responses: {
-          '200': {
+          200: {
             description: 'Success!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/MovieCollection'
+                  $ref: '#/components/schemas/MovieCollection',
                 },
                 example: {
                   offset: 0,
                   limit: 2,
                   total_count: 2,
                   first: {
-                    href: 'first page'
+                    href: 'first page',
                   },
                   last: {
-                    href: 'last page'
+                    href: 'last page',
                   },
                   movies: [
                     { id: '1234', name: 'The Fellowship of the Ring' },
-                    { id: '5678', name: 'The Two Towers' }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
+                    { id: '5678', name: 'The Two Towers' },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
     },
     '/v1/movies/{movie_id}': {
       parameters: [
         {
-          $ref: '#/components/parameters/MovieIdParam'
-        }
+          $ref: '#/components/parameters/MovieIdParam',
+        },
       ],
       get: {
         operationId: 'get_movie',
@@ -388,24 +388,24 @@ module.exports = {
         tags: ['TestTag'],
         security: [
           {
-            MovieScheme: ['moviegoer']
-          }
+            MovieScheme: ['moviegoer'],
+          },
         ],
         responses: {
-          '200': {
-            $ref: '#/components/responses/MovieWithETag'
+          200: {
+            $ref: '#/components/responses/MovieWithETag',
           },
-          '400': {
+          400: {
             description: 'Didnt work!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/ErrorContainer'
-                }
-              }
-            }
-          }
-        }
+                  $ref: '#/components/schemas/ErrorContainer',
+                },
+              },
+            },
+          },
+        },
       },
       put: {
         operationId: 'replace_movie',
@@ -414,13 +414,13 @@ module.exports = {
         tags: ['TestTag'],
         parameters: [
           {
-            $ref: '#/components/parameters/IfMatchParam'
-          }
+            $ref: '#/components/parameters/IfMatchParam',
+          },
         ],
         security: [
           {
-            MovieScheme: ['director']
-          }
+            MovieScheme: ['director'],
+          },
         ],
         'x-codegen-request-body-name': 'movie',
         requestBody: {
@@ -428,37 +428,37 @@ module.exports = {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/schemas/Movie'
-              }
-            }
-          }
+                $ref: '#/components/schemas/Movie',
+              },
+            },
+          },
         },
         responses: {
-          '204': {
-            description: 'The movie was successfully updated.'
+          204: {
+            description: 'The movie was successfully updated.',
           },
-          '400': {
+          400: {
             description: 'Didnt work!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/ErrorContainer'
-                }
-              }
-            }
+                  $ref: '#/components/schemas/ErrorContainer',
+                },
+              },
+            },
           },
-          '409': {
+          409: {
             description: 'Resource conflict!',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/ErrorContainer'
-                }
-              }
-            }
-          }
-        }
-      }
+                  $ref: '#/components/schemas/ErrorContainer',
+                },
+              },
+            },
+          },
+        },
+      },
     },
     '/v1/cars': {
       post: {
@@ -468,50 +468,50 @@ module.exports = {
         tags: ['TestTag'],
         parameters: [
           {
-            $ref: '#/components/parameters/ExpediteParam'
-          }
+            $ref: '#/components/parameters/ExpediteParam',
+          },
         ],
         security: [
           {
-            IAM: []
-          }
+            IAM: [],
+          },
         ],
         'x-codegen-request-body-name': 'car',
         requestBody: {
-          $ref: '#/components/requestBodies/CarRequest'
+          $ref: '#/components/requestBodies/CarRequest',
         },
         responses: {
-          '201': {
+          201: {
             description: 'The car instance was returned in the response.',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Car'
+                  $ref: '#/components/schemas/Car',
                 },
                 examples: {
                   ResponseExample: {
-                    $ref: '#/components/examples/CarExample'
-                  }
-                }
-              }
+                    $ref: '#/components/examples/CarExample',
+                  },
+                },
+              },
             },
             links: {
               CarId: {
-                $ref: '#/components/links/CarIdLink'
-              }
-            }
+                $ref: '#/components/links/CarIdLink',
+              },
+            },
           },
-          '400': {
-            $ref: '#/components/responses/ErrorResponse'
-          }
-        }
-      }
+          400: {
+            $ref: '#/components/responses/ErrorResponse',
+          },
+        },
+      },
     },
     '/v1/cars/{car_id}': {
       parameters: [
         {
-          $ref: '#/components/parameters/CarIdParam'
-        }
+          $ref: '#/components/parameters/CarIdParam',
+        },
       ],
       get: {
         operationId: 'get_car',
@@ -520,17 +520,17 @@ module.exports = {
         tags: ['TestTag'],
         security: [
           {
-            IAM: []
-          }
+            IAM: [],
+          },
         ],
         responses: {
-          '200': {
-            $ref: '#/components/responses/CarResponse'
+          200: {
+            $ref: '#/components/responses/CarResponse',
           },
-          '400': {
-            $ref: '#/components/responses/ErrorResponse'
-          }
-        }
+          400: {
+            $ref: '#/components/responses/ErrorResponse',
+          },
+        },
       },
       patch: {
         operationId: 'update_car',
@@ -539,34 +539,34 @@ module.exports = {
         tags: ['TestTag'],
         security: [
           {
-            IAM: []
-          }
+            IAM: [],
+          },
         ],
         requestBody: {
-          $ref: '#/components/requestBodies/UpdateCarRequest'
+          $ref: '#/components/requestBodies/UpdateCarRequest',
         },
         responses: {
-          '200': {
+          200: {
             description: 'The car instance was updated successfully.',
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Car'
+                  $ref: '#/components/schemas/Car',
                 },
                 examples: {
                   ResponseExample: {
-                    $ref: '#/components/examples/CarExample'
-                  }
-                }
-              }
-            }
+                    $ref: '#/components/examples/CarExample',
+                  },
+                },
+              },
+            },
           },
-          '400': {
-            $ref: '#/components/responses/ErrorResponse'
-          }
-        }
-      }
-    }
+          400: {
+            $ref: '#/components/responses/ErrorResponse',
+          },
+        },
+      },
+    },
   },
   components: {
     parameters: {
@@ -579,8 +579,8 @@ module.exports = {
           type: 'string',
           pattern: '[a-zA-Z0-9 ]+',
           minLength: 1,
-          maxLength: 30
-        }
+          maxLength: 30,
+        },
       },
       MovieIdParam: {
         name: 'movie_id',
@@ -591,8 +591,8 @@ module.exports = {
           type: 'string',
           pattern: '[a-zA-Z0-9 ]+',
           minLength: 1,
-          maxLength: 30
-        }
+          maxLength: 30,
+        },
       },
       VerboseParam: {
         description: 'An optional verbose parameter.',
@@ -600,8 +600,8 @@ module.exports = {
         required: false,
         in: 'query',
         schema: {
-          type: 'boolean'
-        }
+          type: 'boolean',
+        },
       },
       ExpediteParam: {
         description:
@@ -610,8 +610,8 @@ module.exports = {
         required: false,
         in: 'query',
         schema: {
-          type: 'boolean'
-        }
+          type: 'boolean',
+        },
       },
       CarIdParam: {
         description: 'A car id.',
@@ -622,8 +622,8 @@ module.exports = {
           type: 'string',
           pattern: '[a-zA-Z0-9 ]+',
           minLength: 1,
-          maxLength: 30
-        }
+          maxLength: 30,
+        },
       },
       IfMatchParam: {
         description: 'The If-Match header param.',
@@ -634,9 +634,9 @@ module.exports = {
           type: 'string',
           pattern: '[a-zA-Z0-9 ]+',
           minLength: 1,
-          maxLength: 64
-        }
-      }
+          maxLength: 64,
+        },
+      },
     },
     schemas: {
       Movie: {
@@ -645,35 +645,35 @@ module.exports = {
         required: ['id', 'name'],
         properties: {
           id: {
-            $ref: '#/components/schemas/IdString'
+            $ref: '#/components/schemas/IdString',
           },
           name: {
-            $ref: '#/components/schemas/NormalString'
+            $ref: '#/components/schemas/NormalString',
           },
           director: {
-            $ref: '#/components/schemas/NormalString'
+            $ref: '#/components/schemas/NormalString',
           },
           running_time: {
             type: 'integer',
             format: 'int32',
-            description: 'The length of the movie, in minutes.'
+            description: 'The length of the movie, in minutes.',
           },
           imdb_url: {
-            $ref: '#/components/schemas/UrlString'
+            $ref: '#/components/schemas/UrlString',
           },
           trailer: {
             type: 'string',
             format: 'byte',
             description: 'A short trailer for the movie.',
             minLength: 0,
-            maxLength: 1024
-          }
+            maxLength: 1024,
+          },
         },
         example: {
           name: 'The Two Towers',
           director: 'Peter Jackson',
-          running_time: 179
-        }
+          running_time: 179,
+        },
       },
       Drink: {
         type: 'object',
@@ -681,19 +681,19 @@ module.exports = {
           'A Drink can be either a Juice or Soda instance. Sorry, no Beer or Whisky allowed.',
         oneOf: [
           {
-            $ref: '#/components/schemas/Juice'
+            $ref: '#/components/schemas/Juice',
           },
           {
-            $ref: '#/components/schemas/Soda'
-          }
+            $ref: '#/components/schemas/Soda',
+          },
         ],
         discriminator: {
-          propertyName: 'type'
+          propertyName: 'type',
         },
         example: {
           type: 'soda',
-          name: 'Root Beer'
-        }
+          name: 'Root Beer',
+        },
       },
       Soda: {
         description: 'Do you really not know what a Soda is?',
@@ -703,12 +703,12 @@ module.exports = {
           type: {
             description: 'The drink type - should be "soda".',
             type: 'string',
-            enum: ['soda']
+            enum: ['soda'],
           },
           name: {
-            $ref: '#/components/schemas/NormalString'
-          }
-        }
+            $ref: '#/components/schemas/NormalString',
+          },
+        },
       },
       Juice: {
         description: 'Juice box!',
@@ -718,19 +718,19 @@ module.exports = {
           type: {
             description: 'The drink type - should be "juice".',
             type: 'string',
-            enum: ['juice']
+            enum: ['juice'],
           },
           fruit: {
-            $ref: '#/components/schemas/NormalString'
-          }
-        }
+            $ref: '#/components/schemas/NormalString',
+          },
+        },
       },
       NormalString: {
         description: 'This is a normal string.',
         type: 'string',
         pattern: '[a-zA-Z0-9 ]+',
         minLength: 1,
-        maxLength: 30
+        maxLength: 30,
       },
       IdString: {
         description: 'An identifier of some sort.',
@@ -738,20 +738,20 @@ module.exports = {
         readOnly: true,
         pattern: '[a-zA-Z0-9]+',
         minLength: 1,
-        maxLength: 10
+        maxLength: 10,
       },
       UrlString: {
         description: 'A URL of some sort.',
         type: 'string',
         format: 'url',
-        maxLength: 1024
+        maxLength: 1024,
       },
       DrinkCollection: {
         type: 'object',
         description: 'A single page of results containing Drink instances.',
         allOf: [
           {
-            $ref: '#/components/schemas/OffsetPaginationBase'
+            $ref: '#/components/schemas/OffsetPaginationBase',
           },
           {
             type: 'object',
@@ -764,42 +764,42 @@ module.exports = {
                 minItems: 0,
                 maxItems: 50,
                 items: {
-                  $ref: '#/components/schemas/Drink'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/Drink',
+                },
+              },
+            },
+          },
         ],
         example: {
           offset: 0,
           limit: 1,
           total_count: 1,
           first: {
-            href: 'first page'
+            href: 'first page',
           },
           next: {
-            href: 'next page'
+            href: 'next page',
           },
           previous: {
-            href: 'previous page'
+            href: 'previous page',
           },
           last: {
-            href: 'last page'
+            href: 'last page',
           },
           drinks: [
             {
               type: 'soda',
-              name: 'Root Beer'
-            }
-          ]
-        }
+              name: 'Root Beer',
+            },
+          ],
+        },
       },
       MovieCollection: {
         type: 'object',
         description: 'A single page of results containing Movie instances.',
         allOf: [
           {
-            $ref: '#/components/schemas/TokenPaginationBase'
+            $ref: '#/components/schemas/TokenPaginationBase',
           },
           {
             type: 'object',
@@ -812,35 +812,35 @@ module.exports = {
                 minItems: 0,
                 maxItems: 50,
                 items: {
-                  $ref: '#/components/schemas/Movie'
-                }
-              }
-            }
-          }
+                  $ref: '#/components/schemas/Movie',
+                },
+              },
+            },
+          },
         ],
         example: {
           limit: 1,
           total_count: 1,
           first: {
-            href: 'first page'
+            href: 'first page',
           },
           next: {
-            href: 'next page'
+            href: 'next page',
           },
           previous: {
-            href: 'previous page'
+            href: 'previous page',
           },
           last: {
-            href: 'last page'
+            href: 'last page',
           },
           movies: [
             {
               name: 'The Two Towers',
               director: 'Peter Jackson',
-              running_time: 179
-            }
-          ]
-        }
+              running_time: 179,
+            },
+          ],
+        },
       },
       Car: {
         description: 'Information about a car.',
@@ -852,19 +852,19 @@ module.exports = {
             type: 'string',
             minLength: 1,
             maxLength: 64,
-            pattern: '[0-9]+'
+            pattern: '[0-9]+',
           },
           make: {
             description: 'The car make.',
             type: 'string',
             minLength: 1,
             maxLength: 32,
-            pattern: '.*'
+            pattern: '.*',
           },
           model: {
-            $ref: '#/components/schemas/CarModelType'
-          }
-        }
+            $ref: '#/components/schemas/CarModelType',
+          },
+        },
       },
       CarPatch: {
         description: 'Information about a car.',
@@ -875,26 +875,26 @@ module.exports = {
             type: 'string',
             minLength: 1,
             maxLength: 64,
-            pattern: '[0-9]+'
+            pattern: '[0-9]+',
           },
           make: {
             description: 'The car make.',
             type: 'string',
             minLength: 1,
             maxLength: 32,
-            pattern: '.*'
+            pattern: '.*',
           },
           model: {
-            $ref: '#/components/schemas/CarModelType'
-          }
-        }
+            $ref: '#/components/schemas/CarModelType',
+          },
+        },
       },
       CarModelType: {
         description: 'The car model.',
         type: 'string',
         minLength: 1,
         maxLength: 32,
-        pattern: '.*'
+        pattern: '.*',
       },
       OffsetPaginationBase: {
         description:
@@ -906,31 +906,31 @@ module.exports = {
             description:
               'The offset (origin 0) of the first item returned in the result page.',
             type: 'integer',
-            format: 'int32'
+            format: 'int32',
           },
           limit: {
             description: 'The number of items returned in the result page.',
             type: 'integer',
-            format: 'int32'
+            format: 'int32',
           },
           total_count: {
             description: 'The total number of items across all result pages.',
             type: 'integer',
-            format: 'int32'
+            format: 'int32',
           },
           first: {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           next: {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           previous: {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           last: {
-            $ref: '#/components/schemas/PageLink'
-          }
-        }
+            $ref: '#/components/schemas/PageLink',
+          },
+        },
       },
       TokenPaginationBase: {
         description:
@@ -942,33 +942,33 @@ module.exports = {
             description:
               'The number of items returned in this page of results.',
             type: 'integer',
-            format: 'int32'
+            format: 'int32',
           },
           total_count: {
             description: 'The total number of items across all result pages.',
             type: 'integer',
-            format: 'int32'
+            format: 'int32',
           },
           first: {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           next: {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           previous: {
-            $ref: '#/components/schemas/PageLink'
+            $ref: '#/components/schemas/PageLink',
           },
           last: {
             allOf: [
               {
-                $ref: '#/components/schemas/PageLink'
+                $ref: '#/components/schemas/PageLink',
               },
               {
-                description: 'Link to the last page of results.'
-              }
-            ]
-          }
-        }
+                description: 'Link to the last page of results.',
+              },
+            ],
+          },
+        },
       },
       PageLink: {
         description: 'Contains a link to a page of paginated results',
@@ -979,9 +979,9 @@ module.exports = {
             type: 'string',
             pattern: '[a-zA-Z0-9 ]+',
             minLength: 1,
-            maxLength: 30
-          }
-        }
+            maxLength: 30,
+          },
+        },
       },
       ErrorContainer: {
         description: 'An error response for an operation.',
@@ -994,19 +994,19 @@ module.exports = {
             description:
               'The array of error entries associated with the error response',
             items: {
-              $ref: '#/components/schemas/Error'
-            }
+              $ref: '#/components/schemas/Error',
+            },
           },
           status_code: {
             type: 'integer',
-            description: 'The HTTP status code.'
+            description: 'The HTTP status code.',
           },
           trace: {
             description: 'The error trace information.',
             type: 'string',
-            format: 'uuid'
-          }
-        }
+            format: 'uuid',
+          },
+        },
       },
       Error: {
         description: 'An error response entry.',
@@ -1015,20 +1015,20 @@ module.exports = {
           code: {
             description: 'The error code.',
             type: 'string',
-            enum: ['bad_request', 'not_authorized', 'no_need_to_know']
+            enum: ['bad_request', 'not_authorized', 'no_need_to_know'],
           },
           message: {
             description: 'The error message.',
-            type: 'string'
+            type: 'string',
           },
           more_info: {
             description: 'Additional info about the error.',
-            type: 'string'
+            type: 'string',
           },
           target: {
-            $ref: '#/components/schemas/ErrorTarget'
-          }
-        }
+            $ref: '#/components/schemas/ErrorTarget',
+          },
+        },
       },
       ErrorTarget: {
         description: 'An error target (a field, header or query parameter).',
@@ -1037,15 +1037,15 @@ module.exports = {
           type: {
             description: 'The error target type.',
             type: 'string',
-            enum: ['field', 'header', 'parameter']
+            enum: ['field', 'header', 'parameter'],
           },
           name: {
             description:
               'The name of the field/header/query parameter associated with the error.',
-            type: 'string'
-          }
-        }
-      }
+            type: 'string',
+          },
+        },
+      },
     },
     securitySchemes: {
       IAM: {
@@ -1053,13 +1053,13 @@ module.exports = {
         description:
           'An IAM access token provided via the Authorization header',
         in: 'header',
-        name: 'Authorization'
+        name: 'Authorization',
       },
       Basic: {
         type: 'http',
         description: 'A basic-auth type Authorization header',
         scheme: 'Basic',
-        bearerFormat: 'bearer'
+        bearerFormat: 'bearer',
       },
       DrinkScheme: {
         type: 'oauth2',
@@ -1070,17 +1070,17 @@ module.exports = {
             tokenUrl: 'https://myoauthserver.com/token',
             scopes: {
               mixologist: 'Can create Drinks',
-              drinker: 'Can consume beverages'
-            }
+              drinker: 'Can consume beverages',
+            },
           },
           authorizationCode: {
             authorizationUrl: 'https://myoauthserver.com/auth',
             tokenUrl: 'https://myoauthserver.com/token',
             scopes: {
-              mixologist: 'Can create Drinks'
-            }
-          }
-        }
+              mixologist: 'Can create Drinks',
+            },
+          },
+        },
       },
       MovieScheme: {
         type: 'oauth2',
@@ -1091,35 +1091,35 @@ module.exports = {
             tokenUrl: 'https://myoauthserver.com/token',
             scopes: {
               director: 'Can create Movies',
-              moviegoer: 'Can view Movies'
-            }
+              moviegoer: 'Can view Movies',
+            },
           },
           authorizationCode: {
             authorizationUrl: 'https://myoauthserver.com/auth',
             tokenUrl: 'https://myoauthserver.com/token',
             scopes: {
-              director: 'Can create Movies'
-            }
+              director: 'Can create Movies',
+            },
           },
           clientCredentials: {
             tokenUrl: 'https://myoauthserver.com/token',
             scopes: {
-              moviegoer: 'Can view Movies'
-            }
+              moviegoer: 'Can view Movies',
+            },
           },
           password: {
             tokenUrl: 'https://myoauthserver.com/token',
             scopes: {
-              moviegoer: 'Can view Movies'
-            }
-          }
-        }
+              moviegoer: 'Can view Movies',
+            },
+          },
+        },
       },
       OpenIdScheme: {
         type: 'openIdConnect',
         description: 'An openid-connect authorization scheme',
-        openIdConnectUrl: 'https://myopenidserver.com/auth'
-      }
+        openIdConnectUrl: 'https://myopenidserver.com/auth',
+      },
     },
     responses: {
       ConsumedDrink: {
@@ -1127,64 +1127,64 @@ module.exports = {
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/Drink'
-            }
-          }
-        }
+              $ref: '#/components/schemas/Drink',
+            },
+          },
+        },
       },
       MovieWithETag: {
         description: 'Success, we retrieved a movie!',
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/Movie'
-            }
-          }
+              $ref: '#/components/schemas/Movie',
+            },
+          },
         },
         headers: {
           ETag: {
             description: 'The unique version identifier of the movie.',
             schema: {
-              $ref: '#/components/schemas/IdString'
-            }
-          }
-        }
+              $ref: '#/components/schemas/IdString',
+            },
+          },
+        },
       },
       BarIsClosed: {
         description: 'Error, no drinks to be had!',
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/ErrorContainer'
-            }
-          }
-        }
+              $ref: '#/components/schemas/ErrorContainer',
+            },
+          },
+        },
       },
       CarResponse: {
         description: 'The car instance was returned in the response.',
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/Car'
+              $ref: '#/components/schemas/Car',
             },
             examples: {
               ResponseExample: {
-                $ref: '#/components/examples/CarExample'
-              }
-            }
-          }
-        }
+                $ref: '#/components/examples/CarExample',
+              },
+            },
+          },
+        },
       },
       ErrorResponse: {
         description: 'An error occurred.',
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/ErrorContainer'
-            }
-          }
-        }
-      }
+              $ref: '#/components/schemas/ErrorContainer',
+            },
+          },
+        },
+      },
     },
     requestBodies: {
       CarRequest: {
@@ -1192,31 +1192,31 @@ module.exports = {
         content: {
           'application/json': {
             schema: {
-              $ref: '#/components/schemas/Car'
+              $ref: '#/components/schemas/Car',
             },
             examples: {
               RequestExample: {
-                $ref: '#/components/examples/CarExample'
-              }
-            }
-          }
-        }
+                $ref: '#/components/examples/CarExample',
+              },
+            },
+          },
+        },
       },
       UpdateCarRequest: {
         required: true,
         content: {
           'application/merge-patch+json; charset=utf-8': {
             schema: {
-              $ref: '#/components/schemas/CarPatch'
+              $ref: '#/components/schemas/CarPatch',
             },
             examples: {
               RequestExample: {
-                $ref: '#/components/examples/CarExample'
-              }
-            }
-          }
-        }
-      }
+                $ref: '#/components/examples/CarExample',
+              },
+            },
+          },
+        },
+      },
     },
     examples: {
       CarExample: {
@@ -1224,9 +1224,9 @@ module.exports = {
         value: {
           id: '1',
           make: 'Ford',
-          model: 'F150 Lariat'
-        }
-      }
+          model: 'F150 Lariat',
+        },
+      },
     },
     links: {
       CarIdLink: {
@@ -1234,11 +1234,11 @@ module.exports = {
           'Link the `create_car` response `id` property to the `get_car` path parameter named `car_id`.',
         operationId: 'get_car',
         parameters: {
-          car_id: '$response.body#/id'
-        }
-      }
+          car_id: '$response.body#/id',
+        },
+      },
     },
     callbacks: {},
-    headers: {}
-  }
+    headers: {},
+  },
 };

--- a/packages/ruleset/test/utils/severity-codes.js
+++ b/packages/ruleset/test/utils/severity-codes.js
@@ -7,5 +7,5 @@ module.exports = {
   error: 0,
   warning: 1,
   info: 2,
-  hint: 3
+  hint: 3,
 };

--- a/packages/ruleset/test/utils/test-rule.js
+++ b/packages/ruleset/test/utils/test-rule.js
@@ -17,8 +17,8 @@ module.exports = async (ruleName, rule, doc) => {
 
   spectral.setRuleset({
     rules: {
-      [ruleName]: rule
-    }
+      [ruleName]: rule,
+    },
   });
 
   try {

--- a/packages/utilities/src/collections/index.js
+++ b/packages/utilities/src/collections/index.js
@@ -19,7 +19,7 @@ const schemas = [
   '$.paths[*][*][parameters][*].schema',
   '$.paths[*][*][parameters,responses][*].content[*].schema',
   '$.paths[*][*].responses[*].headers[*].schema',
-  '$.paths[*][*][requestBody].content[*].schema'
+  '$.paths[*][*][requestBody].content[*].schema',
 ];
 
 // A collection of locations where a parameter object might be defined.
@@ -27,7 +27,7 @@ const schemas = [
 // should be used with resolved=true and we want to avoid duplication.
 const parameters = [
   '$.paths[*].parameters[*]',
-  '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
+  '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]',
 ];
 
 const paths = ['$.paths[*]'];
@@ -40,14 +40,14 @@ const patchOperations = ['$.paths[*][patch]'];
 // within an unresolved API definition.
 const unresolvedResponseSchemas = [
   '$.paths[*][*].responses[*].content[*].schema',
-  '$.components.responses[*].content[*].schema'
+  '$.components.responses[*].content[*].schema',
 ];
 
 // A collection of locations where a requestBody schema could be defined
 // within an unresolved API definition.
 const unresolvedRequestBodySchemas = [
   '$.paths[*][*].requestBody.content[*].schema',
-  '$.components.requestBodies[*].content[*].schema'
+  '$.components.requestBodies[*].content[*].schema',
 ];
 
 // A collection of locations where a schema object could be defined
@@ -74,7 +74,7 @@ const unresolvedSchemas = [
   '$.components.headers[*].schema',
   '$.components.headers[*].content[*].schema',
   '$.components.responses[*].headers[*].schema',
-  '$.components.responses[*].headers[*].content[*].schema'
+  '$.components.responses[*].headers[*].content[*].schema',
 ];
 
 const securitySchemes = ['$.components.securitySchemes[*]'];
@@ -89,5 +89,5 @@ module.exports = {
   unresolvedResponseSchemas,
   unresolvedSchemas,
   schemas,
-  securitySchemes
+  securitySchemes,
 };

--- a/packages/utilities/src/index.js
+++ b/packages/utilities/src/index.js
@@ -6,6 +6,6 @@
 module.exports = {
   ...require('./utils'),
   collections: {
-    ...require('./collections')
-  }
+    ...require('./collections'),
+  },
 };

--- a/packages/utilities/src/utils/get-schema-type.js
+++ b/packages/utilities/src/utils/get-schema-type.js
@@ -30,7 +30,7 @@ const SchemaType = {
   NUMBER: Symbol('number'),
   OBJECT: Symbol('object'),
   STRING: Symbol('string'),
-  UNKNOWN: Symbol('unknown')
+  UNKNOWN: Symbol('unknown'),
 };
 
 /**
@@ -332,5 +332,5 @@ module.exports = {
   isNumberSchema,
   isObjectSchema,
   isPrimitiveSchema,
-  isStringSchema
+  isStringSchema,
 };

--- a/packages/utilities/src/utils/index.js
+++ b/packages/utilities/src/utils/index.js
@@ -12,5 +12,5 @@ module.exports = {
   schemaRequiresProperty: require('./schema-requires-property'),
   validateComposedSchemas: require('./validate-composed-schemas'),
   validateNestedSchemas: require('./validate-nested-schemas'),
-  validateSubschemas: require('./validate-subschemas')
+  validateSubschemas: require('./validate-subschemas'),
 };

--- a/packages/utilities/test/get-property-names-for-schema.test.js
+++ b/packages/utilities/test/get-property-names-for-schema.test.js
@@ -24,8 +24,8 @@ describe('Utility function: getPropertyNamesForSchema()', () => {
         properties: {
           one: {},
           two: {},
-          three: {}
-        }
+          three: {},
+        },
       }).sort()
     ).toEqual(['three', 'two', 'one'].sort());
   });
@@ -34,29 +34,29 @@ describe('Utility function: getPropertyNamesForSchema()', () => {
     expect(
       getPropertyNamesForSchema({
         properties: {
-          one: {}
+          one: {},
         },
         allOf: [
           {
             properties: {
-              two: {}
-            }
-          }
+              two: {},
+            },
+          },
         ],
         oneOf: [
           {
             properties: {
-              three: {}
-            }
-          }
+              three: {},
+            },
+          },
         ],
         anyOf: [
           {
             properties: {
-              four: {}
-            }
-          }
-        ]
+              four: {},
+            },
+          },
+        ],
       }).sort()
     ).toEqual(['four', 'three', 'two', 'one'].sort());
   });
@@ -65,29 +65,29 @@ describe('Utility function: getPropertyNamesForSchema()', () => {
     expect(
       getPropertyNamesForSchema({
         properties: {
-          one: {}
+          one: {},
         },
         allOf: [
           {
             properties: {
-              two: {}
+              two: {},
             },
             oneOf: [
               {
                 properties: {
-                  three: {}
+                  three: {},
                 },
                 anyOf: [
                   {
                     properties: {
-                      four: {}
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+                      four: {},
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       }).sort()
     ).toEqual(['four', 'three', 'two', 'one'].sort());
   });
@@ -96,15 +96,15 @@ describe('Utility function: getPropertyNamesForSchema()', () => {
     expect(
       getPropertyNamesForSchema({
         properties: {
-          one: {}
+          one: {},
         },
         allOf: [
           {
             properties: {
-              one: {}
-            }
-          }
-        ]
+              one: {},
+            },
+          },
+        ],
       })
     ).toEqual(['one']);
   });
@@ -116,8 +116,8 @@ describe('Utility function: getPropertyNamesForSchema()', () => {
           properties: {
             one: {},
             two: {},
-            three: {}
-          }
+            three: {},
+          },
         },
         name => name.indexOf('o') !== -1
       ).sort()
@@ -131,8 +131,8 @@ describe('Utility function: getPropertyNamesForSchema()', () => {
           properties: {
             one: {},
             two: {},
-            three: { nullable: true }
-          }
+            three: { nullable: true },
+          },
         },
         (_, schema) => schema.nullable === true
       )

--- a/packages/utilities/test/is-array-schema.test.js
+++ b/packages/utilities/test/is-array-schema.test.js
@@ -48,10 +48,10 @@ describe('Utility function: isArraySchema()', () => {
       isArraySchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ items: {} }, { type: 'array' }] }, {}]
+            allOf: [{ anyOf: [{ items: {} }, { type: 'array' }] }, {}],
           },
-          { type: 'array' }
-        ]
+          { type: 'array' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-binary-schema.test.js
+++ b/packages/utilities/test/is-binary-schema.test.js
@@ -50,14 +50,14 @@ describe('Utility function: isBinarySchema()', () => {
               {
                 anyOf: [
                   { type: 'string', format: 'binary' },
-                  { type: 'string', format: 'binary' }
-                ]
+                  { type: 'string', format: 'binary' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'string', format: 'binary' }
-        ]
+          { type: 'string', format: 'binary' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-boolean-schema.test.js
+++ b/packages/utilities/test/is-boolean-schema.test.js
@@ -36,10 +36,10 @@ describe('Utility function: isBooleanSchema()', () => {
       isBooleanSchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ type: 'boolean' }, { type: 'boolean' }] }, {}]
+            allOf: [{ anyOf: [{ type: 'boolean' }, { type: 'boolean' }] }, {}],
           },
-          { type: 'boolean' }
-        ]
+          { type: 'boolean' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-byte-schema.test.js
+++ b/packages/utilities/test/is-byte-schema.test.js
@@ -50,14 +50,14 @@ describe('Utility function: isByteSchema()', () => {
               {
                 anyOf: [
                   { type: 'string', format: 'byte' },
-                  { type: 'string', format: 'byte' }
-                ]
+                  { type: 'string', format: 'byte' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'string', format: 'byte' }
-        ]
+          { type: 'string', format: 'byte' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-date-schema.test.js
+++ b/packages/utilities/test/is-date-schema.test.js
@@ -50,14 +50,14 @@ describe('Utility function: isDateSchema()', () => {
               {
                 anyOf: [
                   { type: 'string', format: 'date' },
-                  { type: 'string', format: 'date' }
-                ]
+                  { type: 'string', format: 'date' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'string', format: 'date' }
-        ]
+          { type: 'string', format: 'date' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-date-time-schema.test.js
+++ b/packages/utilities/test/is-date-time-schema.test.js
@@ -52,14 +52,14 @@ describe('Utility function: isDateTimeSchema()', () => {
               {
                 anyOf: [
                   { type: 'string', format: 'date-time' },
-                  { type: 'string', format: 'date-time' }
-                ]
+                  { type: 'string', format: 'date-time' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'string', format: 'date-time' }
-        ]
+          { type: 'string', format: 'date-time' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-double-schema.test.js
+++ b/packages/utilities/test/is-double-schema.test.js
@@ -50,14 +50,14 @@ describe('Utility function: isDoubleSchema()', () => {
               {
                 anyOf: [
                   { type: 'number', format: 'double' },
-                  { type: 'number', format: 'double' }
-                ]
+                  { type: 'number', format: 'double' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'number', format: 'double' }
-        ]
+          { type: 'number', format: 'double' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-enumeration-schema.test.js
+++ b/packages/utilities/test/is-enumeration-schema.test.js
@@ -41,14 +41,14 @@ describe('Utility function: isEnumerationSchema()', () => {
               {
                 anyOf: [
                   { type: 'string', enum: ['one'] },
-                  { type: 'string', enum: ['two'] }
-                ]
+                  { type: 'string', enum: ['two'] },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'string', enum: ['three'] }
-        ]
+          { type: 'string', enum: ['three'] },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-float-schema.test.js
+++ b/packages/utilities/test/is-float-schema.test.js
@@ -50,14 +50,14 @@ describe('Utility function: isFloatSchema()', () => {
               {
                 anyOf: [
                   { type: 'number', format: 'float' },
-                  { type: 'number', format: 'float' }
-                ]
+                  { type: 'number', format: 'float' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'number', format: 'float' }
-        ]
+          { type: 'number', format: 'float' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-int32-schema.test.js
+++ b/packages/utilities/test/is-int32-schema.test.js
@@ -50,14 +50,14 @@ describe('Utility function: isInt32Schema()', () => {
               {
                 anyOf: [
                   { type: 'integer', format: 'int32' },
-                  { type: 'integer', format: 'int32' }
-                ]
+                  { type: 'integer', format: 'int32' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'integer', format: 'int32' }
-        ]
+          { type: 'integer', format: 'int32' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-int64-schema.test.js
+++ b/packages/utilities/test/is-int64-schema.test.js
@@ -50,14 +50,14 @@ describe('Utility function: isInt64Schema()', () => {
               {
                 anyOf: [
                   { type: 'integer', format: 'int64' },
-                  { type: 'integer', format: 'int64' }
-                ]
+                  { type: 'integer', format: 'int64' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'integer', format: 'int64' }
-        ]
+          { type: 'integer', format: 'int64' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-integer-schema.test.js
+++ b/packages/utilities/test/is-integer-schema.test.js
@@ -36,10 +36,10 @@ describe('Utility function: isIntegerSchema()', () => {
       isIntegerSchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ type: 'integer' }, { type: 'integer' }] }, {}]
+            allOf: [{ anyOf: [{ type: 'integer' }, { type: 'integer' }] }, {}],
           },
-          { type: 'integer' }
-        ]
+          { type: 'integer' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-number-schema.test.js
+++ b/packages/utilities/test/is-number-schema.test.js
@@ -36,10 +36,10 @@ describe('Utility function: isNumberSchema()', () => {
       isNumberSchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ type: 'number' }, { type: 'number' }] }, {}]
+            allOf: [{ anyOf: [{ type: 'number' }, { type: 'number' }] }, {}],
           },
-          { type: 'number' }
-        ]
+          { type: 'number' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-object-schema.test.js
+++ b/packages/utilities/test/is-object-schema.test.js
@@ -56,10 +56,10 @@ describe('Utility function: isObjectSchema()', () => {
       isObjectSchema({
         oneOf: [
           {
-            allOf: [{ properties: {} }, {}]
+            allOf: [{ properties: {} }, {}],
           },
-          { type: 'object' }
-        ]
+          { type: 'object' },
+        ],
       })
     ).toBe(true);
   });
@@ -69,12 +69,12 @@ describe('Utility function: isObjectSchema()', () => {
       isObjectSchema({
         oneOf: [
           {
-            allOf: [{ properties: {} }, {}]
+            allOf: [{ properties: {} }, {}],
           },
           {
-            properties: {}
-          }
-        ]
+            properties: {},
+          },
+        ],
       })
     ).toBe(true);
   });
@@ -84,12 +84,12 @@ describe('Utility function: isObjectSchema()', () => {
       isObjectSchema({
         allOf: [
           {
-            allOf: [{ properties: {} }, {}]
+            allOf: [{ properties: {} }, {}],
           },
           {
-            properties: {}
-          }
-        ]
+            properties: {},
+          },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-primitive-schema.test.js
+++ b/packages/utilities/test/is-primitive-schema.test.js
@@ -73,14 +73,14 @@ describe('Utility function: isPrimitiveSchema()', () => {
               {
                 anyOf: [
                   { type: 'integer', format: 'int32' },
-                  { type: 'integer', format: 'int32' }
-                ]
+                  { type: 'integer', format: 'int32' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'integer', format: 'int32' }
-        ]
+          { type: 'integer', format: 'int32' },
+        ],
       })
     ).toBe(true);
   });
@@ -94,14 +94,14 @@ describe('Utility function: isPrimitiveSchema()', () => {
               {
                 anyOf: [
                   { type: 'number', format: 'double' },
-                  { type: 'number', format: 'double' }
-                ]
+                  { type: 'number', format: 'double' },
+                ],
               },
-              {}
-            ]
+              {},
+            ],
           },
-          { type: 'number', format: 'double' }
-        ]
+          { type: 'number', format: 'double' },
+        ],
       })
     ).toBe(true);
   });
@@ -111,10 +111,10 @@ describe('Utility function: isPrimitiveSchema()', () => {
       isPrimitiveSchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ type: 'number' }, { type: 'number' }] }, {}]
+            allOf: [{ anyOf: [{ type: 'number' }, { type: 'number' }] }, {}],
           },
-          { type: 'number' }
-        ]
+          { type: 'number' },
+        ],
       })
     ).toBe(true);
   });
@@ -124,10 +124,10 @@ describe('Utility function: isPrimitiveSchema()', () => {
       isPrimitiveSchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ type: 'boolean' }, { type: 'boolean' }] }, {}]
+            allOf: [{ anyOf: [{ type: 'boolean' }, { type: 'boolean' }] }, {}],
           },
-          { type: 'boolean' }
-        ]
+          { type: 'boolean' },
+        ],
       })
     ).toBe(true);
   });
@@ -137,10 +137,10 @@ describe('Utility function: isPrimitiveSchema()', () => {
       isPrimitiveSchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ type: 'string' }, { type: 'string' }] }, {}]
+            allOf: [{ anyOf: [{ type: 'string' }, { type: 'string' }] }, {}],
           },
-          { type: 'string' }
-        ]
+          { type: 'string' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/is-string-schema.test.js
+++ b/packages/utilities/test/is-string-schema.test.js
@@ -36,10 +36,10 @@ describe('Utility function: isStringSchema()', () => {
       isStringSchema({
         oneOf: [
           {
-            allOf: [{ anyOf: [{ type: 'string' }, { type: 'string' }] }, {}]
+            allOf: [{ anyOf: [{ type: 'string' }, { type: 'string' }] }, {}],
           },
-          { type: 'string' }
-        ]
+          { type: 'string' },
+        ],
       })
     ).toBe(true);
   });

--- a/packages/utilities/test/schema-has-constraint.test.js
+++ b/packages/utilities/test/schema-has-constraint.test.js
@@ -42,7 +42,7 @@ describe('Utility function: schemaHasConstraint()', () => {
 
   it('should return `true` for a schema with all-compliant `oneOf` schemas', async () => {
     const schemaWithAllCompliantOneOfs = {
-      oneOf: [{ fred: null }, { fred: null }, { fred: null }]
+      oneOf: [{ fred: null }, { fred: null }, { fred: null }],
     };
     expect(schemaHasConstraint(schemaWithAllCompliantOneOfs, fredIsNull)).toBe(
       true
@@ -51,7 +51,7 @@ describe('Utility function: schemaHasConstraint()', () => {
 
   it('should return `true` for a schema with all-compliant `anyOf` schemas', async () => {
     const schemaWithAllCompliantAnyOfs = {
-      anyOf: [{ fred: null }, { fred: null }, { fred: null }]
+      anyOf: [{ fred: null }, { fred: null }, { fred: null }],
     };
     expect(schemaHasConstraint(schemaWithAllCompliantAnyOfs, fredIsNull)).toBe(
       true
@@ -60,7 +60,7 @@ describe('Utility function: schemaHasConstraint()', () => {
 
   it('should return `true` for a schema with one of many compliant `allOf` schemas', async () => {
     const schemaWithOneCompliantAllOf = {
-      allOf: [{}, { fred: null }, {}]
+      allOf: [{}, { fred: null }, {}],
     };
     expect(schemaHasConstraint(schemaWithOneCompliantAllOf, fredIsNull)).toBe(
       true
@@ -69,7 +69,7 @@ describe('Utility function: schemaHasConstraint()', () => {
 
   it('should return `false` for a schema with one of many compliant `oneOf` schemas', async () => {
     const schemaWithOneCompliantOneOf = {
-      anyOf: [{}, { fred: null }, {}]
+      anyOf: [{}, { fred: null }, {}],
     };
     expect(schemaHasConstraint(schemaWithOneCompliantOneOf, fredIsNull)).toBe(
       false
@@ -78,7 +78,7 @@ describe('Utility function: schemaHasConstraint()', () => {
 
   it('should return `false` for a schema with one of many compliant `anyOf` schemas', async () => {
     const schemaWithOneCompliantAnyOf = {
-      anyOf: [{}, { fred: null }, {}]
+      anyOf: [{}, { fred: null }, {}],
     };
     expect(schemaHasConstraint(schemaWithOneCompliantAnyOf, fredIsNull)).toBe(
       false
@@ -89,7 +89,7 @@ describe('Utility function: schemaHasConstraint()', () => {
     const schemaWithOnlyOneOfCompliance = {
       oneOf: [{ fred: null }, { fred: null }],
       anyOf: [{ fred: null }, {}],
-      allOf: [{}, {}]
+      allOf: [{}, {}],
     };
     expect(schemaHasConstraint(schemaWithOnlyOneOfCompliance, fredIsNull)).toBe(
       true
@@ -100,7 +100,7 @@ describe('Utility function: schemaHasConstraint()', () => {
     const schemaWithOnlyAnyOfCompliance = {
       anyOf: [{ fred: null }, { fred: null }],
       oneOf: [{ fred: null }, {}],
-      allOf: [{}, {}]
+      allOf: [{}, {}],
     };
     expect(schemaHasConstraint(schemaWithOnlyAnyOfCompliance, fredIsNull)).toBe(
       true
@@ -111,7 +111,7 @@ describe('Utility function: schemaHasConstraint()', () => {
     const schemaWithOnlyAllOfCompliance = {
       allOf: [{}, { fred: null }, {}],
       oneOf: [{}, { fred: null }],
-      anyOf: [{ fred: null }, {}]
+      anyOf: [{ fred: null }, {}],
     };
     expect(schemaHasConstraint(schemaWithOnlyAllOfCompliance, fredIsNull)).toBe(
       true
@@ -122,10 +122,10 @@ describe('Utility function: schemaHasConstraint()', () => {
     const schemaWithAllOfInOneOf = {
       oneOf: [
         {
-          allOf: [{ fred: null }, {}]
+          allOf: [{ fred: null }, {}],
         },
-        { fred: null }
-      ]
+        { fred: null },
+      ],
     };
     expect(schemaHasConstraint(schemaWithAllOfInOneOf, fredIsNull)).toBe(true);
   });
@@ -134,10 +134,10 @@ describe('Utility function: schemaHasConstraint()', () => {
     const schemaWithAnyOfInAllOf = {
       allOf: [
         {
-          anyOf: [{ fred: null }, { fred: null }]
+          anyOf: [{ fred: null }, { fred: null }],
         },
-        {}
-      ]
+        {},
+      ],
     };
     expect(schemaHasConstraint(schemaWithAnyOfInAllOf, fredIsNull)).toBe(true);
   });
@@ -146,10 +146,10 @@ describe('Utility function: schemaHasConstraint()', () => {
     const schemaWithAnyOfInAllOf = {
       anyOf: [
         {
-          oneOf: [{ fred: null }, { fred: null }]
+          oneOf: [{ fred: null }, { fred: null }],
         },
-        { fred: null }
-      ]
+        { fred: null },
+      ],
     };
     expect(schemaHasConstraint(schemaWithAnyOfInAllOf, fredIsNull)).toBe(true);
   });

--- a/packages/utilities/test/schema-has-property.test.js
+++ b/packages/utilities/test/schema-has-property.test.js
@@ -43,8 +43,8 @@ describe('Utility function: schemaHasProperty()', () => {
       oneOf: [
         { properties: { my_property: {} } },
         { properties: { my_property: {} } },
-        { properties: { my_property: {} } }
-      ]
+        { properties: { my_property: {} } },
+      ],
     };
     expect(schemaHasProperty(schemaWithAllCompliantOneOfs, 'my_property')).toBe(
       true
@@ -56,8 +56,8 @@ describe('Utility function: schemaHasProperty()', () => {
       anyOf: [
         { properties: { my_property: {} } },
         { properties: { my_property: {} } },
-        { properties: { my_property: {} } }
-      ]
+        { properties: { my_property: {} } },
+      ],
     };
     expect(schemaHasProperty(schemaWithAllCompliantAnyOfs, 'my_property')).toBe(
       true
@@ -66,7 +66,7 @@ describe('Utility function: schemaHasProperty()', () => {
 
   it('should return `true` for a schema with one of many compliant `allOf` schemas', async () => {
     const schemaWithOneCompliantAllOf = {
-      allOf: [{}, { properties: { my_property: {} } }, {}]
+      allOf: [{}, { properties: { my_property: {} } }, {}],
     };
     expect(schemaHasProperty(schemaWithOneCompliantAllOf, 'my_property')).toBe(
       true
@@ -75,7 +75,7 @@ describe('Utility function: schemaHasProperty()', () => {
 
   it('should return `false` for a schema with one of many compliant `oneOf` schemas', async () => {
     const schemaWithOneCompliantOneOf = {
-      anyOf: [{}, { properties: { my_property: {} } }, {}]
+      anyOf: [{}, { properties: { my_property: {} } }, {}],
     };
     expect(schemaHasProperty(schemaWithOneCompliantOneOf, 'my_property')).toBe(
       false
@@ -84,7 +84,7 @@ describe('Utility function: schemaHasProperty()', () => {
 
   it('should return `false` for a schema with one of many compliant `anyOf` schemas', async () => {
     const schemaWithOneCompliantAnyOf = {
-      anyOf: [{}, { properties: { my_property: {} } }, {}]
+      anyOf: [{}, { properties: { my_property: {} } }, {}],
     };
     expect(schemaHasProperty(schemaWithOneCompliantAnyOf, 'my_property')).toBe(
       false
@@ -95,10 +95,10 @@ describe('Utility function: schemaHasProperty()', () => {
     const schemaWithOnlyOneOfCompliance = {
       oneOf: [
         { properties: { my_property: {} } },
-        { properties: { my_property: {} } }
+        { properties: { my_property: {} } },
       ],
       anyOf: [{ properties: { my_property: {} } }, {}],
-      allOf: [{}, {}]
+      allOf: [{}, {}],
     };
     expect(
       schemaHasProperty(schemaWithOnlyOneOfCompliance, 'my_property')
@@ -109,10 +109,10 @@ describe('Utility function: schemaHasProperty()', () => {
     const schemaWithOnlyAnyOfCompliance = {
       anyOf: [
         { properties: { my_property: {} } },
-        { properties: { my_property: {} } }
+        { properties: { my_property: {} } },
       ],
       oneOf: [{ properties: { my_property: {} } }, {}],
-      allOf: [{}, {}]
+      allOf: [{}, {}],
     };
     expect(
       schemaHasProperty(schemaWithOnlyAnyOfCompliance, 'my_property')
@@ -123,7 +123,7 @@ describe('Utility function: schemaHasProperty()', () => {
     const schemaWithOnlyAllOfCompliance = {
       allOf: [{}, { properties: { my_property: {} } }, {}],
       oneOf: [{}, { properties: { my_property: {} } }],
-      anyOf: [{ properties: { my_property: {} } }, {}]
+      anyOf: [{ properties: { my_property: {} } }, {}],
     };
     expect(
       schemaHasProperty(schemaWithOnlyAllOfCompliance, 'my_property')
@@ -134,10 +134,10 @@ describe('Utility function: schemaHasProperty()', () => {
     const schemaWithAllOfInOneOf = {
       oneOf: [
         {
-          allOf: [{ properties: { my_property: {} } }, {}]
+          allOf: [{ properties: { my_property: {} } }, {}],
         },
-        { properties: { my_property: {} } }
-      ]
+        { properties: { my_property: {} } },
+      ],
     };
     expect(schemaHasProperty(schemaWithAllOfInOneOf, 'my_property')).toBe(true);
   });
@@ -148,11 +148,11 @@ describe('Utility function: schemaHasProperty()', () => {
         {
           anyOf: [
             { properties: { my_property: {} } },
-            { properties: { my_property: {} } }
-          ]
+            { properties: { my_property: {} } },
+          ],
         },
-        {}
-      ]
+        {},
+      ],
     };
     expect(schemaHasProperty(schemaWithAnyOfInAllOf, 'my_property')).toBe(true);
   });
@@ -163,11 +163,11 @@ describe('Utility function: schemaHasProperty()', () => {
         {
           oneOf: [
             { properties: { my_property: {} } },
-            { properties: { my_property: {} } }
-          ]
+            { properties: { my_property: {} } },
+          ],
         },
-        { properties: { my_property: {} } }
-      ]
+        { properties: { my_property: {} } },
+      ],
     };
     expect(schemaHasProperty(schemaWithAnyOfInAllOf, 'my_property')).toBe(true);
   });

--- a/packages/utilities/test/schema-requires-property.test.js
+++ b/packages/utilities/test/schema-requires-property.test.js
@@ -21,7 +21,7 @@ describe('Utility function: schemaRequiresProperty()', () => {
   it('should return `true` for a compliant simple schema', async () => {
     const compliantSimpleSchema = {
       required: ['fungibility'],
-      properties: { fungibility: {} }
+      properties: { fungibility: {} },
     };
     expect(schemaRequiresProperty(compliantSimpleSchema, 'fungibility')).toBe(
       true
@@ -54,8 +54,8 @@ describe('Utility function: schemaRequiresProperty()', () => {
       oneOf: [
         { required: ['fungibility'], properties: { fungibility: {} } },
         { required: ['fungibility'], properties: { fungibility: {} } },
-        { required: ['fungibility'], properties: { fungibility: {} } }
-      ]
+        { required: ['fungibility'], properties: { fungibility: {} } },
+      ],
     };
     expect(
       schemaRequiresProperty(schemaWithAllCompliantOneOfs, 'fungibility')
@@ -67,8 +67,8 @@ describe('Utility function: schemaRequiresProperty()', () => {
       anyOf: [
         { required: ['fungibility'], properties: { fungibility: {} } },
         { required: ['fungibility'], properties: { fungibility: {} } },
-        { required: ['fungibility'], properties: { fungibility: {} } }
-      ]
+        { required: ['fungibility'], properties: { fungibility: {} } },
+      ],
     };
     expect(
       schemaRequiresProperty(schemaWithAllCompliantAnyOfs, 'fungibility')
@@ -80,8 +80,8 @@ describe('Utility function: schemaRequiresProperty()', () => {
       allOf: [
         {},
         { required: ['fungibility'], properties: { fungibility: {} } },
-        {}
-      ]
+        {},
+      ],
     };
     expect(
       schemaRequiresProperty(schemaWithOneCompliantAllOf, 'fungibility')
@@ -93,8 +93,8 @@ describe('Utility function: schemaRequiresProperty()', () => {
       anyOf: [
         {},
         { required: ['fungibility'], properties: { fungibility: {} } },
-        {}
-      ]
+        {},
+      ],
     };
     expect(
       schemaRequiresProperty(schemaWithOneCompliantOneOf, 'fungibility')
@@ -103,7 +103,7 @@ describe('Utility function: schemaRequiresProperty()', () => {
 
   it('should return `false` for a schema with one of many compliant `anyOf` schemas', async () => {
     const schemaWithOneCompliantAnyOf = {
-      anyOf: [{}, { required: ['fungibility'] }, {}]
+      anyOf: [{}, { required: ['fungibility'] }, {}],
     };
     expect(
       schemaRequiresProperty(schemaWithOneCompliantAnyOf, 'fungibility')
@@ -114,13 +114,13 @@ describe('Utility function: schemaRequiresProperty()', () => {
     const schemaWithOnlyOneOfCompliance = {
       oneOf: [
         { required: ['fungibility'], properties: { fungibility: {} } },
-        { required: ['fungibility'], properties: { fungibility: {} } }
+        { required: ['fungibility'], properties: { fungibility: {} } },
       ],
       anyOf: [
         { required: ['fungibility'], properties: { fungibility: {} } },
-        {}
+        {},
       ],
-      allOf: [{}, {}]
+      allOf: [{}, {}],
     };
     expect(
       schemaRequiresProperty(schemaWithOnlyOneOfCompliance, 'fungibility')
@@ -131,13 +131,13 @@ describe('Utility function: schemaRequiresProperty()', () => {
     const schemaWithOnlyAnyOfCompliance = {
       anyOf: [
         { required: ['fungibility'], properties: { fungibility: {} } },
-        { required: ['fungibility'], properties: { fungibility: {} } }
+        { required: ['fungibility'], properties: { fungibility: {} } },
       ],
       oneOf: [
         { required: ['fungibility'], properties: { fungibility: {} } },
-        {}
+        {},
       ],
-      allOf: [{}, {}]
+      allOf: [{}, {}],
     };
     expect(
       schemaRequiresProperty(schemaWithOnlyAnyOfCompliance, 'fungibility')
@@ -149,16 +149,16 @@ describe('Utility function: schemaRequiresProperty()', () => {
       allOf: [
         {},
         { required: ['fungibility'], properties: { fungibility: {} } },
-        {}
+        {},
       ],
       oneOf: [
         {},
-        { required: ['fungibility'], properties: { fungibility: {} } }
+        { required: ['fungibility'], properties: { fungibility: {} } },
       ],
       anyOf: [
         { required: ['fungibility'], properties: { fungibility: {} } },
-        {}
-      ]
+        {},
+      ],
     };
     expect(
       schemaRequiresProperty(schemaWithOnlyAllOfCompliance, 'fungibility')
@@ -171,11 +171,11 @@ describe('Utility function: schemaRequiresProperty()', () => {
         {
           allOf: [
             { required: ['fungibility'], properties: { fungibility: {} } },
-            {}
-          ]
+            {},
+          ],
         },
-        { required: ['fungibility'], properties: { fungibility: {} } }
-      ]
+        { required: ['fungibility'], properties: { fungibility: {} } },
+      ],
     };
     expect(schemaRequiresProperty(schemaWithAllOfInOneOf, 'fungibility')).toBe(
       true
@@ -188,11 +188,11 @@ describe('Utility function: schemaRequiresProperty()', () => {
         {
           anyOf: [
             { required: ['fungibility'], properties: { fungibility: {} } },
-            { required: ['fungibility'], properties: { fungibility: {} } }
-          ]
+            { required: ['fungibility'], properties: { fungibility: {} } },
+          ],
         },
-        {}
-      ]
+        {},
+      ],
     };
     expect(schemaRequiresProperty(schemaWithAnyOfInAllOf, 'fungibility')).toBe(
       true
@@ -205,11 +205,11 @@ describe('Utility function: schemaRequiresProperty()', () => {
         {
           oneOf: [
             { required: ['fungibility'], properties: { fungibility: {} } },
-            { required: ['fungibility'], properties: { fungibility: {} } }
-          ]
+            { required: ['fungibility'], properties: { fungibility: {} } },
+          ],
         },
-        { required: ['fungibility'], properties: { fungibility: {} } }
-      ]
+        { required: ['fungibility'], properties: { fungibility: {} } },
+      ],
     };
     expect(schemaRequiresProperty(schemaWithAnyOfInAllOf, 'fungibility')).toBe(
       true

--- a/packages/utilities/test/utils/all-schemas-document.js
+++ b/packages/utilities/test/utils/all-schemas-document.js
@@ -12,18 +12,18 @@ module.exports = {
       'A collection of schemas with various kinds of subschemas for testing.',
     version: '0.0.1',
     contact: {
-      email: 'example@example.com'
-    }
+      email: 'example@example.com',
+    },
   },
   tags: [
     {
-      name: 'Index'
-    }
+      name: 'Index',
+    },
   ],
   servers: [
     {
-      url: '/api/v3'
-    }
+      url: '/api/v3',
+    },
   ],
   paths: {
     '/schema': {
@@ -33,18 +33,18 @@ module.exports = {
         description: 'Get the index.',
         operationId: 'get_index',
         responses: {
-          '200': {
+          200: {
             description: "Here's the index.",
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/Index'
-                }
-              }
-            }
-          }
-        }
-      }
+                  $ref: '#/components/schemas/Index',
+                },
+              },
+            },
+          },
+        },
+      },
     },
     '/every_flavor': {
       get: {
@@ -53,19 +53,19 @@ module.exports = {
         description: 'Get every flavor.',
         operationId: 'get_every_flavor',
         responses: {
-          '200': {
+          200: {
             description: "Here's every flavor.",
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/EveryFlavor'
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+                  $ref: '#/components/schemas/EveryFlavor',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   components: {
     schemas: {
@@ -73,144 +73,144 @@ module.exports = {
         type: 'object',
         properties: {
           schema_with_property_schema: {
-            $ref: '#/components/schemas/SchemaWithPropertySchema'
+            $ref: '#/components/schemas/SchemaWithPropertySchema',
           },
           schema_with_additional_properties_schema: {
-            $ref: '#/components/schemas/SchemaWithAdditionalPropertiesSchema'
+            $ref: '#/components/schemas/SchemaWithAdditionalPropertiesSchema',
           },
           schema_with_items_schema: {
-            $ref: '#/components/schemas/SchemaWithItemsSchema'
+            $ref: '#/components/schemas/SchemaWithItemsSchema',
           },
           schema_with_all_of_schema: {
-            $ref: '#/components/schemas/SchemaWithAllOfSchema'
+            $ref: '#/components/schemas/SchemaWithAllOfSchema',
           },
           schema_with_one_of_schema: {
-            $ref: '#/components/schemas/SchemaWithOneOfSchema'
+            $ref: '#/components/schemas/SchemaWithOneOfSchema',
           },
           schema_with_any_of_schema: {
-            $ref: '#/components/schemas/SchemaWithAnyOfSchema'
+            $ref: '#/components/schemas/SchemaWithAnyOfSchema',
           },
           schema_with_not_schema: {
-            $ref: '#/components/schemas/SchemaWithNotSchema'
-          }
-        }
+            $ref: '#/components/schemas/SchemaWithNotSchema',
+          },
+        },
       },
       EveryFlavor: {
         properties: {
           property_schema: {
-            $ref: '#/components/schemas/SchemaWithPropertySchema'
-          }
+            $ref: '#/components/schemas/SchemaWithPropertySchema',
+          },
         },
         additionalProperties: {
-          $ref: '#/components/schemas/AdditionalPropertiesSchema'
+          $ref: '#/components/schemas/AdditionalPropertiesSchema',
         },
         items: {
-          $ref: '#/components/schemas/ItemsSchema'
+          $ref: '#/components/schemas/ItemsSchema',
         },
         allOf: [
           {
-            $ref: '#/components/schemas/AllOfSchema'
-          }
+            $ref: '#/components/schemas/AllOfSchema',
+          },
         ],
         oneOf: [
           {
-            $ref: '#/components/schemas/OneOfSchema'
-          }
+            $ref: '#/components/schemas/OneOfSchema',
+          },
         ],
         anyOf: [
           {
-            $ref: '#/components/schemas/AnyOfSchema'
-          }
+            $ref: '#/components/schemas/AnyOfSchema',
+          },
         ],
         not: {
-          $ref: '#/components/schemas/NotSchema'
-        }
+          $ref: '#/components/schemas/NotSchema',
+        },
       },
       SchemaWithPropertySchema: {
         type: 'object',
         properties: {
           property_schema: {
-            $ref: '#/components/schemas/PropertySchema'
-          }
-        }
+            $ref: '#/components/schemas/PropertySchema',
+          },
+        },
       },
       PropertySchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithPropertySchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithPropertySchema`.',
       },
       SchemaWithAdditionalPropertiesSchema: {
         type: 'object',
         additionalProperties: {
-          $ref: '#/components/schemas/AdditionalPropertiesSchema'
-        }
+          $ref: '#/components/schemas/AdditionalPropertiesSchema',
+        },
       },
       AdditionalPropertiesSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithAdditionalPropertiesSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithAdditionalPropertiesSchema`.',
       },
       SchemaWithItemsSchema: {
         type: 'array',
         items: {
-          $ref: '#/components/schemas/ItemsSchema'
-        }
+          $ref: '#/components/schemas/ItemsSchema',
+        },
       },
       ItemsSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithItemsSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithItemsSchema`.',
       },
       SchemaWithAllOfSchema: {
         type: 'string',
         allOf: [
           {
-            $ref: '#/components/schemas/AllOfSchema'
-          }
-        ]
+            $ref: '#/components/schemas/AllOfSchema',
+          },
+        ],
       },
       AllOfSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithAllOfSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithAllOfSchema`.',
       },
       SchemaWithOneOfSchema: {
         type: 'string',
         oneOf: [
           {
-            $ref: '#/components/schemas/OneOfSchema'
-          }
-        ]
+            $ref: '#/components/schemas/OneOfSchema',
+          },
+        ],
       },
       OneOfSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithOneOfSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithOneOfSchema`.',
       },
       SchemaWithAnyOfSchema: {
         type: 'string',
         anyOf: [
           {
-            $ref: '#/components/schemas/AnyOfSchema'
-          }
-        ]
+            $ref: '#/components/schemas/AnyOfSchema',
+          },
+        ],
       },
       AnyOfSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithAnyOfSchema`.'
+          'This schema is reachable from `EveryFlavor` and `SchemaWithAnyOfSchema`.',
       },
       SchemaWithNotSchema: {
         type: 'string',
         not: {
-          $ref: '#/components/schemas/NotSchema'
-        }
+          $ref: '#/components/schemas/NotSchema',
+        },
       },
       NotSchema: {
         type: 'string',
         description:
-          'This schema is reachable from `EveryFlavor` and `SchemaWithNotSchema`.'
-      }
-    }
-  }
+          'This schema is reachable from `EveryFlavor` and `SchemaWithNotSchema`.',
+      },
+    },
+  },
 };

--- a/packages/utilities/test/utils/index.js
+++ b/packages/utilities/test/utils/index.js
@@ -9,5 +9,5 @@ const testRule = require('./test-rule');
 
 module.exports = {
   allSchemasDocument,
-  testRule
+  testRule,
 };

--- a/packages/utilities/test/utils/test-rule.js
+++ b/packages/utilities/test/utils/test-rule.js
@@ -11,8 +11,8 @@ module.exports = async (ruleName, rule, doc) => {
 
   spectral.setRuleset({
     rules: {
-      [ruleName]: rule
-    }
+      [ruleName]: rule,
+    },
   });
 
   try {

--- a/packages/utilities/test/validate-composed-schemas.test.js
+++ b/packages/utilities/test/validate-composed-schemas.test.js
@@ -33,7 +33,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should validate a composed schema even if `includeSelf` is `false`', async () => {
     const schema = {
-      allOf: [{}]
+      allOf: [{}],
     };
 
     const visitedPaths = validateComposedSchemas(
@@ -50,7 +50,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should validate `allOf` schemas', async () => {
     const schema = {
-      allOf: [{}, {}]
+      allOf: [{}, {}],
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -62,7 +62,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should validate `oneOf` schemas', async () => {
     const schema = {
-      oneOf: [{}, {}]
+      oneOf: [{}, {}],
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -74,7 +74,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should validate `anyOf` schemas', async () => {
     const schema = {
-      anyOf: [{}, {}]
+      anyOf: [{}, {}],
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -86,7 +86,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should validate `not` schema', async () => {
     const schema = {
-      not: {}
+      not: {},
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -98,7 +98,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should not validate `not` schema if `includeNot` is false', async () => {
     const schema = {
-      not: {}
+      not: {},
     };
 
     const visitedPaths = validateComposedSchemas(
@@ -116,7 +116,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should recurse through `allOf`, `oneOf`, `anyOf`, and `not`', async () => {
     const schema = {
-      allOf: [{ oneOf: [{ anyOf: [{ not: {} }] }] }]
+      allOf: [{ oneOf: [{ anyOf: [{ not: {} }] }] }],
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -129,14 +129,14 @@ describe('Utility function: validateComposedSchemas()', () => {
         'allOf.0',
         'allOf.0.oneOf.0',
         'allOf.0.oneOf.0.anyOf.0',
-        'allOf.0.oneOf.0.anyOf.0.not'
+        'allOf.0.oneOf.0.anyOf.0.not',
       ].sort()
     );
   });
 
   it('recorded paths are accurate for each schema', async () => {
     const schema = {
-      allOf: [{ oneOf: [{ anyOf: [{ not: {} }] }] }]
+      allOf: [{ oneOf: [{ anyOf: [{ not: {} }] }] }],
     };
 
     function getObjectByPath(object, path) {
@@ -159,8 +159,8 @@ describe('Utility function: validateComposedSchemas()', () => {
       properties: {
         one: {},
         two: {},
-        three: {}
-      }
+        three: {},
+      },
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -172,7 +172,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should not validate `additionalProperties` schema', async () => {
     const schema = {
-      additionalProperties: {}
+      additionalProperties: {},
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -184,7 +184,7 @@ describe('Utility function: validateComposedSchemas()', () => {
 
   it('should not validate `items` schema', async () => {
     const schema = {
-      items: {}
+      items: {},
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {
@@ -198,10 +198,10 @@ describe('Utility function: validateComposedSchemas()', () => {
     const schema = {
       allOf: [
         {
-          $ref: '#/components/schemas/SomeSchema'
+          $ref: '#/components/schemas/SomeSchema',
         },
-        {}
-      ]
+        {},
+      ],
     };
 
     const visitedPaths = validateComposedSchemas(schema, [], (s, p) => {

--- a/packages/utilities/test/validate-nested-schemas.test.js
+++ b/packages/utilities/test/validate-nested-schemas.test.js
@@ -34,8 +34,8 @@ describe('Utility function: validateNestedSchemas()', () => {
   it('should validate a nested schema even if `includeSelf` is `false`', async () => {
     const schema = {
       properties: {
-        nested_property: {}
-      }
+        nested_property: {},
+      },
     };
 
     const visitedPaths = validateNestedSchemas(
@@ -55,8 +55,8 @@ describe('Utility function: validateNestedSchemas()', () => {
       properties: {
         one: {},
         two: {},
-        three: {}
-      }
+        three: {},
+      },
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -70,7 +70,7 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should validate `additionalProperties` schema', async () => {
     const schema = {
-      additionalProperties: {}
+      additionalProperties: {},
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -82,7 +82,7 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should validate `items` schema', async () => {
     const schema = {
-      items: {}
+      items: {},
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -94,7 +94,7 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should validate through `allOf` schema', async () => {
     const schema = {
-      allOf: [{ properties: { inside_all_of: {} } }]
+      allOf: [{ properties: { inside_all_of: {} } }],
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -108,7 +108,7 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should validate through `oneOf` schema', async () => {
     const schema = {
-      oneOf: [{ properties: { inside_one_of: {} } }]
+      oneOf: [{ properties: { inside_one_of: {} } }],
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -122,7 +122,7 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should validate through `anyOf` schema', async () => {
     const schema = {
-      anyOf: [{ properties: { inside_any_of: {} } }]
+      anyOf: [{ properties: { inside_any_of: {} } }],
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -136,7 +136,7 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should not validate through `not` schema by default', async () => {
     const schema = {
-      not: { properties: { inside_not: {} } }
+      not: { properties: { inside_not: {} } },
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -148,7 +148,7 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should validate through `not` schema if `includeNot` is true', async () => {
     const schema = {
-      not: { properties: { inside_not: {} } }
+      not: { properties: { inside_not: {} } },
     };
 
     const visitedPaths = validateNestedSchemas(
@@ -166,7 +166,9 @@ describe('Utility function: validateNestedSchemas()', () => {
 
   it('should recurse through `allOf`, `oneOf`, and `anyOf`', async () => {
     const schema = {
-      allOf: [{ oneOf: [{ anyOf: [{ properties: { can_you_find_me: {} } }] }] }]
+      allOf: [
+        { oneOf: [{ anyOf: [{ properties: { can_you_find_me: {} } }] }] },
+      ],
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {
@@ -182,15 +184,15 @@ describe('Utility function: validateNestedSchemas()', () => {
     const schema = {
       allOf: [{ properties: { inside_all_of: {} } }],
       properties: {
-        nested_property: {}
+        nested_property: {},
       },
       additionalProperties: {
         oneOf: [
           {
-            items: {}
-          }
-        ]
-      }
+            items: {},
+          },
+        ],
+      },
     };
 
     function getObjectByPath(object, path) {
@@ -214,9 +216,9 @@ describe('Utility function: validateNestedSchemas()', () => {
         one: {},
         two: {},
         three: {
-          $ref: '#/components/schemas/Three'
-        }
-      }
+          $ref: '#/components/schemas/Three',
+        },
+      },
     };
 
     const visitedPaths = validateNestedSchemas(schema, [], (s, p) => {

--- a/packages/utilities/test/validate-subschemas.test.js
+++ b/packages/utilities/test/validate-subschemas.test.js
@@ -26,7 +26,7 @@ describe('Utility: validateSubschemas', () => {
     '$.paths[*][*][parameters][*].schema',
     '$.paths[*][*][parameters,responses][*].content[*].schema',
     '$.paths[*][*].responses[*].headers[*].schema',
-    '$.paths[*][*][requestBody].content[*].schema'
+    '$.paths[*][*][requestBody].content[*].schema',
   ];
 
   // this needs to be executed as a spectral rule to resolve the document
@@ -34,8 +34,8 @@ describe('Utility: validateSubschemas', () => {
     given: schemas,
     resolved: true,
     then: {
-      function: ruleFunction
-    }
+      function: ruleFunction,
+    },
   };
 
   it('should find all subschemas', async () => {

--- a/packages/validator/src/cli-validator/utils/check-version.js
+++ b/packages/validator/src/cli-validator/utils/check-version.js
@@ -9,7 +9,7 @@ const chalk = require('chalk');
 // this module can be used to handle any version-specific functionality
 // it will be called immediately when the program is run
 
-module.exports = function(requiredVersion) {
+module.exports = function (requiredVersion) {
   // this is called since the code uses features that require `requiredVersion`
   const isSupportedVersion = semver.gte(process.version, requiredVersion);
   if (!isSupportedVersion) {

--- a/packages/validator/src/cli-validator/utils/cli-options.js
+++ b/packages/validator/src/cli-validator/utils/cli-options.js
@@ -99,7 +99,7 @@ function createCLIOptions() {
   // and can be captured properly during testing.
   command.configureOutput({
     writeOut: s => console.log(s),
-    writeErr: s => console.error(s)
+    writeErr: s => console.error(s),
   });
 
   return command;

--- a/packages/validator/src/cli-validator/utils/configuration-manager.js
+++ b/packages/validator/src/cli-validator/utils/configuration-manager.js
@@ -6,7 +6,7 @@
 const path = require('path');
 const {
   getFileExtension,
-  supportedFileExtension
+  supportedFileExtension,
 } = require('./file-extension-validator');
 const { LoggerFactory } = require('@ibm-cloud/openapi-ruleset/src/utils');
 const { validate } = require('./schema-validator');
@@ -30,7 +30,7 @@ const defaultConfig = {
     // 'my-api.yaml'
   ],
   limits: {
-    warnings: -1
+    warnings: -1,
   },
   ignoreFiles: [
     // '/full/path/to/file/ignoreMe.json'
@@ -42,7 +42,7 @@ const defaultConfig = {
   outputFormat: 'text',
   ruleset: null,
   summaryOnly: false,
-  verbose: false
+  verbose: false,
 };
 
 const supportedConfigFileTypes = ['json', 'yaml', 'yml', 'js'];
@@ -153,7 +153,7 @@ async function processArgs(args, cliParseOptions) {
   // "context" will serve as a container for the validator's configuration
   // and state information.
   const context = {
-    logger
+    logger,
   };
 
   // Retrieve the options that were set by the user on the command-line.
@@ -265,5 +265,5 @@ module.exports = {
   getConfigFileSchema,
   getDefaultConfig,
   loadConfig,
-  processArgs
+  processArgs,
 };

--- a/packages/validator/src/cli-validator/utils/get-copyright-string.js
+++ b/packages/validator/src/cli-validator/utils/get-copyright-string.js
@@ -5,6 +5,6 @@
 
 const getVersionString = require('./get-version-string');
 
-module.exports = function() {
+module.exports = function () {
   return `IBM OpenAPI Validator (${getVersionString()}), @Copyright IBM Corporation 2017, 2023.\n`;
 };

--- a/packages/validator/src/cli-validator/utils/get-version-string.js
+++ b/packages/validator/src/cli-validator/utils/get-version-string.js
@@ -5,7 +5,7 @@
 
 const packageConfig = require('../../../package.json');
 
-module.exports = function() {
+module.exports = function () {
   const validator = packageConfig.version;
   const ruleset = packageConfig.dependencies['@ibm-cloud/openapi-ruleset'];
 

--- a/packages/validator/src/cli-validator/utils/preprocess-file.js
+++ b/packages/validator/src/cli-validator/utils/preprocess-file.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-module.exports = function(originalFile) {
+module.exports = function (originalFile) {
   let processedFile;
 
   // replace all tabs characters (\t) in the original file with 2 spaces

--- a/packages/validator/src/cli-validator/utils/print-results.js
+++ b/packages/validator/src/cli-validator/utils/print-results.js
@@ -20,7 +20,7 @@ module.exports = function print(context, results) {
     error: 'bgRed',
     warning: 'bgYellow',
     info: 'bgGrey',
-    hint: 'bgGreen'
+    hint: 'bgGreen',
   };
 
   types.forEach(type => {

--- a/packages/validator/src/cli-validator/utils/schema-validator.js
+++ b/packages/validator/src/cli-validator/utils/schema-validator.js
@@ -31,5 +31,5 @@ function validate(data, schema) {
 }
 
 module.exports = {
-  validate
+  validate,
 };

--- a/packages/validator/src/spectral/spectral-validator.js
+++ b/packages/validator/src/spectral/spectral-validator.js
@@ -6,11 +6,11 @@
 const { Document, Spectral } = require('@stoplight/spectral-core');
 const Parsers = require('@stoplight/spectral-parsers');
 const {
-  getRuleset
+  getRuleset,
 } = require('@stoplight/spectral-cli/dist/services/linter/utils/getRuleset');
 const ibmRuleset = require('@ibm-cloud/openapi-ruleset');
 const {
-  getFileExtension
+  getFileExtension,
 } = require('../cli-validator/utils/file-extension-validator');
 const findUp = require('find-up');
 
@@ -26,7 +26,7 @@ const findUp = require('find-up');
  * @param {*} opts.originalFile
  * @returns the formatted results
  */
-const runSpectral = async function({ originalFile, validFile }, context) {
+const runSpectral = async function ({ originalFile, validFile }, context) {
   const spectral = await setup(context);
 
   const fileExtension = getFileExtension(validFile);
@@ -49,7 +49,7 @@ function convertResults(spectralResults, { config, logger }) {
     warning: { results: [], summary: { total: 0, entries: [] } },
     info: { results: [], summary: { total: 0, entries: [] } },
     hint: { results: [], summary: { total: 0, entries: [] } },
-    hasResults: false
+    hasResults: false,
   };
 
   // use this object to count the occurance of each validation
@@ -80,7 +80,7 @@ function convertResults(spectralResults, { config, logger }) {
         message: r.message,
         path: r.path,
         rule: r.code,
-        line: r.range.start.line + 1
+        line: r.range.start.line + 1,
       });
     }
 
@@ -101,7 +101,7 @@ function convertResults(spectralResults, { config, logger }) {
         percentage: Math.round(
           (summaryHelper[sev][field] / finalResultsObject[sev].summary.total) *
             100
-        )
+        ),
       });
     }
   }
@@ -149,7 +149,7 @@ async function setup({ chalk, config, logger }) {
 }
 
 module.exports = {
-  runSpectral
+  runSpectral,
 };
 
 function checkGetRulesetError(logger, error, chalk) {
@@ -210,7 +210,7 @@ async function lookForSpectralRuleset() {
     '.spectral.yaml',
     '.spectral.yml',
     '.spectral.json',
-    '.spectral.js'
+    '.spectral.js',
   ];
 
   let rulesetFile = null;

--- a/packages/validator/test/cli-validator/mock-files/config/valid-config.js
+++ b/packages/validator/test/cli-validator/mock-files/config/valid-config.js
@@ -1,11 +1,11 @@
 module.exports = {
   limits: {
-    warnings: 10
+    warnings: 10,
   },
   ignoreFiles: ['ignored/file/numero_uno', 'another/ignored/file'],
   logLevels: {
     logger1: 'debug',
     root: 'info',
-    logger2: 'error'
-  }
+    logger2: 'error',
+  },
 };

--- a/packages/validator/test/cli-validator/tests/configuration-manager.test.js
+++ b/packages/validator/test/cli-validator/tests/configuration-manager.test.js
@@ -9,7 +9,7 @@ const configMgr = require('../../../src/cli-validator/utils/configuration-manage
 // Use these parse options since we're not actually retrieving process args.
 const cliParseOptions = { from: 'user' };
 
-describe('Configuration Manager tests', function() {
+describe('Configuration Manager tests', function () {
   let consoleSpy;
   const originalWarn = console.warn;
   const originalError = console.error;
@@ -29,8 +29,8 @@ describe('Configuration Manager tests', function() {
     console.info = originalInfo;
   });
 
-  describe('getDefaultConfig()', function() {
-    it('should return correct default configuration object', async function() {
+  describe('getDefaultConfig()', function () {
+    it('should return correct default configuration object', async function () {
       const defaultConfig = configMgr.getDefaultConfig();
 
       expect(typeof defaultConfig).toBe('object');
@@ -47,20 +47,20 @@ describe('Configuration Manager tests', function() {
     });
   });
 
-  describe('loadConfig()', function() {
+  describe('loadConfig()', function () {
     const expectedConfig = {
       limits: {
-        warnings: 10
+        warnings: 10,
       },
       ignoreFiles: ['ignored/file/numero_uno', 'another/ignored/file'],
       logLevels: {
         logger1: 'debug',
         root: 'info',
-        logger2: 'error'
-      }
+        logger2: 'error',
+      },
     };
 
-    it('should return correct config object for .json', async function() {
+    it('should return correct config object for .json', async function () {
       const config = await configMgr.loadConfig(
         './test/cli-validator/mock-files/config/valid-config.json'
       );
@@ -68,28 +68,28 @@ describe('Configuration Manager tests', function() {
       expect(config).toMatchObject(expectedConfig);
     });
 
-    it('should return correct config object for .yaml', async function() {
+    it('should return correct config object for .yaml', async function () {
       const config = await configMgr.loadConfig(
         './test/cli-validator/mock-files/config/valid-config.yaml'
       );
       expect(config).toMatchObject(expectedConfig);
     });
 
-    it('should return correct config object for .js', async function() {
+    it('should return correct config object for .js', async function () {
       const config = await configMgr.loadConfig(
         './test/cli-validator/mock-files/config/valid-config.js'
       );
       expect(config).toMatchObject(expectedConfig);
     });
 
-    it('should return correct config object for five-warnings.json', async function() {
+    it('should return correct config object for five-warnings.json', async function () {
       const config = await configMgr.loadConfig(
         './test/cli-validator/mock-files/config/five-warnings.json'
       );
       expect(config.limits.warnings).toBe(5);
     });
 
-    it('should log error and return default config for invalid config file', async function() {
+    it('should log error and return default config for invalid config file', async function () {
       const defaultConfig = configMgr.getDefaultConfig();
 
       const config = await configMgr.loadConfig(
@@ -118,8 +118,8 @@ describe('Configuration Manager tests', function() {
     });
   });
 
-  describe('processArgs()', function() {
-    it('should return default config when no CLI args', async function() {
+  describe('processArgs()', function () {
+    it('should return default config when no CLI args', async function () {
       const defaultConfig = configMgr.getDefaultConfig();
 
       const { context } = await configMgr.processArgs([], cliParseOptions);
@@ -129,7 +129,7 @@ describe('Configuration Manager tests', function() {
       expect(context).toMatchObject({ config: defaultConfig });
     });
 
-    it('should return default config if invalid config file (bad JSON)', async function() {
+    it('should return default config if invalid config file (bad JSON)', async function () {
       const defaultConfig = configMgr.getDefaultConfig();
 
       const { context } = await configMgr.processArgs(
@@ -149,7 +149,7 @@ describe('Configuration Manager tests', function() {
       expect(context).toMatchObject({ config: defaultConfig });
     });
 
-    it('should return default config if invalid config file (schema)', async function() {
+    it('should return default config if invalid config file (schema)', async function () {
       const defaultConfig = configMgr.getDefaultConfig();
 
       const { context } = await configMgr.processArgs(
@@ -179,7 +179,7 @@ describe('Configuration Manager tests', function() {
       expect(context).toMatchObject({ config: defaultConfig });
     });
 
-    it('should return correct config if valid config file', async function() {
+    it('should return correct config if valid config file', async function () {
       const { context } = await configMgr.processArgs(
         ['-c', './test/cli-validator/mock-files/config/config1.yaml'],
         cliParseOptions
@@ -194,20 +194,20 @@ describe('Configuration Manager tests', function() {
         files: ['file1.yaml', 'file2.json'],
         ignoreFiles: ['ignored/file1'],
         limits: {
-          warnings: 5
+          warnings: 5,
         },
         logLevels: {
           'ibm-schema-description-exists': 'debug',
-          root: 'info'
+          root: 'info',
         },
         outputFormat: 'text',
         summaryOnly: false,
         ruleset: null,
-        verbose: false
+        verbose: false,
       });
     });
 
-    it('should return correct config if valid config file AND cli options used', async function() {
+    it('should return correct config if valid config file AND cli options used', async function () {
       const { context } = await configMgr.processArgs(
         [
           '-c',
@@ -225,7 +225,7 @@ describe('Configuration Manager tests', function() {
           '--summary-only',
           '-v',
           '--warnings-limit',
-          '-1'
+          '-1',
         ],
         cliParseOptions
       );
@@ -239,18 +239,18 @@ describe('Configuration Manager tests', function() {
         files: ['file3.json', 'file4.yaml'],
         ignoreFiles: ['ignored/file2.json'],
         limits: {
-          warnings: -1
+          warnings: -1,
         },
         logLevels: {
-          root: 'debug'
+          root: 'debug',
         },
         ruleset: 'my-rules.yml',
         summaryOnly: true,
-        verbose: true
+        verbose: true,
       });
     });
 
-    it('should log error and use default if invalid warnings value', async function() {
+    it('should log error and use default if invalid warnings value', async function () {
       const { context } = await configMgr.processArgs(
         ['--warnings-limit', 'foo'],
         cliParseOptions
@@ -267,24 +267,24 @@ describe('Configuration Manager tests', function() {
       expect(context.config.limits.warnings).toBe(-1);
     });
 
-    describe('CLI options', function() {
+    describe('CLI options', function () {
       it.each(['-c', '--config'])(
         `should load correct config with -c/--config option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
             colorizeOutput: true,
             errorsOnly: true,
             files: ['file1.yaml', 'file2.json'],
             limits: {
-              warnings: 5
+              warnings: 5,
             },
             logLevels: {
               root: 'info',
-              'ibm-schema-description-exists': 'debug'
+              'ibm-schema-description-exists': 'debug',
             },
             outputFormat: 'text',
             summaryOnly: false,
-            verbose: false
+            verbose: false,
           };
 
           const { context } = await configMgr.processArgs(
@@ -301,9 +301,9 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-e', '--errors-only'])(
         `should produce correct config with -e/--errors-only option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
-            errorsOnly: true
+            errorsOnly: true,
           };
 
           const { context } = await configMgr.processArgs(
@@ -320,9 +320,9 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-i', '--ignore'])(
         `should produce correct config with -i/--ignore option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
-            ignoreFiles: ['ignoredFile1.yaml', 'ignoredFile2.json']
+            ignoreFiles: ['ignoredFile1.yaml', 'ignoredFile2.json'],
           };
 
           const { context } = await configMgr.processArgs(
@@ -339,9 +339,9 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-j', '--json'])(
         `should produce correct config with -j/--json option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
-            outputFormat: 'json'
+            outputFormat: 'json',
           };
 
           const { context } = await configMgr.processArgs(
@@ -358,11 +358,11 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-lroot=debug', '--log-level=root=debug'])(
         `should produce correct config with -l/--log-level option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
             logLevels: {
-              root: 'debug'
-            }
+              root: 'debug',
+            },
           };
 
           const { context } = await configMgr.processArgs(
@@ -379,9 +379,9 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-n', '--no-colors'])(
         `should produce correct config with -n/--no-colors option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
-            colorizeOutput: false
+            colorizeOutput: false,
           };
 
           const { context } = await configMgr.processArgs(
@@ -398,9 +398,9 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-r', '--ruleset'])(
         `should produce correct config with -r/--ruleset option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
-            ruleset: 'my-custom-rules.yaml'
+            ruleset: 'my-custom-rules.yaml',
           };
 
           const { context } = await configMgr.processArgs(
@@ -417,9 +417,9 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-s', '--summary-only'])(
         `should produce correct config with -s/--summary-only option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
-            summaryOnly: true
+            summaryOnly: true,
           };
 
           const { context } = await configMgr.processArgs(
@@ -436,9 +436,9 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-v', '--verbose'])(
         `should produce correct config with -v/--verbose option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
-            verbose: true
+            verbose: true,
           };
 
           const { context } = await configMgr.processArgs(
@@ -455,11 +455,11 @@ describe('Configuration Manager tests', function() {
 
       it.each(['-w', '--warnings-limit'])(
         `should produce correct config with -v/--verbose option`,
-        async function(option) {
+        async function (option) {
           const expectedConfig = {
             limits: {
-              warnings: 38
-            }
+              warnings: 38,
+            },
           };
 
           const { context } = await configMgr.processArgs(
@@ -474,7 +474,7 @@ describe('Configuration Manager tests', function() {
         }
       );
 
-      it('should throw error for --version option', async function() {
+      it('should throw error for --version option', async function () {
         let caughtException;
         try {
           await configMgr.processArgs(['--version'], cliParseOptions);
@@ -489,7 +489,7 @@ describe('Configuration Manager tests', function() {
         expect(caughtException).toBe(true);
       });
 
-      it('should throw error for --help option', async function() {
+      it('should throw error for --help option', async function () {
         let caughtException;
         try {
           await configMgr.processArgs(['--help'], cliParseOptions);

--- a/packages/validator/test/cli-validator/tests/error-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/error-handling.test.js
@@ -5,7 +5,7 @@
 
 const { getCapturedText, testValidator } = require('../../test-utils');
 
-describe('cli tool - test error handling', function() {
+describe('cli tool - test error handling', function () {
   let consoleSpy;
   const originalWarn = console.warn;
   const originalError = console.error;
@@ -25,7 +25,7 @@ describe('cli tool - test error handling', function() {
     console.info = originalInfo;
   });
 
-  it('should display help text and return an error when no filename is given', async function() {
+  it('should display help text and return an error when no filename is given', async function () {
     let exitCode;
     try {
       exitCode = await testValidator([]);
@@ -45,7 +45,7 @@ describe('cli tool - test error handling', function() {
     expect(capturedText[0]).toMatch(/-h, --help +display help for command/);
   });
 
-  it('should return an error when there is no file extension', async function() {
+  it('should return an error when there is no file extension', async function () {
     let exitCode;
     try {
       exitCode = await testValidator(['json']);
@@ -67,7 +67,7 @@ describe('cli tool - test error handling', function() {
     expect(capturedText[2].trim()).toEqual('[Error] No files to validate.');
   });
 
-  it('should return an error when there is an invalid file extension', async function() {
+  it('should return an error when there is an invalid file extension', async function () {
     let exitCode;
     try {
       exitCode = await testValidator(['badExtension.jsob']);
@@ -89,11 +89,11 @@ describe('cli tool - test error handling', function() {
     expect(capturedText[2].trim()).toEqual('[Error] No files to validate.');
   });
 
-  it('should return an error when a file contains an invalid object', async function() {
+  it('should return an error when a file contains an invalid object', async function () {
     let exitCode;
     try {
       exitCode = await testValidator([
-        './test/cli-validator/mock-files/bad-json.json'
+        './test/cli-validator/mock-files/bad-json.json',
       ]);
     } catch (err) {
       exitCode = err;
@@ -112,11 +112,11 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when a json file has duplicated key mappings', async function() {
+  it('should return an error when a json file has duplicated key mappings', async function () {
     let exitCode;
     try {
       exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/duplicate-keys.json'
+        './test/cli-validator/mock-files/oas3/duplicate-keys.json',
       ]);
     } catch (err) {
       exitCode = err;
@@ -135,11 +135,11 @@ describe('cli tool - test error handling', function() {
     );
   });
 
-  it('should return an error when a JSON document contains a trailing comma', async function() {
+  it('should return an error when a JSON document contains a trailing comma', async function () {
     let exitCode;
     try {
       exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/trailing-comma.json'
+        './test/cli-validator/mock-files/oas3/trailing-comma.json',
       ]);
     } catch (err) {
       exitCode = err;

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -9,7 +9,7 @@ const count = (array, regex) => {
   return array.reduce((a, v) => (v.match(regex) ? a + 1 : a), 0);
 };
 
-describe('Expected output tests', function() {
+describe('Expected output tests', function () {
   let consoleSpy;
   const originalWarn = console.warn;
   const originalError = console.error;
@@ -29,10 +29,10 @@ describe('Expected output tests', function() {
     console.info = originalInfo;
   });
 
-  describe('OpenAPI 3', function() {
-    it('should not produce any errors or warnings from a clean file', async function() {
+  describe('OpenAPI 3', function () {
+    it('should not produce any errors or warnings from a clean file', async function () {
       const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/clean.yml'
+        './test/cli-validator/mock-files/oas3/clean.yml',
       ]);
       expect(exitCode).toEqual(0);
 
@@ -44,9 +44,9 @@ describe('Expected output tests', function() {
       );
     });
 
-    it('should produce errors, then warnings from mock-files/oas3/err-and-warn.yaml', async function() {
+    it('should produce errors, then warnings from mock-files/oas3/err-and-warn.yaml', async function () {
       const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
       ]);
 
       const capturedText = getCapturedText(consoleSpy.mock.calls);
@@ -55,7 +55,7 @@ describe('Expected output tests', function() {
       expect(exitCode).toEqual(1);
 
       const whichProblems = [];
-      capturedText.forEach(function(line) {
+      capturedText.forEach(function (line) {
         if (line.includes('errors')) {
           whichProblems.push('errors');
         }
@@ -68,9 +68,9 @@ describe('Expected output tests', function() {
       expect(whichProblems[1]).toEqual('warnings');
     });
 
-    it('should print the correct line numbers for each error/warning', async function() {
+    it('should print the correct line numbers for each error/warning', async function () {
       const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
       ]);
       expect(exitCode).toEqual(1);
 
@@ -120,9 +120,9 @@ describe('Expected output tests', function() {
       expect(capturedText[160].match(/\S+/g)[2]).toEqual('213');
     });
 
-    it('should catch problems in a multi-file spec from an outside directory', async function() {
+    it('should catch problems in a multi-file spec from an outside directory', async function () {
       const exitCode = await testValidator([
-        './test/cli-validator/mock-files/multi-file-spec/main.yaml'
+        './test/cli-validator/mock-files/multi-file-spec/main.yaml',
       ]);
       expect(exitCode).toEqual(1);
 
@@ -138,11 +138,11 @@ describe('Expected output tests', function() {
       );
     });
 
-    it('should handle an array of file names', async function() {
+    it('should handle an array of file names', async function () {
       const args = [
         './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
         'notAFile.json',
-        './test/cli-validator/mock-files/oas3/clean.yml'
+        './test/cli-validator/mock-files/oas3/clean.yml',
       ];
       const exitCode = await testValidator(args);
       expect(exitCode).toEqual(1);
@@ -169,9 +169,9 @@ describe('Expected output tests', function() {
       ).toEqual(true);
     });
 
-    it('should not produce any errors or warnings from mock-files/oas3/clean-with-tabs.yml', async function() {
+    it('should not produce any errors or warnings from mock-files/oas3/clean-with-tabs.yml', async function () {
       const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/clean-with-tabs.yml'
+        './test/cli-validator/mock-files/oas3/clean-with-tabs.yml',
       ]);
       expect(exitCode).toEqual(0);
 
@@ -186,10 +186,10 @@ describe('Expected output tests', function() {
 
     it.each(['-v', '--verbose'])(
       'should display the associated rule with each error and warning',
-      async function(option) {
+      async function (option) {
         const exitCode = await testValidator([
           option,
-          './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+          './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
         ]);
         expect(exitCode).toEqual(1);
 
@@ -203,10 +203,10 @@ describe('Expected output tests', function() {
 
     it.each(['-j', '--json'])(
       'should include the associated rule with each error and warning in JSON output',
-      async function(option) {
+      async function (option) {
         const exitCode = await testValidator([
           option,
-          './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+          './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
         ]);
         expect(exitCode).toEqual(1);
 
@@ -229,9 +229,9 @@ describe('Expected output tests', function() {
       }
     );
 
-    it('should return exit code of 0 if there are only warnings', async function() {
+    it('should return exit code of 0 if there are only warnings', async function () {
       const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/just-warn.yml'
+        './test/cli-validator/mock-files/oas3/just-warn.yml',
       ]);
       expect(exitCode).toEqual(0);
 
@@ -242,10 +242,10 @@ describe('Expected output tests', function() {
 
     it.each(['-v', '--verbose'])(
       'should include the path to the component (if it exists) when in verbose mode',
-      async function(option) {
+      async function (option) {
         const exitCode = await testValidator([
           option,
-          './test/cli-validator/mock-files/oas3/component-path-example.yaml'
+          './test/cli-validator/mock-files/oas3/component-path-example.yaml',
         ]);
         expect(exitCode).toEqual(0);
 
@@ -256,11 +256,11 @@ describe('Expected output tests', function() {
       }
     );
 
-    it('should include the path to the component (if it exists) when in verbose mode and json mode', async function() {
+    it('should include the path to the component (if it exists) when in verbose mode and json mode', async function () {
       const exitCode = await testValidator([
         '-j',
         '-v',
-        './test/cli-validator/mock-files/oas3/component-path-example.yaml'
+        './test/cli-validator/mock-files/oas3/component-path-example.yaml',
       ]);
       expect(exitCode).toEqual(0);
 

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -7,14 +7,14 @@ const stripAnsiFrom = require('strip-ansi');
 const {
   getCapturedText,
   getCapturedTextWithColor,
-  testValidator
+  testValidator,
 } = require('../../test-utils');
 const {
-  validate
+  validate,
 } = require('../../../src/cli-validator/utils/schema-validator');
 const { readYaml } = require('../../../src/cli-validator/utils/read-yaml');
 
-describe('cli tool - test option handling', function() {
+describe('cli tool - test option handling', function () {
   let consoleSpy;
   const originalWarn = console.warn;
   const originalError = console.error;
@@ -34,14 +34,14 @@ describe('cli tool - test option handling', function() {
     console.info = originalInfo;
   });
 
-  it('should colorize output by default @skip-ci', async function() {
+  it('should colorize output by default @skip-ci', async function () {
     await testValidator([
-      './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+      './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
     ]);
     const capturedText = getCapturedTextWithColor(consoleSpy.mock.calls);
     // originalError('Captured text:\n', capturedText);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       if (line) {
         expect(line).not.toEqual(stripAnsiFrom(line));
       }
@@ -50,41 +50,41 @@ describe('cli tool - test option handling', function() {
 
   it.each(['-n', '--no-colors'])(
     'should not colorize output when -n/--no-colors option is specified',
-    async function(option) {
+    async function (option) {
       await testValidator([
         option,
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
       ]);
       const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-      capturedText.forEach(function(line) {
+      capturedText.forEach(function (line) {
         expect(line).toEqual(stripAnsiFrom(line));
       });
     }
   );
 
-  it('should not print validator source file by default', async function() {
+  it('should not print validator source file by default', async function () {
     await testValidator([
-      './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+      './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
     ]);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-    capturedText.forEach(function(line) {
+    capturedText.forEach(function (line) {
       expect(line.includes('Validator')).toEqual(false);
     });
   });
 
   it.each(['-e', '--errors-only'])(
     'should print only errors when the -e/--errors-only option is specified',
-    async function(option) {
+    async function (option) {
       await testValidator([
         option,
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
       ]);
       const capturedText = getCapturedText(consoleSpy.mock.calls);
       // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
 
-      capturedText.forEach(function(line) {
+      capturedText.forEach(function (line) {
         expect(line.includes('warnings')).toEqual(false);
       });
     }
@@ -92,10 +92,10 @@ describe('cli tool - test option handling', function() {
 
   it.each(['-s', '--summary-only'])(
     'should print only the summary when -s/--summary-only option is specified',
-    async function(option) {
+    async function (option) {
       await testValidator([
         option,
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
       ]);
       const capturedText = getCapturedText(consoleSpy.mock.calls);
       // This can be uncommented to display the output when adjustments to
@@ -108,7 +108,7 @@ describe('cli tool - test option handling', function() {
 
       let summaryReported = false;
 
-      capturedText.forEach(function(line) {
+      capturedText.forEach(function (line) {
         if (line.includes('summary')) {
           summaryReported = true;
         }
@@ -173,10 +173,10 @@ describe('cli tool - test option handling', function() {
 
   it.each(['-j', '--json'])(
     'should print json output when -j/--json option is specified',
-    async function(option) {
+    async function (option) {
       await testValidator([
         option,
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
       ]);
       const capturedText = getCapturedText(consoleSpy.mock.calls);
       // originalError(`Captured text: ${capturedText}`);
@@ -199,11 +199,11 @@ describe('cli tool - test option handling', function() {
     }
   );
 
-  it('should print only errors as json output when -j and -e options are specified together', async function() {
+  it('should print only errors as json output when -j and -e options are specified together', async function () {
     await testValidator([
       '-j',
       '-e',
-      './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+      './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
     ]);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
@@ -216,11 +216,11 @@ describe('cli tool - test option handling', function() {
     });
   });
 
-  it('should not include results in json output when -j and -s options are specified together', async function() {
+  it('should not include results in json output when -j and -s options are specified together', async function () {
     await testValidator([
       '-j',
       '-s',
-      './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
+      './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
     ]);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
 
@@ -235,8 +235,8 @@ describe('cli tool - test option handling', function() {
     expect(outputObject.warning.summary.total).toBeGreaterThan(0);
   });
 
-  describe('test unknown option handling', function() {
-    it('should return an error and help text when there is an unknown option', async function() {
+  describe('test unknown option handling', function () {
+    it('should return an error and help text when there is an unknown option', async function () {
       let caughtException = false;
       let exception;
       try {
@@ -266,15 +266,16 @@ describe('cli tool - test option handling', function() {
     '-lerror',
     '-lroot=error',
     '--log-level=error',
-    '--log-level=root=error'
-  ])('should not print anything when loglevel is error', async function(
-    option
-  ) {
-    await testValidator([
-      option,
-      './test/cli-validator/mock-files/oas3/err-and-warn.yaml'
-    ]);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-    expect(capturedText).toHaveLength(0);
-  });
+    '--log-level=root=error',
+  ])(
+    'should not print anything when loglevel is error',
+    async function (option) {
+      await testValidator([
+        option,
+        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
+      ]);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      expect(capturedText).toHaveLength(0);
+    }
+  );
 });

--- a/packages/validator/test/cli-validator/tests/run-validator.test.js
+++ b/packages/validator/test/cli-validator/tests/run-validator.test.js
@@ -5,7 +5,7 @@
 
 const { getCapturedText, testValidator } = require('../../test-utils');
 
-describe('run-validator tests', function() {
+describe('run-validator tests', function () {
   let consoleSpy;
   const originalWarn = console.warn;
   const originalError = console.error;
@@ -25,11 +25,11 @@ describe('run-validator tests', function() {
     console.info = originalInfo;
   });
 
-  it('should show error/exit code 1 when warnings limit exceeded (config)', async function() {
+  it('should show error/exit code 1 when warnings limit exceeded (config)', async function () {
     const exitCode = await testValidator([
       '--config',
       './test/cli-validator/mock-files/config/five-warnings.json',
-      './test/cli-validator/mock-files/oas3/warn-threshold.yml'
+      './test/cli-validator/mock-files/oas3/warn-threshold.yml',
     ]);
     const capturedText = getCapturedText(consoleSpy.mock.calls);
     // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
@@ -41,10 +41,10 @@ describe('run-validator tests', function() {
   });
   it.each(['-w5', '--warnings-limit=5'])(
     'should show error/exit code 1 when -w/--warnings-limit used',
-    async function(option) {
+    async function (option) {
       const exitCode = await testValidator([
         option,
-        './test/cli-validator/mock-files/oas3/warn-threshold.yml'
+        './test/cli-validator/mock-files/oas3/warn-threshold.yml',
       ]);
       const capturedText = getCapturedText(consoleSpy.mock.calls);
       // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
@@ -56,11 +56,11 @@ describe('run-validator tests', function() {
     }
   );
 
-  it('should show errors/use default config when config file fails validation', async function() {
+  it('should show errors/use default config when config file fails validation', async function () {
     const exitCode = await testValidator([
       '-c',
       './test/cli-validator/mock-files/config/invalid-values.json',
-      './test/cli-validator/mock-files/oas3/clean.yml'
+      './test/cli-validator/mock-files/oas3/clean.yml',
     ]);
 
     // The config file is invalid, so we should end up using the default config instead.
@@ -76,20 +76,20 @@ describe('run-validator tests', function() {
     expect(allOutput).toMatch(/validator will use a default config/);
   });
 
-  it('should get exit code 0 when warnings limit not exceeded', async function() {
+  it('should get exit code 0 when warnings limit not exceeded', async function () {
     const exitCode = await testValidator([
       './test/cli-validator/mock-files/oas3/clean.yml',
       '-c',
-      './test/cli-validator/mock-files/config/zero-warnings.json'
+      './test/cli-validator/mock-files/config/zero-warnings.json',
     ]);
     expect(exitCode).toEqual(0);
   });
 
-  it('should print errors/use default config when config file is invalid JSON', async function() {
+  it('should print errors/use default config when config file is invalid JSON', async function () {
     const exitCode = await testValidator([
       '-c',
       './test/cli-validator/mock-files/config/invalid-json.json',
-      './test/cli-validator/mock-files/oas3/clean.yml'
+      './test/cli-validator/mock-files/oas3/clean.yml',
     ]);
 
     // The config file is invalid, so we should end up using the default config instead.

--- a/packages/validator/test/cli-validator/tests/utils/read-yaml.test.js
+++ b/packages/validator/test/cli-validator/tests/utils/read-yaml.test.js
@@ -5,7 +5,7 @@
 
 const { readYaml } = require('../../../../src/cli-validator/utils/read-yaml');
 
-describe('Read YAML tests', function() {
+describe('Read YAML tests', function () {
   it('should read a yaml file and return an object representing the contents', async () => {
     const filepath = __dirname + '/../../../../src/schemas/results-object.yaml';
     const obj = await readYaml(filepath);

--- a/packages/validator/test/cli-validator/tests/utils/schema-validator.test.js
+++ b/packages/validator/test/cli-validator/tests/utils/schema-validator.test.js
@@ -4,85 +4,85 @@
  */
 
 const {
-  validate
+  validate,
 } = require('../../../../src/cli-validator/utils/schema-validator');
 const {
-  getConfigFileSchema
+  getConfigFileSchema,
 } = require('../../../../src/cli-validator/utils/configuration-manager');
 
-describe('Schema validator tests', function() {
+describe('Schema validator tests', function () {
   let configFileSchema;
   beforeAll(async () => {
     configFileSchema = await getConfigFileSchema();
   });
 
-  it('correct object should validate clean', function() {
+  it('correct object should validate clean', function () {
     const schema = {
       type: 'object',
       properties: {
         foo: {
-          type: 'string'
-        }
-      }
+          type: 'string',
+        },
+      },
     };
 
     const fooObj = {
-      foo: 'bar'
+      foo: 'bar',
     };
 
     const results = validate(fooObj, schema);
     expect(results).toHaveLength(0);
   });
 
-  it('empty config object should validate clean', function() {
+  it('empty config object should validate clean', function () {
     const configObj = {};
 
     const results = validate(configObj, configFileSchema);
     expect(results).toHaveLength(0);
   });
 
-  it('valid config object should validate clean', function() {
+  it('valid config object should validate clean', function () {
     const configObj = {
       logLevels: {
-        root: 'debug'
+        root: 'debug',
       },
       limits: {
-        warnings: 10
+        warnings: 10,
       },
-      ignoreFiles: ['file1']
+      ignoreFiles: ['file1'],
     };
 
     const results = validate(configObj, configFileSchema);
     expect(results).toHaveLength(0);
   });
 
-  it('incorrect object should return an error', function() {
+  it('incorrect object should return an error', function () {
     const schema = {
       type: 'object',
       properties: {
         foo: {
-          type: 'string'
-        }
-      }
+          type: 'string',
+        },
+      },
     };
 
     const fooObj = {
-      foo: 38
+      foo: 38,
     };
 
     const results = validate(fooObj, schema);
     expect(results).toHaveLength(1);
   });
 
-  it('invalid config object should return errors', function() {
+  it('invalid config object should return errors', function () {
     const configObj = {
       xlogLevels: {
-        root: 'debug'
+        root: 'debug',
       },
       limits: {
-        xwarnings: 10
+        xwarnings: 10,
       },
-      ignoreFiles: ['file1']
+      ignoreFiles: ['file1'],
     };
 
     const results = validate(configObj, configFileSchema);

--- a/packages/validator/test/test-utils/get-message-and-path-from-captured-text.js
+++ b/packages/validator/test/test-utils/get-message-and-path-from-captured-text.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-module.exports.getMessageAndPathFromCapturedText = getMessageAndPathFromCapturedText;
+module.exports.getMessageAndPathFromCapturedText =
+  getMessageAndPathFromCapturedText;
 
 function getMessageAndPathFromCapturedText(pattern, capturedText) {
   const messages = [];

--- a/packages/validator/test/test-utils/index.js
+++ b/packages/validator/test/test-utils/index.js
@@ -4,6 +4,8 @@
  */
 
 module.exports.getCapturedText = require('./get-captured-text').getCapturedText;
-module.exports.getCapturedTextWithColor = require('./get-captured-text').getCapturedTextWithColor;
-module.exports.getMessageAndPathFromCapturedText = require('./get-message-and-path-from-captured-text').getMessageAndPathFromCapturedText;
+module.exports.getCapturedTextWithColor =
+  require('./get-captured-text').getCapturedTextWithColor;
+module.exports.getMessageAndPathFromCapturedText =
+  require('./get-message-and-path-from-captured-text').getMessageAndPathFromCapturedText;
 module.exports.testValidator = require('./test-validator');


### PR DESCRIPTION
Even though it's a perfectly compatible change, I thought the new version would be a good opportunity to update our linting rules which is something I've wanted to do for a while.

This commit bumps our `prettier` version to 2.x, which includes some beneficial defaults; primarily, enforcing trailing commas. I realize trailing commas may not be viewed as "beneficial" by all :) but I think they are valuable and the AirBnb JS style guide (which we try to use as our source of truth, not that we're following it perfectly) requires them. Happy to debate the change but thought I'd propose it because the lack of trailing commas has bugged me for a while haha.