### PR TITLE
fix: bump spectral dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1639,9 +1639,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.17.0.tgz",
-      "integrity": "sha512-7D9og+iX2bCJMGPY7cvt2YdevFGDeSI7S2jPo7HWeGGitkef1FDSQ9AEapdwmCYvOJ7ztUlQdCCLTOb6Aani8w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.0.tgz",
+      "integrity": "sha512-0aj+IELHvhjoPWoOFj41EJilPbaexUuWFg7GCsiJ3BXrniRp3GnPl+TIZkC1ZuuAr/oi77RviDhW9Gm7ndKB9Q==",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "~3.20.1",
@@ -1816,9 +1816,9 @@
       }
     },
     "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.15.0.tgz",
-      "integrity": "sha512-xgltt54aQPSKKAxPZ2oCA25X/xmDPVCV1e4qxqH5bw/t7LvDWVusBFUrtcl/5HAJIIgkpxOKXKEc2XRC0ea8HQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.16.0.tgz",
+      "integrity": "sha512-vHnQ50zZARymT+LkLD1l0sXoe76iUf0FWFyTp3xSRFvMIvoqFlUHONjKqFUUQzLaidSWWVah3repmAibHTdaSA==",
       "dependencies": {
         "@asyncapi/specs": "^4.1.0",
         "@stoplight/better-ajv-errors": "1.0.3",
@@ -12970,13 +12970,13 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.0.0",
-        "@stoplight/spectral-formats": "^1.4.0",
+        "@stoplight/spectral-formats": "^1.5.0",
         "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-rulesets": "^1.14.1",
+        "@stoplight/spectral-rulesets": "^1.16.0",
         "chalk": "^4.1.1",
         "lodash": "^4.17.21",
         "loglevel": "^1.8.1",
@@ -12985,7 +12985,7 @@
         "validator": "^13.7.0"
       },
       "devDependencies": {
-        "@stoplight/spectral-core": "^1.12.4",
+        "@stoplight/spectral-core": "^1.18.0",
         "jest": "^27.4.5"
       },
       "engines": {
@@ -13012,7 +13012,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@stoplight/spectral-core": "^1.16.0",
+        "@stoplight/spectral-core": "^1.18.0",
         "jest": "^27.4.5"
       },
       "engines": {
@@ -13021,12 +13021,12 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.0.0",
+        "@ibm-cloud/openapi-ruleset": "1.0.1",
         "@stoplight/spectral-cli": "^6.6.0",
-        "@stoplight/spectral-core": "^1.16.0",
+        "@stoplight/spectral-core": "^1.18.0",
         "@stoplight/spectral-parsers": "^1.0.2",
         "ajv": "^8.12.0",
         "chalk": "^4.1.1",
@@ -13522,11 +13522,11 @@
       "version": "file:packages/ruleset",
       "requires": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.0.0",
-        "@stoplight/spectral-core": "^1.12.4",
-        "@stoplight/spectral-formats": "^1.4.0",
+        "@stoplight/spectral-core": "^1.18.0",
+        "@stoplight/spectral-formats": "^1.5.0",
         "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-rulesets": "^1.14.1",
-        "chalk": "4.1.1",
+        "@stoplight/spectral-rulesets": "^1.16.0",
+        "chalk": "^4.1.1",
         "jest": "^27.4.5",
         "lodash": "^4.17.21",
         "loglevel": "^1.8.1",
@@ -13549,7 +13549,7 @@
     "@ibm-cloud/openapi-ruleset-utilities": {
       "version": "file:packages/utilities",
       "requires": {
-        "@stoplight/spectral-core": "^1.16.0",
+        "@stoplight/spectral-core": "^1.18.0",
         "jest": "^27.4.5"
       }
     },
@@ -14342,9 +14342,9 @@
       }
     },
     "@stoplight/spectral-core": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.17.0.tgz",
-      "integrity": "sha512-7D9og+iX2bCJMGPY7cvt2YdevFGDeSI7S2jPo7HWeGGitkef1FDSQ9AEapdwmCYvOJ7ztUlQdCCLTOb6Aani8w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.0.tgz",
+      "integrity": "sha512-0aj+IELHvhjoPWoOFj41EJilPbaexUuWFg7GCsiJ3BXrniRp3GnPl+TIZkC1ZuuAr/oi77RviDhW9Gm7ndKB9Q==",
       "requires": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "~3.20.1",
@@ -14494,9 +14494,9 @@
       }
     },
     "@stoplight/spectral-rulesets": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.15.0.tgz",
-      "integrity": "sha512-xgltt54aQPSKKAxPZ2oCA25X/xmDPVCV1e4qxqH5bw/t7LvDWVusBFUrtcl/5HAJIIgkpxOKXKEc2XRC0ea8HQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.16.0.tgz",
+      "integrity": "sha512-vHnQ50zZARymT+LkLD1l0sXoe76iUf0FWFyTp3xSRFvMIvoqFlUHONjKqFUUQzLaidSWWVah3repmAibHTdaSA==",
       "requires": {
         "@asyncapi/specs": "^4.1.0",
         "@stoplight/better-ajv-errors": "1.0.3",
@@ -16936,9 +16936,9 @@
     "ibm-openapi-validator": {
       "version": "file:packages/validator",
       "requires": {
-        "@ibm-cloud/openapi-ruleset": "1.0.0",
+        "@ibm-cloud/openapi-ruleset": "1.0.1",
         "@stoplight/spectral-cli": "^6.6.0",
-        "@stoplight/spectral-core": "^1.16.0",
+        "@stoplight/spectral-core": "^1.18.0",
         "@stoplight/spectral-parsers": "^1.0.2",
         "ajv": "^8.12.0",
         "chalk": "^4.1.1",

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@ibm-cloud/openapi-ruleset-utilities": "1.0.0",
-    "@stoplight/spectral-formats": "^1.4.0",
+    "@stoplight/spectral-formats": "^1.5.0",
     "@stoplight/spectral-functions": "^1.7.2",
-    "@stoplight/spectral-rulesets": "^1.14.1",
+    "@stoplight/spectral-rulesets": "^1.16.0",
     "chalk": "^4.1.1",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",
@@ -28,7 +28,7 @@
     "validator": "^13.7.0"
   },
   "devDependencies": {
-    "@stoplight/spectral-core": "^1.12.4",
+    "@stoplight/spectral-core": "^1.18.0",
     "jest": "^27.4.5"
   },
   "engines": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -15,7 +15,7 @@
     "pkg": "echo no executables to build in this package"
   },
   "devDependencies": {
-    "@stoplight/spectral-core": "^1.16.0",
+    "@stoplight/spectral-core": "^1.18.0",
     "jest": "^27.4.5"
   },
   "engines": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@ibm-cloud/openapi-ruleset": "1.0.1",
     "@stoplight/spectral-cli": "^6.6.0",
-    "@stoplight/spectral-core": "^1.16.0",
+    "@stoplight/spectral-core": "^1.18.0",
     "@stoplight/spectral-parsers": "^1.0.2",
     "ajv": "^8.12.0",
     "chalk": "^4.1.1",


### PR DESCRIPTION
## PR summary
This PR bumps our spectral-related dependencies to their current most recent versions in order to pull in the fix for https://github.ibm.com/arf/planning-sdk-squad/issues/3531

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
