### PR TITLE
fix: use node v18 for travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: jammy
 language: node_js
 
 node_js:
-- 14
 - 16
 - 18
 
@@ -22,5 +21,5 @@ deploy:
   skip_cleanup: true
   script: npx -p @qiwi/semrel-toolkit multi-semrel --deps.release inherit
   on:
-    node: 14
+    node: 18
     branch: main

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -85,6 +85,7 @@ describe('Expected output tests', function () {
       expect(capturedText[errorStart + 5].match(/\S+/g)[2]).toEqual('52');
       expect(capturedText[errorStart + 10].match(/\S+/g)[2]).toEqual('96');
       expect(capturedText[errorStart + 15].match(/\S+/g)[2]).toEqual('103');
+
       // warnings
       const warningStart = 20;
       expect(capturedText[warningStart + 5].match(/\S+/g)[2]).toEqual('22');


### PR DESCRIPTION
We no longer support v14 for this tool.