### PR TITLE
fix(ibm-define-required-properties): avoid false positives

### DIFF
--- a/packages/ruleset/src/functions/required-property.js
+++ b/packages/ruleset/src/functions/required-property.js
@@ -26,31 +26,106 @@ module.exports = function (schema, _opts, context) {
   );
 };
 
+/**
+ * Checks "schema" to make sure that any property names contained in "required" fields
+ * are in fact properties that are defined by the schema.
+ * The algorithm used to perform these checks will vary a bit depending on the type
+ * of composition being used (if any):
+ * - none (no allOf/anyOf/oneOf):
+ *   - each property name in the "required" field should be a property that is
+ *     explicitly defined by "schema".
+ * - allOf:
+ *   - avoid checking the individual allOf element schemas as these can be partial schemas
+ *   - any property names contained in the "required" fields defined within
+ *     the allOf elements or on the main schema should be defined on "schema" or
+ *     within one or more of the allOf elements
+ *  - anyOf/oneOf:
+ *   - each anyOf/oneOf element schema should be checked on its own in isolation,
+ *     which happens automatically
+ *   - each schema with a oneOf/anyOf will have its main required list checked against
+ *     the conjuction of its own properties and the element schemas, recursively
+ *
+ * @param {*} schema the schema to check
+ * @param {*} path the jsonpath location of "schema"
+ * @returns zero or more errors
+ */
 function checkRequiredProperties(schema, path) {
+  logger.debug(
+    `${ruleId}: checking for required properties in schema at location: ${path.join(
+      '.'
+    )}`
+  );
+
+  // If "schema" is an element of an allOf list, we'll bypass checking
+  // that schema in isolation, since each allOf element schema can be a partial schema.
+  // For a schema containing an allOf, we'll do all the checking for that schema
+  // when we're called for the schema containing the allOf.
+  if (path[path.length - 2] == 'allOf') {
+    logger.debug(`${ruleId}: bypassing check for allOf list element schema.`);
+    return [];
+  }
+
   const errors = [];
-  if (Array.isArray(schema.required)) {
+
+  // If "schema" contains an allOf list, then check the "required" field
+  // in each of the allOf elements.
+  if (Array.isArray(schema.allOf)) {
     logger.debug(
-      `${ruleId}: checking for required properties in schema at location: ${path.join(
-        '.'
-      )}`
+      `${ruleId}: schema contains allOf; checking allOf list elements.`
     );
-    schema.required.forEach(function (requiredPropName) {
-      if (!schemaHasProperty(schema, requiredPropName)) {
-        let message;
-        if (schema.allOf) {
-          message = `Required property must be defined in at least one of the allOf schemas: ${requiredPropName}`;
-        } else if (schema.anyOf || schema.oneOf) {
-          message = `Required property must be defined in all of the anyOf/oneOf schemas: ${requiredPropName}`;
-        } else {
-          message = `Required property must be defined in the schema: ${requiredPropName}`;
-        }
-        logger.debug(`${ruleId}: Uh oh: ${message}`);
+
+    // Check the "required" field in each of the allOf elements.
+    for (let i = 0; i < schema.allOf.length; i++) {
+      errors.push(
+        ...checkRequired(
+          schema,
+          [...path, 'allOf', i.toString()],
+          schema.allOf[i]
+        )
+      );
+    }
+
+    // Finally, check the "required" field in the main schema.
+    errors.push(...checkRequired(schema, path));
+  } else {
+    // For a non-allOf schema, just check its properties vs its required field.
+    // This handles both non-composed schemas and oneOf/anyOf schemas.
+    errors.push(...checkRequired(schema, path));
+  }
+
+  return errors;
+}
+
+/**
+ * Checks schema's "required" list for property names that are not
+ * contained in "propNames".
+ * @param {*} schema the schema whose "required" field is to be checked
+ * @param {*} propNames the names of properties defined by "schema"
+ * @param {*} path the jsonpath location of "schema"
+ * @returns
+ */
+function checkRequired(schema, path, subschema) {
+  // In the case of an allOf, we want to check the individual subschemas
+  // required list against the whole schema
+  const required = subschema ? subschema.required : schema.required;
+  if (Array.isArray(required)) {
+    const errors = [];
+    const localPath = [...path, 'required'];
+    logger.debug(`${ruleId}: checking ${localPath.join('.')}`);
+
+    required.forEach(name => {
+      logger.debug(`${ruleId}: looking for property ${name}`);
+      if (!schemaHasProperty(schema, name)) {
         errors.push({
-          message,
-          path,
+          message: `Required property must be defined in the schema: ${name}`,
+          path: localPath,
         });
+        logger.debug(`${ruleId}: Missing required property: ${name}`);
       }
     });
+
+    return errors;
   }
-  return errors;
+
+  return [];
 }

--- a/packages/ruleset/test/required-property-missing.test.js
+++ b/packages/ruleset/test/required-property-missing.test.js
@@ -164,7 +164,45 @@ describe(`Spectral rule: ${ruleId}`, () => {
     expect(results).toHaveLength(0);
   });
 
-  it('should error if allOf schema is missing a required property', async () => {
+  it('should not error if "required" in separate allOf element', async () => {
+    const testDocument = makeCopy(rootDocument);
+
+    testDocument.components.schemas['DrinkCollection'] = {
+      type: 'object',
+      description: 'A single page of results containing Drink instances.',
+      allOf: [
+        {
+          $ref: '#/components/schemas/OffsetPaginationBase',
+        },
+        {
+          type: 'object',
+          required: ['drinks'],
+          properties: {
+            drinks: {
+              description:
+                'The set of Drink instances in this page of results.',
+              type: 'array',
+              minItems: 0,
+              maxItems: 50,
+              items: {
+                $ref: '#/components/schemas/Drink',
+              },
+            },
+          },
+        },
+        {
+          // The "first" property is defined in OffsetPaginationBase.
+          required: ['first'],
+        },
+      ],
+    };
+
+    const results = await testRule(ruleId, rule, testDocument);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should error if allOf schema is missing a required property ("required" in main schema)', async () => {
     const testDocument = makeCopy(rootDocument);
     testDocument.paths['v1/books'] = {
       post: {
@@ -178,7 +216,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   type: 'object',
                   required: ['foo'],
                   allOf: [
-                    // an allOf needs at least one subschema with the required property
                     {
                       type: 'object',
                       properties: {
@@ -211,18 +248,69 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const validation = results[0];
     expect(validation.code).toBe(ruleId);
     expect(validation.message).toBe(
-      'Required property must be defined in at least one of the allOf schemas: foo'
+      'Required property must be defined in the schema: foo'
     );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      'v1/books',
-      'post',
-      'parameters',
-      '0',
-      'content',
-      'application/json',
-      'schema',
-    ]);
+    expect(validation.path.join('.')).toBe(
+      'paths.v1/books.post.parameters.0.content.application/json.schema.required'
+    );
+    expect(validation.severity).toBe(severityCodes.error);
+  });
+
+  it('should error if allOf schema is missing a required property ("required" in allOf element)', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['v1/books'] = {
+      post: {
+        parameters: [
+          {
+            name: 'metadata',
+            in: 'header',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  allOf: [
+                    {
+                      type: 'object',
+                      required: ['baz'],
+                      properties: {
+                        baz: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                    {
+                      type: 'object',
+                      required: ['bar'],
+                      properties: {
+                        bar: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                    {
+                      required: ['foo'],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const results = await testRule(ruleId, rule, testDocument);
+
+    expect(results).toHaveLength(1);
+
+    const validation = results[0];
+    expect(validation.code).toBe(ruleId);
+    expect(validation.message).toBe(
+      'Required property must be defined in the schema: foo'
+    );
+    expect(validation.path.join('.')).toBe(
+      'paths.v1/books.post.parameters.0.content.application/json.schema.allOf.2.required'
+    );
     expect(validation.severity).toBe(severityCodes.error);
   });
 
@@ -237,7 +325,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
                 type: 'object',
                 required: ['foo'],
                 anyOf: [
-                  // an anyOf needs all subschemas to define the required property
                   {
                     type: 'object',
                     properties: {
@@ -272,17 +359,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const validation = results[0];
     expect(validation.code).toBe(ruleId);
     expect(validation.message).toBe(
-      'Required property must be defined in all of the anyOf/oneOf schemas: foo'
+      'Required property must be defined in the schema: foo'
     );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      'v1/books',
-      'post',
-      'requestBody',
-      'content',
-      'application/json',
-      'schema',
-    ]);
+    expect(validation.path.join('.')).toBe(
+      'paths.v1/books.post.requestBody.content.application/json.schema.required'
+    );
     expect(validation.severity).toBe(severityCodes.error);
   });
 
@@ -298,7 +379,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   type: 'object',
                   required: ['foo'],
                   oneOf: [
-                    // a oneOf needs all subschemas to define the required property
                     {
                       type: 'object',
                       properties: {
@@ -334,18 +414,190 @@ describe(`Spectral rule: ${ruleId}`, () => {
     const validation = results[0];
     expect(validation.code).toBe(ruleId);
     expect(validation.message).toBe(
-      'Required property must be defined in all of the anyOf/oneOf schemas: foo'
+      'Required property must be defined in the schema: foo'
     );
-    expect(validation.path).toStrictEqual([
-      'paths',
-      'v1/books',
-      'post',
-      'responses',
-      '201',
-      'content',
-      'application/json',
-      'schema',
-    ]);
+    expect(validation.path.join('.')).toBe(
+      'paths.v1/books.post.responses.201.content.application/json.schema.required'
+    );
+    expect(validation.severity).toBe(severityCodes.error);
+  });
+
+  it('should error if nested oneOf schema is missing a required property', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['v1/books'] = {
+      post: {
+        responses: {
+          201: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['foo'],
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        foo: {
+                          type: 'string',
+                        },
+                        bar: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                    {
+                      type: 'object',
+                      oneOf: [
+                        {
+                          type: 'object',
+                          properties: {
+                            foo: {
+                              type: 'string',
+                            },
+                            baz: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                        {
+                          type: 'object',
+                          properties: {
+                            bat: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const results = await testRule(ruleId, rule, testDocument);
+
+    expect(results).toHaveLength(1);
+
+    const validation = results[0];
+    expect(validation.code).toBe(ruleId);
+    expect(validation.message).toBe(
+      'Required property must be defined in the schema: foo'
+    );
+    expect(validation.path.join('.')).toBe(
+      'paths.v1/books.post.responses.201.content.application/json.schema.required'
+    );
+    expect(validation.severity).toBe(severityCodes.error);
+  });
+
+  it('should error if anyOf list element schema is missing a required property', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['v1/books'] = {
+      post: {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                anyOf: [
+                  {
+                    type: 'object',
+                    properties: {
+                      foo: {
+                        type: 'string',
+                      },
+                      bar: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                  {
+                    type: 'object',
+                    properties: {
+                      baz: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['foo'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const results = await testRule(ruleId, rule, testDocument);
+
+    expect(results).toHaveLength(1);
+
+    const validation = results[0];
+    expect(validation.code).toBe(ruleId);
+    expect(validation.message).toBe(
+      'Required property must be defined in the schema: foo'
+    );
+    expect(validation.path.join('.')).toBe(
+      'paths.v1/books.post.requestBody.content.application/json.schema.anyOf.1.required'
+    );
+    expect(validation.severity).toBe(severityCodes.error);
+  });
+
+  it('should error if oneOf list element schema is missing a required property', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['v1/books'] = {
+      post: {
+        responses: {
+          201: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        foo: {
+                          type: 'string',
+                        },
+                        bar: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        baz: {
+                          type: 'string',
+                        },
+                      },
+                      required: ['foo'],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const results = await testRule(ruleId, rule, testDocument);
+
+    expect(results).toHaveLength(1);
+
+    const validation = results[0];
+    expect(validation.code).toBe(ruleId);
+    expect(validation.message).toBe(
+      'Required property must be defined in the schema: foo'
+    );
+    expect(validation.path.join('.')).toBe(
+      'paths.v1/books.post.responses.201.content.application/json.schema.oneOf.1.required'
+    );
     expect(validation.severity).toBe(severityCodes.error);
   });
 
@@ -407,36 +659,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(r.severity).toBe(severityCodes.error);
     });
 
-    expect(results[0].path).toStrictEqual([
-      'paths',
-      'v1/books',
-      'post',
-      'parameters',
-      '0',
-      'content',
-      'application/json',
-      'schema',
-    ]);
-
-    expect(results[1].path).toStrictEqual([
-      'paths',
-      'v1/books',
-      'post',
-      'requestBody',
-      'content',
-      'application/json',
-      'schema',
-    ]);
-
-    expect(results[2].path).toStrictEqual([
-      'paths',
-      'v1/books',
-      'post',
-      'responses',
-      '201',
-      'content',
-      'application/json',
-      'schema',
-    ]);
+    expect(results[0].path.join('.')).toBe(
+      'paths.v1/books.post.parameters.0.content.application/json.schema.required'
+    );
+    expect(results[1].path.join('.')).toBe(
+      'paths.v1/books.post.requestBody.content.application/json.schema.required'
+    );
+    expect(results[2].path.join('.')).toBe(
+      'paths.v1/books.post.responses.201.content.application/json.schema.required'
+    );
   });
 });


### PR DESCRIPTION
## PR summary
Fixes: arf/planning-sdk-squad#3592

This commit fixes the ibm-define-required-properties rule to avoid false positives.  Specifically the logic related to composed models was updated to (hopefully) perform a more accurate set of checks on the schemas in the API definition.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
