### PR TITLE
build: require node v16 as minimum version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12988,7 +12988,7 @@
         "jest": "^27.4.5"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "packages/ruleset/node_modules/@ibm-cloud/openapi-ruleset-utilities": {
@@ -13008,7 +13008,7 @@
         "jest": "^27.4.5"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "packages/validator": {
@@ -13046,7 +13046,7 @@
         "strip-ansi": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "packages/validator/node_modules/semver": {

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -31,7 +31,7 @@
     "jest": "^27.4.5"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "jest": {
     "collectCoverage": true,

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -19,7 +19,7 @@
     "jest": "^27.4.5"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "jest": {
     "collectCoverage": true,

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -50,7 +50,7 @@
     "lint-openapi": "src/cli-validator/index.js"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "pkg": {
     "scripts": "src/**/*.js"


### PR DESCRIPTION
Node v14 will be sunset [very soon](https://endoflife.date/nodejs). We should take the v1 opportunity to bump our minimum version to v16.

BREAKING CHANGE: Node v16 is now the minimum supported version of Node for running this tool.