### PR TITLE
feat: Containerfile to create image from current source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/.*
+/node_modules
+/appscan-config.xml
+/*.md
+/LICENSE

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,26 @@
+FROM node:current-alpine3.17 AS builder
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . ./
+RUN cd packages/validator && npm pack && mv ibm-openapi-validator-*.tgz /tmp/ibm-openapi-validator-latest.tgz
+
+FROM node:current-alpine3.17
+
+ARG SOURCE=https://github.com/IBM/openapi-validator
+
+LABEL org.opencontainers.image.source=$SOURCE
+LABEL org.opencontainers.image.documentation=$SOURCE/README.md#container-image
+LABEL org.opencontainers.image.licenses=Apache-2.0
+LABEL org.opencontainers.image.title="OpenAPI Validator"
+LABEL org.opencontainers.image.description="The IBM OpenAPI Validator lets you validate OpenAPI 3.x documents according to the OpenAPI 3.x specification, as well as IBM-defined best practices."
+
+RUN apk add --no-cache git
+
+COPY --from=builder /tmp/ibm-openapi-validator-latest.tgz /tmp
+RUN npm install -g /tmp/ibm-openapi-validator-latest.tgz \
+  && npm cache clean --force
+
+WORKDIR /data
+ENTRYPOINT ["lint-openapi"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The IBM OpenAPI Validator lets you validate OpenAPI 3.x documents according to t
   * [Download an executable binary](#download-an-executable-binary)
   * [Build from source](#build-from-source)
     + [Build platform-specific binaries](#build-platform-specific-binaries)
+  * [container image](#container-image)
+    + [examples](#examples)
 - [Usage](#usage)
   * [Command Syntax](#command-syntax)
   * [Configuration](#configuration)
@@ -102,6 +104,28 @@ _If you installed the validator using `npm install -g ibm-openapi-validator`, yo
 
 #### Build platform-specific binaries
 It is also possible to build platform specific binaries from the source code by running `npm run pkg` in the project root directory.  The binaries (lint-openapi-macos, lint-openapi-linux, lint-openapi-windows.exe) will be in the project's `packages/validator/bin` directory.
+
+### container image
+
+You can build and run this tool as a container image with the provided `Containerfile`.
+
+The container can be run directly, but mount a volume containing the OpenAPI specification file so that it can be accessed.
+
+#### examples
+```bash
+buildah bud -t openapi-validator
+podman run --volume "$PWD":/data:Z openapi-validator packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
+```
+```bash
+git checkout ibm-openapi-validator@1.1.1
+buildah bud -t openapi-validator:1.1.1
+podman run --volume "$PWD":/data:Z openapi-validator:1.1.1 packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
+```
+```bash
+docker build -t openapi-validator -f Containerfile .
+cd packages/validator/test/cli-validator/mock-files/
+docker run --volume "$PWD":/data openapi-validator --json oas3/complex-test-compose-model.yaml
+```
 
 ## Usage
 ### Command Syntax


### PR DESCRIPTION
## PR summary
This PR adds a `Containerfile` to the repository and documentation on how to use it.

Documentation about container images have been removed in #599. Because of this, the image at [jamescooke/openapi-validator](https://hub.docker.com/r/jamescooke/openapi-validator) got marked as deprecated.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [X] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
  - I made a github workflow which builds and uploads the image ([build-image.yml](https://github.com/Blaimi/openapi-validator/blob/e5f8824349b5be4424ca0bbd9b236e8935696405/.github/workflows/build-image.yml)), the build part could be adapted to test the build on every push/pr. Adapting the upload task would require some decisions about the image-target (dockerhub, quay, …) and how to handle tags and autobuilds.
- [X] Docs have been added / updated (for bug fixes / features)
- [X] Dependencies have been updated as needed
- [X] .secrets.baseline updated as needed?
