### PR TITLE
fix: bump minimum node version to 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12631,9 +12631,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.15",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.15.tgz",
-      "integrity": "sha512-XqNqknHGw2avJo13gbIwLNZUumvrSHc9mLqoadFZTpo3KaNEJoe1I0lqTFhRXmXD7WkLyG01aaraXdXT0pa4ag==",
+      "version": "3.9.16",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
+      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
@@ -22558,9 +22558,9 @@
       "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "vm2": {
-      "version": "3.9.15",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.15.tgz",
-      "integrity": "sha512-XqNqknHGw2avJo13gbIwLNZUumvrSHc9mLqoadFZTpo3KaNEJoe1I0lqTFhRXmXD7WkLyG01aaraXdXT0pa4ag==",
+      "version": "3.9.16",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
+      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"

--- a/packages/validator/src/cli-validator/index.js
+++ b/packages/validator/src/cli-validator/index.js
@@ -6,8 +6,8 @@
 
 // this module enforces that the user is running a supported version
 // of Node by exiting the process if the version is less than
-// the passed in argument (currently 14.0.0)
-require('./utils/check-version')('14.0.0');
+// the passed in argument (currently 16.0.0)
+require('./utils/check-version')('16.0.0');
 
 const runValidator = require('./run-validator');
 runValidator(process.argv)


### PR DESCRIPTION
## PR summary
This commit modifies the validator's startup script (packages/validator/src/cli-validator/index.js) so that it requires node 16 as the minimum version of the runtime. We had previously updated the package.json to cover the install-related steps.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
