### PR TITLE
fix(collections): use correct http method names in responseSchemas collection

### DIFF
--- a/packages/utilities/src/collections/index.js
+++ b/packages/utilities/src/collections/index.js
@@ -6,88 +6,89 @@
 // A group of predefined "collections" of OpenAPI locations to validate,
 // to be re-used by multiple rules.
 
+// A collection of all locations where an operation might exist.
+const operations = [`$.paths[*][get,put,post,delete,options,head,patch,trace]`];
+
 // A collection of locations of top-level response schemas
-const responseSchemas = ['$.paths[*][*][responses][*].content[*].schema'];
+const responseSchemas = [`${operations[0]}[responses][*].content[*].schema`];
 
 // A collection of locations where a JSON Schema object can be *used*.
 // Note that this does not include "components.schemas" to avoid duplication.
 // this collection should be used in a rule that has "resolved" set to "true".
 // we separately validate that all schemas in "components" need to be used.
 const schemas = [
-  '$.paths[*][parameters][*].schema',
-  '$.paths[*][parameters][*].content[*].schema',
-  '$.paths[*][*][parameters][*].schema',
-  '$.paths[*][*][parameters,responses][*].content[*].schema',
-  '$.paths[*][*].responses[*].headers[*].schema',
-  '$.paths[*][*][requestBody].content[*].schema',
+  `$.paths[*][parameters][*].schema`,
+  `$.paths[*][parameters][*].content[*].schema`,
+  `${operations[0]}[parameters][*].schema`,
+  `${operations[0]}[parameters,responses][*].content[*].schema`,
+  `${operations[0]}.responses[*].headers[*].schema`,
+  `${operations[0]}[requestBody].content[*].schema`,
 ];
 
 // A collection of locations where a parameter object might be defined.
 // This does not include components.parameters because this collection
 // should be used with resolved=true and we want to avoid duplication.
 const parameters = [
-  '$.paths[*].parameters[*]',
-  '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]',
+  `$.paths[*].parameters[*]`,
+  `${operations[0]}.parameters[*]`,
 ];
 
-const paths = ['$.paths[*]'];
+const paths = [`$.paths[*]`];
 
-const operations = ['$.paths[*][get,put,post,delete,options,head,patch,trace]'];
-
-const patchOperations = ['$.paths[*][patch]'];
+const patchOperations = [`$.paths[*][patch]`];
 
 // A collection of locations where a response schema could be defined
 // within an unresolved API definition.
 const unresolvedResponseSchemas = [
-  '$.paths[*][*].responses[*].content[*].schema',
-  '$.components.responses[*].content[*].schema',
+  `${operations[0]}.responses[*].content[*].schema`,
+  `$.components.responses[*].content[*].schema`,
 ];
 
 // A collection of locations where a requestBody schema could be defined
 // within an unresolved API definition.
 const unresolvedRequestBodySchemas = [
-  '$.paths[*][*].requestBody.content[*].schema',
-  '$.components.requestBodies[*].content[*].schema',
+  `${operations[0]}.requestBody.content[*].schema`,
+  `$.components.requestBodies[*].content[*].schema`,
 ];
 
 // A collection of locations where a schema object could be defined
 // within an unresolved API definition.
 const unresolvedSchemas = [
   // Named schemas.
-  '$.components.schemas[*]',
+  `$.components.schemas[*]`,
 
   // Request/response schemas.
   ...unresolvedRequestBodySchemas,
   ...unresolvedResponseSchemas,
 
   // Parameter schemas.
-  '$.paths[*].parameters[*].schema',
-  '$.paths[*].parameters[*].content[*].schema',
-  '$.paths[*][*].parameters[*].schema',
-  '$.paths[*][*].parameters[*].content[*].schema',
-  '$.components.parameters[*].schema',
-  '$.components.parameters[*].content[*].schema',
+  `$.paths[*].parameters[*].schema`,
+  `$.paths[*].parameters[*].content[*].schema`,
+  `${operations[0]}.parameters[*].schema`,
+  `${operations[0]}.parameters[*].content[*].schema`,
+  `$.components.parameters[*].schema`,
+  `$.components.parameters[*].content[*].schema`,
 
   // Header schemas.
-  '$.paths[*][*].responses[*].headers[*].schema',
-  '$.paths[*][*].responses[*].headers[*].content[*].schema',
-  '$.components.headers[*].schema',
-  '$.components.headers[*].content[*].schema',
-  '$.components.responses[*].headers[*].schema',
-  '$.components.responses[*].headers[*].content[*].schema',
+  `${operations[0]}.responses[*].headers[*].schema`,
+  `${operations[0]}.responses[*].headers[*].content[*].schema`,
+  `$.components.headers[*].schema`,
+  `$.components.headers[*].content[*].schema`,
+  `$.components.responses[*].headers[*].schema`,
+  `$.components.responses[*].headers[*].content[*].schema`,
 ];
 
-const securitySchemes = ['$.components.securitySchemes[*]'];
+const securitySchemes = [`$.components.securitySchemes[*]`];
 
 module.exports = {
-  responseSchemas,
   operations,
-  patchOperations,
   parameters,
+  patchOperations,
   paths,
+  responseSchemas,
+  schemas,
+  securitySchemes,
   unresolvedRequestBodySchemas,
   unresolvedResponseSchemas,
   unresolvedSchemas,
-  schemas,
-  securitySchemes,
 };


### PR DESCRIPTION
## PR summary
Fixes: https://github.com/IBM/openapi-validator/issues/438

This commit modifies the "responseSchemas" definition in the collections module so that it uses specific HTTP method names to identify operations.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
