### PR TITLE
fix(ibm-unique-parameter-request-property-names): avoid checks on readOnly requestBody properties

### DIFF
--- a/packages/ruleset/src/functions/unique-parameter-request-property-names.js
+++ b/packages/ruleset/src/functions/unique-parameter-request-property-names.js
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const { schemaHasProperty } = require('@ibm-cloud/openapi-ruleset-utilities');
+const {
+  isObject,
+  schemaHasConstraint,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const {
   isJsonMimeType,
@@ -81,7 +84,7 @@ function checkForNameCollisions(pathItem, path) {
         );
 
         for (const paramName of params) {
-          if (schemaHasProperty(jsonBodySchema, paramName)) {
+          if (schemaHasWritableProperty(jsonBodySchema, paramName)) {
             logger.debug(
               `${ruleId}: Found requestBody property ${paramName}, collision detected!`
             );
@@ -117,4 +120,18 @@ function getParamNames(paramContainer) {
   }
 
   return paramNames;
+}
+
+/**
+ * Returns true iff 'schema' defines a property named 'name' that is NOT readOnly.
+ * This function handles composed schemas as well.
+ */
+function schemaHasWritableProperty(schema, name) {
+  return schemaHasConstraint(
+    schema,
+    s =>
+      'properties' in s &&
+      isObject(s.properties[name]) &&
+      !s.properties[name].readOnly
+  );
 }


### PR DESCRIPTION
## PR summary
Tweaks the validation rule so that it avoids doing checks on readOnly properties since those would not be included in the set of exploded body vars.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
