### PR TITLE
chore: final edits and migration info for 1.0

### DIFF
--- a/Migration-Guide.md
+++ b/Migration-Guide.md
@@ -3,7 +3,7 @@ This migration guide is intended to help users migrate from the version 0.x pre-
 to the new version 1.0 official release.
 
 ## Minimum Node version
-The minimum supported version of Node.js remains at version 14.x.
+The minimum supported version of Node.js is now version 16.x (formerly 14.x).
 
 ## Supported OpenAPI versions
 The old v0.x pre-release validator supported both Swagger 2.x and OpenAPI 3.x documents.

--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -159,7 +159,7 @@ async function runValidator(cliArgs, parseOptions = {}) {
 
     if (context.config.outputFormat != 'json') {
       console.log('');
-      console.log(chalk.underline(`Validation Results for ${validFile}:`));
+      console.log(chalk.underline(`Validation Results for ${validFile}:\n`));
     }
     try {
       originalFile = await readFile(validFile, 'utf8');
@@ -223,7 +223,9 @@ async function runValidator(cliArgs, parseOptions = {}) {
       if (results.hasResults) {
         print(context, results);
       } else {
-        console.log(`${validFile} passed the validator`);
+        console.log(
+          context.chalk.green(`\n${validFile} passed the validator\n`)
+        );
       }
     }
   }


### PR DESCRIPTION
Add a couple of strategic newlines for better presentation in the CLI and add information to the Migration Guide indicating the move up to Node engine v16.

I found these newlines to make the output more clear while preparing to give a demo on the tool during our playback.