### PR TITLE
docs: clean up individual changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Current CHANGELOG Files
+
+**Since v0.51.3, the OpenAPI Ruleset has been shipped as a separate package from the OpenAPI Validator tool. Accordingly, each package has their own individual CHANGELOG file, which are linked here:**
+
+* [OpenAPI Validator](https://github.com/IBM/openapi-validator/blob/main/packages/validator/CHANGELOG.md)
+* [OpenAPI Ruleset](https://github.com/IBM/openapi-validator/blob/main/packages/ruleset/CHANGELOG.md)
+* [OpenAPI Ruleset Utilities](https://github.com/IBM/openapi-validator/blob/main/utilities/validator/CHANGELOG.md)
+
+---
+
 ## [0.51.3](https://github.com/IBM/openapi-validator/compare/v0.51.2...v0.51.3) (2021-10-11)
 
 

--- a/packages/ruleset/CHANGELOG.md
+++ b/packages/ruleset/CHANGELOG.md
@@ -14,29 +14,13 @@
 ### Features
 
 * **logger:** add logger facility to validator core ([#537](https://github.com/IBM/openapi-validator/issues/537)) ([f5aa2fc](https://github.com/IBM/openapi-validator/commit/f5aa2fc42ba886b86b4d861949c035ebe9d48d1a))
-* unify all configuration options ([#559](https://github.com/IBM/openapi-validator/issues/559)) ([ef93371](https://github.com/IBM/openapi-validator/commit/ef9337175feaac95addcb0a8ac0c9a074a1419a9))
-* update command-line options ([53f4fbb](https://github.com/IBM/openapi-validator/commit/53f4fbb07bc97468da30b8af59c90eda83663d87))
-* use consistent format/color for logs ([#572](https://github.com/IBM/openapi-validator/issues/572)) ([1ae158e](https://github.com/IBM/openapi-validator/commit/1ae158edb7d476b2f27ee73e1c25937ea10d2704))
 
 
 ### BREAKING CHANGES
 
 * Node v16 is now the minimum supported version of Node for running this tool.
-
-Signed-off-by: Dustin Popp <dpopp07@gmail.com>
-* The 'verbose' option is no longer supported. Use the logger to see additional output.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
 * Support for the .thresholdrc and .validateignore files is removed. Use CLI options or the newly-supported configuration file.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
 * All rules have been renamed. See the Migration Guide for specific information.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
-* The 'summary-only', 'debug', 'print-validators' options have been removed.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
-
 
 
 

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 * Node v16 is now the minimum supported version of Node for running this tool.
 
-Signed-off-by: Dustin Popp <dpopp07@gmail.com>
-
 ## @ibm-cloud/openapi-ruleset-utilities [0.0.2-rc.1](https://github.com/IBM/openapi-validator/compare/@ibm-cloud/openapi-ruleset-utilities@0.0.1...@ibm-cloud/openapi-ruleset-utilities@0.0.2-rc.1) (2023-03-03)
 
 

--- a/packages/validator/CHANGELOG.md
+++ b/packages/validator/CHANGELOG.md
@@ -43,29 +43,11 @@
 ### BREAKING CHANGES
 
 * Node v16 is now the minimum supported version of Node for running this tool.
-
-Signed-off-by: Dustin Popp <dpopp07@gmail.com>
 * The 'verbose' option is no longer supported. Use the logger to see additional output.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
 * Support for the .thresholdrc and .validateignore files is removed. Use CLI options or the newly-supported configuration file.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
 * The structure of the JSON output is now different. See the documented JSON Schema for the new structure.
-
-Signed-off-by: Dustin Popp <dpopp07@gmail.com>
-* All rules have been renamed. See the Migration Guide for specific information.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
 * The Node interface of this tool is no longer supported, it is now a CLI tool only.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
 * The 'summary-only', 'debug', 'print-validators' options have been removed.
-
-Signed-off-by: Phil Adams <phil_adams@us.ibm.com>
-
-
-
 
 
 ### Dependencies


### PR DESCRIPTION
TIL that the root changelog hasn't been updated since we switched to a monorepo, so I updated it to point to the individual changelogs. I also cleaned those up, as there were a few extraneous lines from the 1.0 release.