### PR TITLE
feat: add initial support for openapi 3.1 documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![CLA assistant](https://cla-assistant.io/readme/badge/ibm/openapi-validator)](https://cla-assistant.io/ibm/openapi-validator)
 
 # OpenAPI Validator
-The IBM OpenAPI Validator lets you validate OpenAPI 3.0.x documents according to the [OpenAPI 3.0.x specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md), as well as IBM-defined best practices.
+The IBM OpenAPI Validator lets you validate [OpenAPI 3.0.x](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
+and [OpenAPI 3.1.x](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md) documents for compliance with the OpenAPI specifications, as well as IBM-defined best practices.
 
 #### Prerequisites
 - Node 16.0.0+
@@ -57,7 +58,8 @@ The IBM OpenAPI Validator lets you validate OpenAPI 3.0.x documents according to
 <!-- tocstop -->
 
 ## Getting Started
-The validator analyzes your API definition and reports any problems within. The validator is highly customizable, and supports OpenAPI 3.0.x documents.
+The validator analyzes your API definition and reports any problems within. The validator is highly customizable,
+and supports OpenAPI 3.0.x and 3.1.x documents.
 The tool also supports a number of rules from [Spectral](https://stoplight.io/open-source/spectral/). You can easily extend the tool with custom rules to meet your specific needs and ensure compliance to your standards.
 
 Get started by [installing the tool](#installation), then [run the tool](#usage) on your API definition.
@@ -108,7 +110,7 @@ It is also possible to build platform specific binaries from the source code by 
 ```bash
 Usage: lint-openapi [options] [file...]
 
-Run the validator on one or more OpenAPI 3.0.x documents
+Run the validator on one or more OpenAPI 3.x documents
 
 Options:
   -c, --config <file>            use configuration stored in <file> (*.json, *.yaml, *.js)
@@ -123,7 +125,7 @@ Options:
   --version                      output the version number
   -h, --help                     display help for command
 ```
-where `[file...]` is a space-separated list containing the filenames of one or more OpenAPI 3.0.x documents to be validated.
+where `[file...]` is a space-separated list containing the filenames of one or more OpenAPI 3.x documents to be validated.
 The validator supports OpenAPI documents in either JSON or YAML format, using these supported file extensions:
 ```
 .json

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -93,6 +93,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-string-attributes](#ibm-string-attributes)
   * [ibm-success-response-example](#ibm-success-response-example)
   * [ibm-summary-sentence-style](#ibm-summary-sentence-style)
+  * [ibm-unevaluated-properties](#ibm-unevaluated-properties)
   * [ibm-unique-parameter-request-property-names](#ibm-unique-parameter-request-property-names)
   * [ibm-valid-path-segments](#ibm-valid-path-segments)
 
@@ -516,6 +517,12 @@ has non-form content.</td>
 <td>warn</td>
 <td>An operation's <code>summary</code> field should not have a trailing period.</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-unevaluated-properties">ibm-unevaluated-properties</a></td>
+<td>error</td>
+<td>Ensures that <code>unevaluatedProperties</code> is not enabled within a schema.</td>
+<td>oas3_1</td>
 </tr>
 <tr>
 <td><a href="#ibm-unique-parameter-request-property-names">ibm-unique-parameter-request-property-names</a></td>
@@ -5360,6 +5367,66 @@ paths:
       operationId: list_things
       summary: List things
       description: Retrieve a paginated collection of Thing instances.
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-unevaluated-properties
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-unevaluated-properties</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule ensures that <code>unevaluatedProperties</code> is not enabled within a schema.
+It checks to make sure that if the <code>unevaluatedProperties</code> field
+is set on a schema, then it is set to the value <code>false</code> (i.e. disabled).
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3_1</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+      unevaluatedProperties:
+        type: string
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+      unevaluatedProperties: false
 </pre>
 </td>
 </tr>

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -30,6 +30,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
 - [Reference](#reference)
   * [ibm-array-attributes](#ibm-array-attributes)
   * [ibm-avoid-inline-schemas](#ibm-avoid-inline-schemas)
+  * [ibm-avoid-multiple-types](#ibm-avoid-multiple-types)
   * [ibm-avoid-property-name-collision](#ibm-avoid-property-name-collision)
   * [ibm-avoid-repeating-path-parameters](#ibm-avoid-repeating-path-parameters)
   * [ibm-binary-schemas](#ibm-binary-schemas)
@@ -125,6 +126,13 @@ is provided in the [Reference](#reference) section below.
 Instead, use a ref to a named schema.
 </td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-avoid-multiple-types">ibm-avoid-multiple-types</a></td>
+<td>warn</td>
+<td>Multiple types within a schema's <code>type</code> field should be avoided because it creates ambiguity.
+</td>
+<td>oas3_1</td>
 </tr>
 <tr>
 <td><a href="#ibm-avoid-property-name-collision">ibm-avoid-property-name-collision</a></td>
@@ -873,6 +881,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Thing'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-avoid-multiple-types
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-avoid-multiple-types</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>The OpenAPI 3.1 Specification allows multiple types to be used within a schema's <code>type</code> field, but this can create
+ambiguity in an API definition.  Therefore, multiple types should be avoided.
+<p>This rule will return an error for schemas that are defined with multiple types (e.g. <code>['string', 'integer', 'boolean']</code>).
+One exception to this is that the special type <code>"null"</code> is simply ignored by the rule when counting 
+the number of elements in the schema's <code>type</code> field.  So, the type value <code>['string', 'integer']</code>
+would cause an error, but the type value <code>['string', 'null']</code> would not.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3_1</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type:
+            - string
+            - boolean
+            - integer
+            - null
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type:
+            - string
+            - null
 </pre>
 </td>
 </tr>

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -2644,7 +2644,7 @@ where the overridden description is defined directly as an attribute of the "nex
 second allOf list element.  Both are considered to be examples of the "ref sibling" allOf pattern.
 
 <p>This rule specifically looks for instances of this pattern where the overridden description is the same as the
-description defined within the reference schema, thus rending the use of the "ref sibling" pattern unnecessary.
+description defined within the referenced schema, thus making the use of the "ref sibling" pattern unnecessary.
 Here is an example of this:
 <pre>
 components:

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -71,6 +71,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-parameter-schema-or-content](#ibm-parameter-schema-or-content)
   * [ibm-patch-request-content-type](#ibm-patch-request-content-type)
   * [ibm-path-segment-casing-convention](#ibm-path-segment-casing-convention)
+  * [ibm-pattern-properties](#ibm-pattern-properties)
   * [ibm-precondition-headers](#ibm-precondition-headers)
   * [ibm-prefer-token-pagination](#ibm-prefer-token-pagination)
   * [ibm-property-attributes](#ibm-property-attributes)
@@ -381,6 +382,12 @@ or <code>application/merge-patch+json</code>.</td>
 <td>error</td>
 <td>Path segments must follow a specific case convention.</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-pattern-properties">ibm-pattern-properties</a></td>
+<td>error</td>
+<td>Enforces certain restrictions on the use of <code>patternProperties</code> within a schema.</td>
+<td>oas3_1</td>
 </tr>
 <tr>
 <td><a href="#ibm-precondition-headers">ibm-precondition-headers</a></td>
@@ -3838,6 +3845,74 @@ paths:
 <pre>
 paths:
   '/v1/some_things/{thing_id}':
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-pattern-properties
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-pattern-properties</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule enforces certain restrictions related to the use of the <code>patternProperties</code> field
+within a schema:
+<ul>
+<li>The <code>patternProperties</code> field must be an object with exactly one entry.
+<li>The <code>patternProperties</code> and <code>additionalProperties</code> fields are mutually exclusive within a particular schema.
+</ul>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3_1</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+          patternProperties:
+            '^foo.*$':
+              type: string
+            '^bar.*$':
+              type: integer
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+          patternProperties:
+            '^(foo|bar).*$':
+              type: string
 </pre>
 </td>
 </tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1294,9 +1294,9 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.0.tgz",
-      "integrity": "sha512-0gg/NwewU0iXctYBale0VVcCPqOtoW5lsog8cNBJgzV/CyTHa2gicUBOlNnzOk6pJkuwXI34qkq+uRm40PmD4A==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+      "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
       "dev": true,
       "dependencies": {
         "@octokit/endpoint": "^9.0.0",
@@ -3337,9 +3337,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001516",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
-      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "dev": true,
       "funding": [
         {
@@ -3861,7 +3861,8 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -3899,12 +3900,12 @@
       }
     },
     "node_modules/degenerator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.0.tgz",
-      "integrity": "sha512-pdRxyYVe0unlUE/eeXBxFdB8w8J7QNNf7hFE/BKOAlTCz0bkF9h1MC82ii0r1ypqB/PTKYDbg4K9SZT9yfd9Fg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dependencies": {
         "ast-types": "^0.13.4",
-        "escodegen": "^1.14.3",
+        "escodegen": "^2.1.0",
         "esprima": "^4.0.1"
       },
       "engines": {
@@ -3920,82 +3921,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/degenerator/node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/degenerator/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/degenerator/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/degenerator/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/degenerator/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/degenerator/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -4123,9 +4048,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.463",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.463.tgz",
-      "integrity": "sha512-fT3hvdUWLjDbaTGzyOjng/CQhQJSQP8ThO3XZAoaxHvHo2kUXiRQVMj9M235l8uDFiNPsPa6KHT1p3RaR6ugRw==",
+      "version": "1.4.465",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.465.tgz",
+      "integrity": "sha512-XQcuHvEJRMU97UJ75e170mgcITZoz0lIyiaVjk6R+NMTJ8KBIvUHYd1779swgOppUlzxR+JsLpq59PumaXS1jQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4411,7 +4336,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4600,7 +4524,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4752,7 +4675,8 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fast-memoize": {
       "version": "2.5.2",
@@ -7960,15 +7884,17 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.0.tgz",
-      "integrity": "sha512-AXeiBAdfM5K2jvBwA7EGLKeYyt0VnhmJRnlq4k2+M0Ao9v7yKJBqF8xFPzQL8kAybzwlfpTPCZwM4uTIszb3xA==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/config",
+        "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
+        "@npmcli/promise-spawn",
         "@npmcli/run-script",
         "abbrev",
         "archy",
@@ -8036,13 +7962,15 @@
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^6.3.0",
         "@npmcli/config": "^6.2.1",
+        "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
         "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
         "cacache": "^17.1.3",
-        "chalk": "^5.2.0",
+        "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
@@ -8058,7 +7986,7 @@
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
         "libnpmdiff": "^5.0.19",
-        "libnpmexec": "^6.0.2",
+        "libnpmexec": "^6.0.3",
         "libnpmfund": "^4.0.19",
         "libnpmhook": "^9.0.3",
         "libnpmorg": "^5.0.4",
@@ -8068,7 +7996,7 @@
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
         "make-fetch-happen": "^11.1.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -8088,10 +8016,10 @@
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
-        "semver": "^7.5.2",
+        "semver": "^7.5.4",
         "sigstore": "^1.7.0",
         "ssri": "^10.0.4",
-        "supports-color": "^9.3.1",
+        "supports-color": "^9.4.0",
         "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
@@ -8377,17 +8305,18 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^4.1.0",
         "glob": "^10.2.2",
+        "hosted-git-info": "^6.1.1",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^5.0.0",
-        "npm-normalize-package-bin": "^3.0.1",
-        "proc-log": "^3.0.0"
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -8632,7 +8561,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8721,7 +8650,7 @@
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "5.2.0",
+      "version": "5.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9467,7 +9396,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9637,7 +9566,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.1",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10554,7 +10483,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.5.2",
+      "version": "7.5.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10782,7 +10711,7 @@
       }
     },
     "node_modules/npm/node_modules/supports-color": {
-      "version": "9.3.1",
+      "version": "9.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14267,14 +14196,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -15595,9 +15516,9 @@
       }
     },
     "@octokit/request": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.0.tgz",
-      "integrity": "sha512-0gg/NwewU0iXctYBale0VVcCPqOtoW5lsog8cNBJgzV/CyTHa2gicUBOlNnzOk6pJkuwXI34qkq+uRm40PmD4A==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+      "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^9.0.0",
@@ -17154,9 +17075,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001516",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
-      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "dev": true
     },
     "cardinal": {
@@ -17534,7 +17455,8 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "deepmerge": {
       "version": "4.3.1",
@@ -17560,12 +17482,12 @@
       }
     },
     "degenerator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.0.tgz",
-      "integrity": "sha512-pdRxyYVe0unlUE/eeXBxFdB8w8J7QNNf7hFE/BKOAlTCz0bkF9h1MC82ii0r1ypqB/PTKYDbg4K9SZT9yfd9Fg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "requires": {
         "ast-types": "^0.13.4",
-        "escodegen": "^1.14.3",
+        "escodegen": "^2.1.0",
         "esprima": "^4.0.1"
       },
       "dependencies": {
@@ -17575,58 +17497,6 @@
           "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
           "requires": {
             "tslib": "^2.0.1"
-          }
-        },
-        "escodegen": {
-          "version": "1.14.3",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-          "requires": {
-            "prelude-ls": "~1.1.2"
           }
         }
       }
@@ -17725,9 +17595,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.463",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.463.tgz",
-      "integrity": "sha512-fT3hvdUWLjDbaTGzyOjng/CQhQJSQP8ThO3XZAoaxHvHo2kUXiRQVMj9M235l8uDFiNPsPa6KHT1p3RaR6ugRw==",
+      "version": "1.4.465",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.465.tgz",
+      "integrity": "sha512-XQcuHvEJRMU97UJ75e170mgcITZoz0lIyiaVjk6R+NMTJ8KBIvUHYd1779swgOppUlzxR+JsLpq59PumaXS1jQ==",
       "dev": true
     },
     "emittery": {
@@ -17931,7 +17801,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -18053,8 +17922,7 @@
     "estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
     },
     "estree-walker": {
       "version": "2.0.2",
@@ -18172,7 +18040,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "fast-memoize": {
       "version": "2.5.2",
@@ -20668,21 +20537,23 @@
       "dev": true
     },
     "npm": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.0.tgz",
-      "integrity": "sha512-AXeiBAdfM5K2jvBwA7EGLKeYyt0VnhmJRnlq4k2+M0Ao9v7yKJBqF8xFPzQL8kAybzwlfpTPCZwM4uTIszb3xA==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^6.3.0",
         "@npmcli/config": "^6.2.1",
+        "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
         "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
         "cacache": "^17.1.3",
-        "chalk": "^5.2.0",
+        "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
@@ -20698,7 +20569,7 @@
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
         "libnpmdiff": "^5.0.19",
-        "libnpmexec": "^6.0.2",
+        "libnpmexec": "^6.0.3",
         "libnpmfund": "^4.0.19",
         "libnpmhook": "^9.0.3",
         "libnpmorg": "^5.0.4",
@@ -20708,7 +20579,7 @@
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
         "make-fetch-happen": "^11.1.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -20728,10 +20599,10 @@
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
-        "semver": "^7.5.2",
+        "semver": "^7.5.4",
         "sigstore": "^1.7.0",
         "ssri": "^10.0.4",
-        "supports-color": "^9.3.1",
+        "supports-color": "^9.4.0",
         "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
@@ -20923,16 +20794,17 @@
           "dev": true
         },
         "@npmcli/package-json": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^4.1.0",
             "glob": "^10.2.2",
+            "hosted-git-info": "^6.1.1",
             "json-parse-even-better-errors": "^3.0.0",
             "normalize-package-data": "^5.0.0",
-            "npm-normalize-package-bin": "^3.0.1",
-            "proc-log": "^3.0.0"
+            "proc-log": "^3.0.0",
+            "semver": "^7.5.3"
           }
         },
         "@npmcli/promise-spawn": {
@@ -21085,7 +20957,7 @@
           "dev": true
         },
         "bin-links": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21145,7 +21017,7 @@
           }
         },
         "chalk": {
-          "version": "5.2.0",
+          "version": "5.3.0",
           "bundled": true,
           "dev": true
         },
@@ -21632,7 +21504,7 @@
           }
         },
         "libnpmexec": {
-          "version": "6.0.2",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21758,7 +21630,7 @@
           }
         },
         "minimatch": {
-          "version": "9.0.1",
+          "version": "9.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22380,7 +22252,7 @@
           "optional": true
         },
         "semver": {
-          "version": "7.5.2",
+          "version": "7.5.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22535,7 +22407,7 @@
           }
         },
         "supports-color": {
-          "version": "9.3.1",
+          "version": "9.4.0",
           "bundled": true,
           "dev": true
         },
@@ -25080,11 +24952,6 @@
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "word-wrap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA=="
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/packages/ruleset/src/functions/array-responses.js
+++ b/packages/ruleset/src/functions/array-responses.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
+const { isArraySchema } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
 let ruleId;
@@ -36,10 +37,7 @@ function checkForArrayResponses(op, path) {
       response.content || {}
     )) {
       logger.debug(`${ruleId}: checking response for mimetype '${mimeType}'`);
-      const isArrayResponse =
-        contentEntry.schema &&
-        (contentEntry.schema.type === 'array' || contentEntry.schema.items);
-      if (isArrayResponse) {
+      if (contentEntry.schema && isArraySchema(contentEntry.schema)) {
         logger.debug('Found an array response!');
         errors.push({
           message:

--- a/packages/ruleset/src/functions/avoid-multiple-types.js
+++ b/packages/ruleset/src/functions/avoid-multiple-types.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  validateNestedSchemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateNestedSchemas(
+    schema,
+    context.path,
+    avoidMultipleTypes,
+    true,
+    false
+  );
+};
+
+/**
+ * Warns about the presence of multiple types within a schema's "type" field.
+ * @param {*} schema the schema to check
+ * @param {*} path the array of path segments indicating the location of "schema" within the API definition
+ * @returns an array of zero or more errors
+ */
+function avoidMultipleTypes(schema, path) {
+  logger.debug(
+    `${ruleId}: checking 'type' in schema at location: ${path.join('.')}`
+  );
+
+  if (!schema.type || typeof schema.type === 'string') {
+    return [];
+  }
+
+  const errors = [];
+
+  if (Array.isArray(schema.type)) {
+    const filteredTypes = schema.type.filter(t => t !== 'null');
+
+    if (filteredTypes.length > 1) {
+      logger.debug(
+        `${ruleId}: detected multiple types at location: ${path.join('.')}.type`
+      );
+      errors.push({
+        message: `Avoid multiple types in schema 'type' field`,
+        path: [...path, 'type'],
+      });
+    }
+  }
+
+  return errors;
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -7,6 +7,7 @@ module.exports = {
   arrayAttributes: require('./array-attributes'),
   arrayOfArrays: require('./array-of-arrays'),
   arrayResponses: require('./array-responses'),
+  avoidMultipleTypes: require('./avoid-multiple-types'),
   binarySchemas: require('./binary-schemas'),
   checkMajorVersion: require('./check-major-version'),
   circularRefs: require('./circular-refs'),

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -34,6 +34,7 @@ module.exports = {
   patchRequestContentType: require('./patch-request-content-type'),
   pathParameterNotCRN: require('./path-parameter-not-crn'),
   pathSegmentCasingConvention: require('./path-segment-casing-convention'),
+  patternPropertiesCheck: require('./pattern-properties'),
   preconditionHeader: require('./precondition-header'),
   preferTokenPagination: require('./prefer-token-pagination'),
   propertyAttributes: require('./property-attributes'),

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -55,6 +55,7 @@ module.exports = {
   securitySchemeAttributes: require('./securityscheme-attributes'),
   securitySchemes: require('./securityschemes'),
   stringAttributes: require('./string-attributes'),
+  unevaluatedProperties: require('./unevaluated-properties'),
   uniqueParameterRequestPropertyNames: require('./unique-parameter-request-property-names'),
   unusedTags: require('./unused-tags'),
   validatePathSegments: require('./valid-path-segments'),

--- a/packages/ruleset/src/functions/pagination-style.js
+++ b/packages/ruleset/src/functions/pagination-style.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-<<<<<<< HEAD
 const {
   mergeAllOfSchemaProperties,
   LoggerFactory,
@@ -13,14 +12,10 @@ const {
   getResponseSchema,
   getPaginatedOperationFromPath,
 } = require('../utils');
-=======
-const { mergeAllOfSchemaProperties, LoggerFactory } = require('../utils');
 const {
-  isArraySchema,
   isIntegerSchema,
   isStringSchema,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
->>>>>>> 38541df (fix: support type list in existing rules)
 
 let ruleId;
 let logger;
@@ -59,92 +54,12 @@ function paginationStyle(pathItem, path) {
     ruleId,
   });
 
-<<<<<<< HEAD
   // If `operation` is null, this is not a paginated operation.
   if (!operation) {
     logger.debug(
       `${ruleId}: no paginated operation found at path '${path.join('.')}'`
     );
-=======
-  // The actual path string (e.g. '/v1/resources') will be the last element in 'path'.
-  const pathStr = path[path.length - 1];
 
-  // Retrieve this path item's 'get' operation.
-  const operation = pathItem.get;
-
-  // We'll bail out now if any of the following are true:
-  // 1. If the path string ends with a path param reference (e.g. '{resource_id}'
-  // 2. If the path item doesn't have a 'get' operation.
-  if (/}$/.test(pathStr) || !operation) {
-    logger.debug(`${ruleId}: 'get' operation is absent or excluded`);
-    return [];
-  }
-
-  // Next, find the first success response code.
-  const successCode = Object.keys(operation.responses || {}).find(code =>
-    code.startsWith('2')
-  );
-  if (!successCode) {
-    logger.debug(`${ruleId}: No success response code found!`);
-    return [];
-  }
-
-  // Next, find the json content of that response.
-  const content = operation.responses[successCode].content;
-  const jsonResponse = content && content['application/json'];
-
-  // If there's no response schema, then we can't check this operation so bail out now.
-  if (!jsonResponse || !jsonResponse.schema) {
-    logger.debug(`${ruleId}: No response schema found!`);
-    return [];
-  }
-
-  // Next, let's get the response schema (while potentially taking into account allOf).
-  const responseSchema = mergeAllOfSchemaProperties(jsonResponse.schema);
-  if (!responseSchema || !responseSchema.properties) {
-    logger.debug(`${ruleId}: Merged response schema has no properties!`);
-    return [];
-  }
-
-  // Next, make sure there is at least one array property in the response schema.
-  if (
-    !Object.values(responseSchema.properties).some(prop => isArraySchema(prop))
-  ) {
-    logger.debug(`${ruleId}: Response schema has no array property!`);
-    return [];
-  }
-
-  // Next, make sure this operation has parameters.
-  const params = operation.parameters;
-  if (!params) {
-    logger.debug(`${ruleId}: Operation has no parameters!`);
-    return [];
-  }
-
-  // Check to see if the operation defines a page token-type query param.
-  // This could have any of the names below.
-  const pageTokenParamNames = [
-    'start',
-    'token',
-    'cursor',
-    'page',
-    'page_token',
-  ];
-  const pageTokenParamIndex = params.findIndex(
-    param =>
-      param.in === 'query' && pageTokenParamNames.indexOf(param.name) !== -1
-  );
-
-  // Check to see if the operation defines an "offset" query param.
-  const offsetParamIndex = params.findIndex(
-    param => param.name === 'offset' && param.in === 'query'
-  );
-
-  // If the operation doesn't define a page token-type query param or an "offset" query param,
-  // then bail out now as pagination isn't supported by this operation.
-  if (pageTokenParamIndex < 0 && offsetParamIndex < 0) {
-    logger.debug(`${ruleId}: No start or offset query param!`);
->>>>>>> 38541df (fix: support type list in existing rules)
     return [];
   }
 

--- a/packages/ruleset/src/functions/pattern-properties.js
+++ b/packages/ruleset/src/functions/pattern-properties.js
@@ -5,7 +5,7 @@
 
 const {
   isObject,
-  validateNestedSchemas,
+  validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
@@ -17,7 +17,7 @@ module.exports = function (schema, _opts, context) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
   }
-  return validateNestedSchemas(
+  return validateSubschemas(
     schema,
     context.path,
     patternPropertiesCheck,

--- a/packages/ruleset/src/functions/pattern-properties.js
+++ b/packages/ruleset/src/functions/pattern-properties.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  isObject,
+  validateNestedSchemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateNestedSchemas(
+    schema,
+    context.path,
+    patternPropertiesCheck,
+    true,
+    false
+  );
+};
+
+/**
+ * Enforces certain restrictions on the use of "patternProperties" within a schema:
+ * 1. patternProperties and additionalProperties are mutually exclusive
+ * 2. patternProperties must be an object
+ * 3. patternProperties must not be empty
+ * 4. patternProperties must have at most one entry
+ *
+ * @param {*} schema the schema to check
+ * @param {*} path the array of path segments indicating the location of "schema" within the API definition
+ * @returns an array of zero or more errors
+ */
+function patternPropertiesCheck(schema, path) {
+  logger.debug(
+    `${ruleId}: checking 'patternProperties' in schema at location: ${path.join(
+      '.'
+    )}`
+  );
+
+  // We're only interested in this schema if it defines "patternProperties".
+  if (!('patternProperties' in schema)) {
+    return [];
+  }
+
+  if ('additionalProperties' in schema) {
+    logger.debug(
+      `${ruleId}: Error: found patternProperties and additionalProperties`
+    );
+    return [
+      {
+        message:
+          'patternProperties and additionalProperties are mutually exclusive',
+        path,
+      },
+    ];
+  }
+
+  if (!isObject(schema.patternProperties)) {
+    logger.debug(`${ruleId}: Error: patternProperties is not an object!`);
+    return [
+      {
+        message: 'patternProperties must be an object',
+        path: [...path, 'patternProperties'],
+      },
+    ];
+  }
+
+  const keys = Object.keys(schema.patternProperties);
+  if (!keys.length) {
+    logger.debug(`${ruleId}: Error: patternProperties is empty!`);
+    return [
+      {
+        message: 'patternProperties must be a non-empty object',
+        path: [...path, 'patternProperties'],
+      },
+    ];
+  }
+
+  if (keys.length > 1) {
+    logger.debug(
+      `${ruleId}: Error: patternProperties has more than one entry!`
+    );
+    return [
+      {
+        message: 'patternProperties must be an object with at most one entry',
+        path: [...path, 'patternProperties'],
+      },
+    ];
+  }
+
+  logger.debug(`${ruleId}: PASSED!`);
+
+  return [];
+}

--- a/packages/ruleset/src/functions/schema-type-exists.js
+++ b/packages/ruleset/src/functions/schema-type-exists.js
@@ -48,6 +48,21 @@ function schemaTypeExists(schema, path) {
   return [];
 }
 
+/**
+ * Returns true iff schema 's' explicitly defines its type.
+ * The type could be a non-empty string or a list of non-empty strings.
+ * @param {*} s the schema to check
+ * @returns boolean true if 's' explicitly defines its type, false otherwise
+ */
 function schemaHasType(s) {
-  return s && s.type && s.type.toString().trim().length;
+  return (
+    s &&
+    'type' in s &&
+    ((typeof s.type === 'string' && s.type.toString().trim().length) ||
+      (Array.isArray(s.type) &&
+        s.type.length &&
+        s.type.every(t => {
+          return typeof t === 'string' && t.trim().length;
+        })))
+  );
 }

--- a/packages/ruleset/src/functions/unevaluated-properties.js
+++ b/packages/ruleset/src/functions/unevaluated-properties.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { validateSubschemas } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateSubschemas(
+    schema,
+    context.path,
+    unevaluatedProperties,
+    true,
+    false
+  );
+};
+
+/**
+ * If 'unevaluatedProperties' is specified within "schema" then it must be set to false.
+ *
+ * @param {*} schema the schema to check
+ * @param {*} path the array of path segments indicating the location of "schema" within the API definition
+ * @returns an array of zero or more errors
+ */
+function unevaluatedProperties(schema, path) {
+  logger.debug(
+    `${ruleId}: checking 'unevaluatedProperties' in schema at location: ${path.join(
+      '.'
+    )}`
+  );
+
+  // If "unevaluatedProperties" is specified and it is NOT false, we have an error.
+  if (
+    'unevaluatedProperties' in schema &&
+    schema.unevaluatedProperties !== false
+  ) {
+    logger.debug(`${ruleId}: Error: unevaluatedProperties !== false!`);
+    return [
+      {
+        message: 'unevaluatedProperties must be set to false, if present',
+        path: [...path, 'unevaluatedProperties'],
+      },
+    ];
+  }
+
+  logger.debug(`${ruleId}: PASSED!`);
+  return [];
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -163,6 +163,7 @@ module.exports = {
     'ibm-string-attributes': ibmRules.stringAttributes,
     'ibm-success-response-example': ibmRules.responseExampleExists,
     'ibm-summary-sentence-style': ibmRules.summarySentenceStyle,
+    'ibm-unevaluated-properties': ibmRules.unevaluatedProperties,
     'ibm-unique-parameter-request-property-names':
       ibmRules.uniqueParameterRequestPropertyNames,
     'ibm-valid-path-segments': ibmRules.validPathSegments,

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -140,6 +140,7 @@ module.exports = {
     'ibm-parameter-schema-or-content': ibmRules.parameterSchemaOrContentExists,
     'ibm-patch-request-content-type': ibmRules.patchRequestContentType,
     'ibm-path-segment-casing-convention': ibmRules.pathSegmentCasingConvention,
+    'ibm-pattern-properties': ibmRules.patternProperties,
     'ibm-precondition-headers': ibmRules.preconditionHeader,
     'ibm-prefer-token-pagination': ibmRules.preferTokenPagination,
     'ibm-property-attributes': ibmRules.propertyAttributes,

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -97,6 +97,7 @@ module.exports = {
     // IBM Custom Rules
     'ibm-array-attributes': ibmRules.arrayAttributes,
     'ibm-avoid-inline-schemas': ibmRules.inlineSchemas,
+    'ibm-avoid-multiple-types': ibmRules.avoidMultipleTypes,
     'ibm-avoid-property-name-collision': ibmRules.propertyNameCollision,
     'ibm-avoid-repeating-path-parameters': ibmRules.duplicatePathParameter,
     'ibm-binary-schemas': ibmRules.binarySchemas,

--- a/packages/ruleset/src/rules/avoid-multiple-types.js
+++ b/packages/ruleset/src/rules/avoid-multiple-types.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3_1 } = require('@stoplight/spectral-formats');
+const { avoidMultipleTypes } = require('../functions');
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+
+module.exports = {
+  description:
+    'OpenAPI 3.1 documents should avoid multiple types in the schema "type" field.',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'error',
+  formats: [oas3_1],
+  resolved: true,
+  then: {
+    function: avoidMultipleTypes,
+  },
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -9,6 +9,7 @@ module.exports = {
   arrayOfArrays: require('./array-of-arrays'),
   arrayResponses: require('./array-responses'),
   authorizationHeader: require('./authorization-header'),
+  avoidMultipleTypes: require('./avoid-multiple-types'),
   binarySchemas: require('./binary-schemas'),
   circularRefs: require('./circular-refs'),
   collectionArrayProperty: require('./collection-array-property'),

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -45,6 +45,7 @@ module.exports = {
   patchRequestContentType: require('./patch-request-content-type'),
   pathParameterNotCRN: require('./path-parameter-not-crn'),
   pathSegmentCasingConvention: require('./path-segment-casing-convention'),
+  patternProperties: require('./pattern-properties'),
   preconditionHeader: require('./precondition-header'),
   preferTokenPagination: require('./prefer-token-pagination'),
   propertyAttributes: require('./property-attributes'),

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -68,6 +68,7 @@ module.exports = {
   serverVariableDefaultValue: require('./server-variable-default-value'),
   stringAttributes: require('./string-attributes'),
   summarySentenceStyle: require('./summary-sentence-style'),
+  unevaluatedProperties: require('./unevaluated-properties'),
   unusedTags: require('./unused-tags'),
   uniqueParameterRequestPropertyNames: require('./unique-parameter-request-property-names'),
   validPathSegments: require('./valid-path-segments'),

--- a/packages/ruleset/src/rules/pattern-properties.js
+++ b/packages/ruleset/src/rules/pattern-properties.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3_1 } = require('@stoplight/spectral-formats');
+const { patternPropertiesCheck } = require('../functions');
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+
+module.exports = {
+  description:
+    'Enforces certain restrictions on the use of "patternProperties" within a schema.',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'error',
+  formats: [oas3_1],
+  resolved: true,
+  then: {
+    function: patternPropertiesCheck,
+  },
+};

--- a/packages/ruleset/src/rules/unevaluated-properties.js
+++ b/packages/ruleset/src/rules/unevaluated-properties.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3_1 } = require('@stoplight/spectral-formats');
+const { unevaluatedProperties } = require('../functions');
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+
+module.exports = {
+  description:
+    'Enforces certain restrictions on the use of "unevaluatedProperties" within a schema.',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'error',
+  formats: [oas3_1],
+  resolved: true,
+  then: {
+    function: unevaluatedProperties,
+  },
+};

--- a/packages/ruleset/src/utils/pagination-utils.js
+++ b/packages/ruleset/src/utils/pagination-utils.js
@@ -2,7 +2,7 @@
  * Copyright 2023 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
-
+const { isArraySchema } = require('@ibm-cloud/openapi-ruleset-utilities');
 const mergeAllOfSchemaProperties = require('./merge-allof-schema-properties');
 
 /**
@@ -134,9 +134,7 @@ function getPaginatedOperationFromPath(pathItem, path, logInfo) {
 
   // Next, make sure there is at least one array property in the response schema.
   if (
-    !Object.values(responseSchema.properties).some(
-      prop => prop.type === 'array'
-    )
+    !Object.values(responseSchema.properties).some(prop => isArraySchema(prop))
   ) {
     logger.debug(`${ruleId}: Response schema has no array property!`);
     return;

--- a/packages/ruleset/test/accept-header.test.js
+++ b/packages/ruleset/test/accept-header.test.js
@@ -14,8 +14,10 @@ const expectedErrorMsg =
 
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
-    it('Clean spec', async () => {
-      const results = await testRule(ruleId, rule, rootDocument);
+    it.each(['3.0.0', '3.1.0'])('Clean spec', async function (oasVersion) {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.openapi = oasVersion;
+      const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
 
@@ -59,27 +61,31 @@ describe(`Spectral rule: ${ruleId}`, () => {
   });
 
   describe('Should yield errors', () => {
-    it('Header parameter named Accept', async () => {
-      const testDocument = makeCopy(rootDocument);
+    it.each(['3.0.0', '3.1.0'])(
+      'Header parameter named Accept',
+      async function (oasVersion) {
+        const testDocument = makeCopy(rootDocument);
+        testDocument.openapi = oasVersion;
 
-      testDocument.paths['/v1/drinks'].parameters = [
-        {
-          description: 'The expected response mimetype.',
-          name: 'Accept',
-          required: true,
-          in: 'header',
-          schema: {
-            type: 'string',
+        testDocument.paths['/v1/drinks'].parameters = [
+          {
+            description: 'The expected response mimetype.',
+            name: 'Accept',
+            required: true,
+            in: 'header',
+            schema: {
+              type: 'string',
+            },
           },
-        },
-      ];
+        ];
 
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedErrorMsg);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path.join('.')).toBe('paths./v1/drinks.parameters.0');
-    });
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(1);
+        expect(results[0].code).toBe(ruleId);
+        expect(results[0].message).toBe(expectedErrorMsg);
+        expect(results[0].severity).toBe(expectedSeverity);
+        expect(results[0].path.join('.')).toBe('paths./v1/drinks.parameters.0');
+      }
+    );
   });
 });

--- a/packages/ruleset/test/array-attributes.test.js
+++ b/packages/ruleset/test/array-attributes.test.js
@@ -435,20 +435,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsgItems);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'allOf',
-        '1',
-        'properties',
-        'drinks',
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks'
+      );
     });
     it('Response schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
@@ -462,16 +451,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsgItems);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.get.responses.200.content.application/json.schema'
+      );
     });
     it('Request schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
@@ -487,16 +469,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsgItems);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.application/json.schema'
+      );
     });
+
     it('Request schema with non-object items property', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -507,21 +484,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
         items: 'not a schema!',
       };
 
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgItems);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-      ]);
+      await expect(async () => {
+        await testRule(ruleId, rule, testDocument);
+      }).rejects.toThrow();
     });
+
     it('additionalProperties schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -531,69 +498,20 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(5);
-      for (const result of results) {
-        expect(result.code).toBe(ruleId);
-        expect(result.message).toBe(expectedMsgItems);
-        expect(result.severity).toBe(expectedSeverity);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.additionalProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.additionalProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.additionalProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.additionalProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.additionalProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsgItems);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
       }
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
-      expect(results[1].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
-      expect(results[2].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'allOf',
-        '1',
-        'properties',
-        'movies',
-        'items',
-        'additionalProperties',
-      ]);
-      expect(results[3].path).toStrictEqual([
-        'paths',
-        '/v1/movies/{movie_id}',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
-      expect(results[4].path).toStrictEqual([
-        'paths',
-        '/v1/movies/{movie_id}',
-        'put',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
     });
     it('minItems > maxItems', async () => {
       const testDocument = makeCopy(rootDocument);

--- a/packages/ruleset/test/avoid-multiple-types.test.js
+++ b/packages/ruleset/test/avoid-multiple-types.test.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { avoidMultipleTypes } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = avoidMultipleTypes;
+const ruleId = 'ibm-avoid-multiple-types';
+const expectedSeverity = severityCodes.error;
+const expectedMessage = `Avoid multiple types in schema 'type' field`;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  beforeAll(() => {
+    rootDocument.openapi = '3.1.0';
+  });
+
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('One-element type list - property', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['NormalString'].type = ['string'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('One-element type list - parameter', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: ['string'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('Two-element type list includes "null" - property', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['NormalString'].type = ['null', 'string'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('Two-element type list includes "null" - parameter', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter1',
+          in: 'query',
+          schema: {
+            type: ['string', 'null'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+        {
+          name: 'filter2',
+          in: 'query',
+          schema: {
+            type: ['null', 'string'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Multiple values in type list - property', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['UrlString'].type = [
+        'integer',
+        'string',
+        'null',
+        'boolean',
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+      for (const result of results) {
+        expect(result.code).toBe(ruleId);
+        expect(result.message).toBe(expectedMessage);
+        expect(result.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.application/json.schema.properties.imdb_url.type'
+      );
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.201.content.application/json.schema.properties.imdb_url.type'
+      );
+      expect(results[2].path.join('.')).toBe(
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.properties.imdb_url.type'
+      );
+      expect(results[3].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.properties.imdb_url.type'
+      );
+      expect(results[4].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.properties.imdb_url.type'
+      );
+    });
+    it('Multiple values in type list - parameter', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: ['integer', 'string', 'null', 'boolean'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+      ];
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.message).toBe(expectedMessage);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.path.join('.')).toBe(
+        'paths./v1/movies.post.parameters.0.schema.type'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/inline-schemas.test.js
+++ b/packages/ruleset/test/inline-schemas.test.js
@@ -353,6 +353,39 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+
+    it('Inline primitive in additionalProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Car.additionalProperties = {
+        description: 'Inline string schema within additionalProperties',
+        type: 'string',
+        pattern: '^blah.*$',
+        minLength: 0,
+        maxLength: 64,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Inline primitive in patternProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.openapi = '3.1.0';
+      testDocument.components.schemas.Car.patternProperties = {
+        '^foo.*$': {
+          description: 'Inline object schema within additionalProperties',
+          type: 'string',
+          pattern: '^blah.*$',
+          minLength: 0,
+          maxLength: 64,
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {
@@ -526,6 +559,32 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
         'components.schemas.Car.additionalProperties'
+      );
+    });
+
+    it('Inline object in patternProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.openapi = '3.1.0';
+      testDocument.components.schemas.Car.patternProperties = {
+        '^foo.*$': {
+          description: 'Inline object schema within additionalProperties',
+          properties: {
+            prop1: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgProperty);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'components.schemas.Car.patternProperties.^foo.*$'
       );
     });
 

--- a/packages/ruleset/test/pagination-style.test.js
+++ b/packages/ruleset/test/pagination-style.test.js
@@ -230,24 +230,28 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
-    it('Valid pagination on get operation w/ no limit param or response property', async () => {
-      const testDocument = makeCopy(rootDocument);
+    it.each(['3.0.0', '3.1.0'])(
+      'Valid pagination on get operation w/ no limit param or response property',
+      async function (oasVersion) {
+        const testDocument = makeCopy(rootDocument);
+        testDocument.openapi = oasVersion;
 
-      testDocument.components.schemas.DrinkCollection.allOf[0] =
-        makeCopy(offsetPaginationBase);
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
 
-      // Remove the limit param and limit response property from the "list_movies" operation.
-      testDocument.paths['/v1/movies'].get.parameters.splice(2, 1);
-      delete testDocument.components.schemas['TokenPaginationBase'].properties
-        .limit;
-      testDocument.components.schemas['TokenPaginationBase'].required.splice(
-        0,
-        1
-      );
+        // Remove the limit param and limit response property from the "list_movies" operation.
+        testDocument.paths['/v1/movies'].get.parameters.splice(2, 1);
+        delete testDocument.components.schemas['TokenPaginationBase'].properties
+          .limit;
+        testDocument.components.schemas['TokenPaginationBase'].required.splice(
+          0,
+          1
+        );
 
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(0);
-    });
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(0);
+      }
+    );
     it('Response indicates pagination, but operation has no parameters', async () => {
       const testDocument = makeCopy(rootDocument);
 

--- a/packages/ruleset/test/pattern-properties.test.js
+++ b/packages/ruleset/test/pattern-properties.test.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { patternProperties } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = patternProperties;
+const ruleId = 'ibm-patternProperties';
+const expectedSeverity = severityCodes.error;
+const expectedMessage1 = `patternProperties and additionalProperties are mutually exclusive`;
+const expectedMessage2 = `patternProperties must be an object`;
+const expectedMessage3 = `patternProperties must be a non-empty object`;
+const expectedMessage4 = `patternProperties must be an object with at most one entry`;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  beforeAll(() => {
+    rootDocument.openapi = '3.1.0';
+  });
+
+  describe('Should not yield errors', () => {
+    it('Clean spec - no patternProperties', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Valid patternProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        '^str.*$': {
+          type: 'string',
+        },
+      };
+      testDocument.components.schemas['Juice'].patternProperties = {
+        '^is.*$': {
+          type: 'boolean',
+        },
+      };
+      testDocument.components.schemas['Soda'].patternProperties = {
+        '^int.*$': {
+          type: 'integer',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('patternProperties specified with additionalProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        '^str.*$': {
+          type: 'string',
+        },
+      };
+      testDocument.components.schemas['Movie'].additionalProperties = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema',
+        'paths./v1/movies.post.responses.201.content.application/json.schema',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage1);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties is not an object', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = 'foo';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage2);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties is an empty object', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage3);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties contains > 1 entry', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        '^str.*$': {
+          type: 'string',
+        },
+        '^bool.*$': {
+          type: 'boolean',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage4);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});

--- a/packages/ruleset/test/pattern-properties.test.js
+++ b/packages/ruleset/test/pattern-properties.test.js
@@ -7,7 +7,7 @@ const { patternProperties } = require('../src/rules');
 const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 
 const rule = patternProperties;
-const ruleId = 'ibm-patternProperties';
+const ruleId = 'ibm-pattern-properties';
 const expectedSeverity = severityCodes.error;
 const expectedMessage1 = `patternProperties and additionalProperties are mutually exclusive`;
 const expectedMessage2 = `patternProperties must be an object`;

--- a/packages/ruleset/test/schema-type.test.js
+++ b/packages/ruleset/test/schema-type.test.js
@@ -30,27 +30,60 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Response schema, property defined correctly with nested allOf', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/movies'].post.responses['400'].content[
-        'application/json'
-      ].schema = {
-        type: 'object',
-        properties: {
-          no_type: {
-            allOf: [
-              {
-                allOf: [
-                  {
-                    description: 'nested allOf definition',
-                  },
-                  {
-                    type: 'string',
-                  },
-                ],
+      testDocument.paths['/v1/movies'].post.responses['400'] = {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                no_type: {
+                  allOf: [
+                    {
+                      allOf: [
+                        {
+                          description: 'nested allOf definition',
+                        },
+                        {
+                          type: 'string',
+                        },
+                      ],
+                    },
+                    {
+                      description: 'overridden description, but no type',
+                    },
+                  ],
+                },
               },
-              {
-                description: 'overridden description, but no type',
+            },
+          },
+        },
+      };
+
+      testDocument.paths['/v1/movies'].post.responses['401'] = {
+        content: {
+          'application/json': {
+            schema: {
+              type: ['object'],
+              properties: {
+                no_type: {
+                  allOf: [
+                    {
+                      allOf: [
+                        {
+                          description: 'nested allOf definition',
+                        },
+                        {
+                          type: ['string'],
+                        },
+                      ],
+                    },
+                    {
+                      description: 'overridden description, but no type',
+                    },
+                  ],
+                },
               },
-            ],
+            },
           },
         },
       };

--- a/packages/ruleset/test/string-attributes.test.js
+++ b/packages/ruleset/test/string-attributes.test.js
@@ -28,6 +28,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
             enum: ['fiction', 'nonfiction'],
           },
         },
+        {
+          name: 'sort_order',
+          in: 'query',
+          schema: {
+            type: ['string'],
+            enum: ['asc', 'desc'],
+          },
+        },
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -70,7 +78,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           name: 'trailer',
           in: 'query',
           schema: {
-            type: 'string',
+            type: ['string'],
             format: 'byte',
             minLength: 0,
             maxLength: 1024,
@@ -148,17 +156,42 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
       testDocument.paths['/v1/movies'].post.parameters = [
         {
-          name: 'ruleTester',
+          name: 'ruleTester1',
           in: 'query',
           schema: {
-            $ref: '#/components/schemas/RuleTester',
+            $ref: '#/components/schemas/RuleTester1',
+          },
+        },
+        {
+          name: 'ruleTester2',
+          in: 'query',
+          schema: {
+            $ref: '#/components/schemas/RuleTester2',
           },
         },
       ];
 
-      testDocument.components.schemas['RuleTester'] = {
+      testDocument.components.schemas['RuleTester1'] = {
         description: 'Tests string fields within allOf',
         type: 'string',
+        minLength: 1,
+        maxLength: 38,
+        allOf: [
+          {
+            minLength: 1,
+          },
+          {
+            maxLength: 38,
+          },
+          {
+            pattern: 'id:.*',
+          },
+        ],
+        example: 'example string',
+      };
+      testDocument.components.schemas['RuleTester2'] = {
+        description: 'Tests string fields within allOf',
+        type: ['string'],
         minLength: 1,
         maxLength: 38,
         allOf: [
@@ -217,7 +250,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           content: {
             'text/plain': {
               schema: {
-                type: 'string',
+                type: ['string'],
                 pattern: '[a-zA-Z0-9]+',
                 maxLength: 15,
               },
@@ -291,7 +324,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.paths['/v1/movies'].post.requestBody.content['text/plain'] =
         {
           schema: {
-            type: 'integer',
+            type: ['integer', 'null', 'boolean'],
             minLength: 15,
           },
         };
@@ -371,14 +404,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
               {
                 anyOf: [
                   {
-                    type: 'string',
+                    type: ['string'],
                     maxLength: 10,
                     minLength: 1,
                   },
                   {
                     oneOf: [
                       {
-                        type: 'string',
+                        type: ['string'],
                         maxLength: 10,
                         minLength: 1,
                       },
@@ -409,7 +442,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           name: 'filter',
           in: 'query',
           schema: {
-            type: 'string',
+            type: ['string'],
             minLength: 1,
             maxLength: 15,
           },
@@ -487,7 +520,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.components.schemas['RuleTester'] = {
         description: 'Tests pattern field within anyOf',
-        type: 'string',
+        type: ['string'],
         minLength: 1,
         maxLength: 38,
         oneOf: [

--- a/packages/ruleset/test/unevaluated-properties.test.js
+++ b/packages/ruleset/test/unevaluated-properties.test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { unevaluatedProperties } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = unevaluatedProperties;
+const ruleId = 'ibm-unevaluated-properties';
+const expectedSeverity = severityCodes.error;
+const expectedMsg = `unevaluatedProperties must be set to false, if present`;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  beforeAll(() => {
+    rootDocument.openapi = '3.1.0';
+  });
+
+  describe('Should not yield errors', () => {
+    it('Clean spec - no unevaluatedProperties', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('unevaluatedProperties set to false', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].unevaluatedProperties = false;
+      testDocument.components.schemas['Juice'].unevaluatedProperties = false;
+      testDocument.components.schemas['Soda'].unevaluatedProperties = false;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('unevaluatedProperties set to true', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].unevaluatedProperties = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.unevaluatedProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.unevaluatedProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.unevaluatedProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.unevaluatedProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.unevaluatedProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('unevaluatedProperties set to a schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas[
+        'DrinkCollection'
+      ].allOf[1].unevaluatedProperties = {
+        type: 'string',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.unevaluatedProperties'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/utils/test-rule.js
+++ b/packages/ruleset/test/utils/test-rule.js
@@ -21,11 +21,6 @@ module.exports = async (ruleName, rule, doc) => {
     },
   });
 
-  try {
-    const results = await spectral.run(doc);
-    return results;
-  } catch (err) {
-    console.error(err);
-    throw err;
-  }
+  const results = await spectral.run(doc);
+  return results;
 };

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/IBM/openapi-validator",
   "scripts": {
     "clean": "rm -rf node_modules",
+    "jest": "jest",
     "test": "jest test",
     "test-travis": "jest --silent --runInBand --no-colors --testNamePattern='^((?!@skip-ci).)*$' test",
     "lint": "eslint --cache --quiet --ext '.js' src test",

--- a/packages/utilities/src/utils/get-schema-type.js
+++ b/packages/utilities/src/utils/get-schema-type.js
@@ -295,7 +295,8 @@ const isObjectSchema = schema => {
       (!('type' in s) &&
         (isObject(s.properties) ||
           s.additionalProperties === true ||
-          isObject(s.additionalProperties)))
+          isObject(s.additionalProperties) ||
+          isObject(s.patternProperties)))
     );
   });
 };

--- a/packages/utilities/src/utils/validate-nested-schemas.js
+++ b/packages/utilities/src/utils/validate-nested-schemas.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
+const isObject = require('./is-object');
+
 /*
  * Performs validation on a schema and all of its nested schemas.
  *
@@ -29,6 +31,13 @@ const validateNestedSchemas = (
   includeSelf = true,
   includeNot = false
 ) => {
+  // Make sure 'schema' is an object.
+  if (!isObject(schema)) {
+    throw new Error(
+      `the entity at location ${path.join('.')} must be a schema object`
+    );
+  }
+
   // If "schema" is a $ref, that means it didn't get resolved
   // properly (perhaps due to a circular ref), so just ignore it.
   if (schema.$ref) {
@@ -107,6 +116,23 @@ const validateNestedSchemas = (
           )
         );
       });
+    }
+  }
+
+  if (
+    schema.patternProperties &&
+    typeof schema.patternProperties === 'object'
+  ) {
+    for (const entry of Object.entries(schema.patternProperties)) {
+      errors.push(
+        ...validateNestedSchemas(
+          entry[1],
+          [...path, 'patternProperties', entry[0]],
+          validate,
+          true,
+          includeNot
+        )
+      );
     }
   }
 

--- a/packages/utilities/test/get-schema-type.test.js
+++ b/packages/utilities/test/get-schema-type.test.js
@@ -10,69 +10,128 @@ const { getSchemaType, SchemaType } = require('../src');
  * so these tests are very limited.
  */
 describe('Utility function: getSchemaType()', () => {
-  it('should return `SchemaType.ARRAY` for `type` of `array`', async () => {
-    expect(getSchemaType({ type: 'array' })).toBe(SchemaType.ARRAY);
+  describe('type is a string', () => {
+    it('type=array (ARRAY)', async () => {
+      expect(getSchemaType({ type: 'array' })).toBe(SchemaType.ARRAY);
+    });
+    it('type=boolean (BOOLEAN)', async () => {
+      expect(getSchemaType({ type: 'boolean' })).toBe(SchemaType.BOOLEAN);
+    });
+    it('type=string, format=date (DATE)', async () => {
+      expect(getSchemaType({ type: 'string', format: 'date' })).toBe(
+        SchemaType.DATE
+      );
+    });
+    it('type=string, format=date-time (DATE_TIME)', async () => {
+      expect(getSchemaType({ type: 'string', format: 'date-time' })).toBe(
+        SchemaType.DATE_TIME
+      );
+    });
+    it('type=number, format=double (DOUBLE)', async () => {
+      expect(getSchemaType({ type: 'number', format: 'double' })).toBe(
+        SchemaType.DOUBLE
+      );
+    });
+    it('type=string, enum present (ENUMERATION)', async () => {
+      expect(getSchemaType({ type: 'string', enum: ['one', 'two'] })).toBe(
+        SchemaType.ENUMERATION
+      );
+    });
+    it('type=number, format=float (FLOAT)', async () => {
+      expect(getSchemaType({ type: 'number', format: 'float' })).toBe(
+        SchemaType.FLOAT
+      );
+    });
+    it('type=integer, format=int32 (INT32)', async () => {
+      expect(getSchemaType({ type: 'integer', format: 'int32' })).toBe(
+        SchemaType.INT32
+      );
+    });
+    it('type=integer, format=int64 (INT64)', async () => {
+      expect(getSchemaType({ type: 'integer', format: 'int64' })).toBe(
+        SchemaType.INT64
+      );
+    });
+    it('type=integer (INTEGER)', async () => {
+      expect(getSchemaType({ type: 'integer' })).toBe(SchemaType.INTEGER);
+    });
+
+    it('type=number (NUMBER)', async () => {
+      expect(getSchemaType({ type: 'number' })).toBe(SchemaType.NUMBER);
+    });
+    it('type=object (OBJECT)', async () => {
+      expect(getSchemaType({ type: 'object' })).toBe(SchemaType.OBJECT);
+    });
+    it('type=string (STRING)', async () => {
+      expect(getSchemaType({ type: 'string' })).toBe(SchemaType.STRING);
+    });
   });
 
-  it('should return `SchemaType.BOOLEAN` for `type` of `boolean`', async () => {
-    expect(getSchemaType({ type: 'boolean' })).toBe(SchemaType.BOOLEAN);
-  });
+  describe('type is a list', () => {
+    it('type contains array (ARRAY)', async () => {
+      expect(getSchemaType({ type: ['array'] })).toBe(SchemaType.ARRAY);
+    });
 
-  it('should return `SchemaType.DATE` for `type` of `string` and `format` of `date`', async () => {
-    expect(getSchemaType({ type: 'string', format: 'date' })).toBe(
-      SchemaType.DATE
-    );
-  });
+    it('type contains boolean (BOOLEAN)', async () => {
+      expect(getSchemaType({ type: ['boolean'] })).toBe(SchemaType.BOOLEAN);
+    });
 
-  it('should return `SchemaType.DATE_TIME` for `type` of `string` and `format` of `date-time`', async () => {
-    expect(getSchemaType({ type: 'string', format: 'date-time' })).toBe(
-      SchemaType.DATE_TIME
-    );
-  });
+    it('type contains string, format=date (DATE)', async () => {
+      expect(getSchemaType({ type: ['string'], format: 'date' })).toBe(
+        SchemaType.DATE
+      );
+    });
 
-  it('should return `SchemaType.DOUBLE` for `type` of `number` and `format` of `double`', async () => {
-    expect(getSchemaType({ type: 'number', format: 'double' })).toBe(
-      SchemaType.DOUBLE
-    );
-  });
+    it('type contains string, format=date-time (DATE_TIME)', async () => {
+      expect(getSchemaType({ type: ['string'], format: 'date-time' })).toBe(
+        SchemaType.DATE_TIME
+      );
+    });
 
-  it('should return `SchemaType.ENUMERATION` for `type` of `string` and an `enum` array of strings', async () => {
-    expect(getSchemaType({ type: 'string', enum: ['one', 'two'] })).toBe(
-      SchemaType.ENUMERATION
-    );
-  });
+    it('type contains number, format=double (DOUBLE)', async () => {
+      expect(getSchemaType({ type: ['number'], format: 'double' })).toBe(
+        SchemaType.DOUBLE
+      );
+    });
 
-  it('should return `SchemaType.FLOAT` for `type` of `number` and `format` of `float`', async () => {
-    expect(getSchemaType({ type: 'number', format: 'float' })).toBe(
-      SchemaType.FLOAT
-    );
-  });
+    it('type contains string, enum is present (ENUMERATION)', async () => {
+      expect(getSchemaType({ type: ['string'], enum: ['one', 'two'] })).toBe(
+        SchemaType.ENUMERATION
+      );
+    });
 
-  it('should return `SchemaType.INT32` for `type` of `integer` and `format` of `int32`', async () => {
-    expect(getSchemaType({ type: 'integer', format: 'int32' })).toBe(
-      SchemaType.INT32
-    );
-  });
+    it('type contains number, format=float (FLOAT)', async () => {
+      expect(getSchemaType({ type: ['number'], format: 'float' })).toBe(
+        SchemaType.FLOAT
+      );
+    });
 
-  it('should return `SchemaType.INT64` for `type` of `integer` and `format` of `int64`', async () => {
-    expect(getSchemaType({ type: 'integer', format: 'int64' })).toBe(
-      SchemaType.INT64
-    );
-  });
+    it('type contains integer, format=int32 (INT32)', async () => {
+      expect(getSchemaType({ type: ['integer'], format: 'int32' })).toBe(
+        SchemaType.INT32
+      );
+    });
 
-  it('should return `SchemaType.INTEGER` for `type` of `integer`', async () => {
-    expect(getSchemaType({ type: 'integer' })).toBe(SchemaType.INTEGER);
-  });
+    it('type contains integer, format=int64 (INT64)', async () => {
+      expect(getSchemaType({ type: ['integer'], format: 'int64' })).toBe(
+        SchemaType.INT64
+      );
+    });
 
-  it('should return `SchemaType.NUMBER` for `type` of `number`', async () => {
-    expect(getSchemaType({ type: 'number' })).toBe(SchemaType.NUMBER);
-  });
+    it('type contains integer (INTEGER)', async () => {
+      expect(getSchemaType({ type: ['integer'] })).toBe(SchemaType.INTEGER);
+    });
 
-  it('should return `SchemaType.OBJECT` for `type` of `object`', async () => {
-    expect(getSchemaType({ type: 'object' })).toBe(SchemaType.OBJECT);
-  });
+    it('type contains number (NUMBER)', async () => {
+      expect(getSchemaType({ type: ['number'] })).toBe(SchemaType.NUMBER);
+    });
 
-  it('should return `SchemaType.STRING` for `type` of `string`', async () => {
-    expect(getSchemaType({ type: 'string' })).toBe(SchemaType.STRING);
+    it('type contains object (OBJECT)', async () => {
+      expect(getSchemaType({ type: ['object'] })).toBe(SchemaType.OBJECT);
+    });
+
+    it('type contains string (STRING)', async () => {
+      expect(getSchemaType({ type: ['string'] })).toBe(SchemaType.STRING);
+    });
   });
 });

--- a/packages/utilities/test/is-array-schema.test.js
+++ b/packages/utilities/test/is-array-schema.test.js
@@ -26,8 +26,7 @@ describe('Utility function: isArraySchema()', () => {
     expect(isArraySchema({ type: 'array' })).toBe(true);
   });
 
-  // Skipped: debatable whether this test ought to pass, but maybe for OAS 3.1 support
-  it.skip('should return `true` for an object with `type` of ["array"]', async () => {
+  it('should return `true` if `type` contains "array"', async () => {
     expect(isArraySchema({ type: ['array'] })).toBe(true);
   });
 
@@ -51,6 +50,16 @@ describe('Utility function: isArraySchema()', () => {
             allOf: [{ anyOf: [{ items: {} }, { type: 'array' }] }, {}],
           },
           { type: 'array' },
+        ],
+      })
+    ).toBe(true);
+    expect(
+      isArraySchema({
+        oneOf: [
+          {
+            allOf: [{ anyOf: [{ items: {} }, { type: ['array'] }] }, {}],
+          },
+          { type: ['array'] },
         ],
       })
     ).toBe(true);

--- a/packages/utilities/test/is-object-schema.test.js
+++ b/packages/utilities/test/is-object-schema.test.js
@@ -41,8 +41,30 @@ describe('Utility function: isObjectSchema()', () => {
     expect(isObjectSchema({ additionalProperties: {} })).toBe(true);
   });
 
-  it('should return `false` for an object with non-"object" `type` and an `properties` object', async () => {
+  it('should return `false` for an object with no `type` and an `additionalProperties` of `false`', async () => {
+    expect(isObjectSchema({ additionalProperties: false })).toBe(false);
+  });
+
+  it('should return `true` for an object with no `type` and a `patternProperties` object', async () => {
+    expect(
+      isObjectSchema({ patternProperties: { '.*': { type: 'string' } } })
+    ).toBe(true);
+  });
+
+  it('should return `false` for an object with no `type` and a `patternProperties` not an object', async () => {
+    expect(
+      isObjectSchema({
+        patternProperties: 'bad patternProperties object!',
+      })
+    ).toBe(false);
+  });
+
+  it('should return `false` for an object with non-"object" `type` and a `properties` object', async () => {
     expect(isObjectSchema({ type: 'array', properties: {} })).toBe(false);
+  });
+
+  it('should return `false` for a non-object value for "schema"', async () => {
+    expect(isObjectSchema('this is not a schema object')).toBe(false);
   });
 
   it('should return `false` for an object with no `type` and a non-object `properties`', async () => {

--- a/packages/utilities/test/is-object-schema.test.js
+++ b/packages/utilities/test/is-object-schema.test.js
@@ -25,9 +25,7 @@ describe('Utility function: isObjectSchema()', () => {
   it('should return `true` for an object with `type` of "object"', async () => {
     expect(isObjectSchema({ type: 'object' })).toBe(true);
   });
-
-  // Skipped: debatable whether this test ought to pass, but maybe for OAS 3.1 support
-  it.skip('should return `true` for an object with `type` of ["object"]', async () => {
+  it('should return `true` for an object if `type` contains "object"', async () => {
     expect(isObjectSchema({ type: ['object'] })).toBe(true);
   });
 
@@ -59,6 +57,16 @@ describe('Utility function: isObjectSchema()', () => {
             allOf: [{ properties: {} }, {}],
           },
           { type: 'object' },
+        ],
+      })
+    ).toBe(true);
+    expect(
+      isObjectSchema({
+        oneOf: [
+          {
+            allOf: [{ properties: {} }, {}],
+          },
+          { type: ['object'] },
         ],
       })
     ).toBe(true);

--- a/packages/utilities/test/schema-is-of-type.test.js
+++ b/packages/utilities/test/schema-is-of-type.test.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { schemaIsOfType } = require('../src');
+
+describe('Utility function: schemaIsOfType()', () => {
+  describe('Should return true', () => {
+    it('single type: null', async () => {
+      expect(schemaIsOfType({ type: 'null' }, 'null')).toBe(true);
+    });
+    it('single type: boolean', async () => {
+      expect(schemaIsOfType({ type: 'boolean' }, 'boolean')).toBe(true);
+    });
+    it('single type: string', async () => {
+      expect(schemaIsOfType({ type: 'string' }, 'string')).toBe(true);
+    });
+    it('single type: number', async () => {
+      expect(schemaIsOfType({ type: 'number' }, 'number')).toBe(true);
+    });
+    it('single type: integer', async () => {
+      expect(schemaIsOfType({ type: 'integer' }, 'integer')).toBe(true);
+    });
+    it('single type: object', async () => {
+      expect(schemaIsOfType({ type: 'object' }, 'object')).toBe(true);
+    });
+    it('single type: array', async () => {
+      expect(schemaIsOfType({ type: 'array' }, 'array')).toBe(true);
+    });
+
+    it('multiple types: null', async () => {
+      expect(
+        schemaIsOfType({ type: ['array', 'string', 'null'] }, 'null')
+      ).toBe(true);
+    });
+    it('multiple types: boolean', async () => {
+      expect(
+        schemaIsOfType({ type: ['string', 'null', 'boolean'] }, 'boolean')
+      ).toBe(true);
+    });
+    it('multiple types: string', async () => {
+      expect(
+        schemaIsOfType({ type: ['string', 'null', 'boolean'] }, 'string')
+      ).toBe(true);
+    });
+    it('multiple types: number', async () => {
+      expect(
+        schemaIsOfType({ type: ['string', 'number', 'boolean'] }, 'number')
+      ).toBe(true);
+    });
+    it('multiple types: integer', async () => {
+      expect(
+        schemaIsOfType({ type: ['string', 'null', 'integer'] }, 'integer')
+      ).toBe(true);
+    });
+    it('multiple types: object', async () => {
+      expect(
+        schemaIsOfType({ type: ['string', 'object', 'boolean'] }, 'object')
+      ).toBe(true);
+    });
+    it('multiple types: array', async () => {
+      expect(schemaIsOfType({ type: ['string', 'array'] }, 'array')).toBe(true);
+    });
+  });
+  describe('Should return false', () => {
+    it('single type: not null', async () => {
+      expect(schemaIsOfType({ type: 'string' }, 'null')).toBe(false);
+    });
+    it('single type: not boolean', async () => {
+      expect(schemaIsOfType({ type: 'string' }, 'boolean')).toBe(false);
+    });
+    it('single type: not string', async () => {
+      expect(schemaIsOfType({ type: 'integer' }, 'string')).toBe(false);
+    });
+    it('single type: not number', async () => {
+      expect(schemaIsOfType({ type: 'array' }, 'number')).toBe(false);
+    });
+    it('single type: not integer', async () => {
+      expect(schemaIsOfType({ type: 'number' }, 'integer')).toBe(false);
+    });
+    it('single type: not object', async () => {
+      expect(schemaIsOfType({ type: 'array' }, 'object')).toBe(false);
+    });
+    it('single type: not array', async () => {
+      expect(schemaIsOfType({ type: 'object' }, 'array')).toBe(false);
+    });
+
+    it('multiple types: not null', async () => {
+      expect(schemaIsOfType({ type: ['array', 'string'] }, 'null')).toBe(false);
+    });
+    it('multiple types: not boolean', async () => {
+      expect(schemaIsOfType({ type: ['null', 'string'] }, 'boolean')).toBe(
+        false
+      );
+    });
+    it('multiple types: not string', async () => {
+      expect(schemaIsOfType({ type: ['array', 'boolean'] }, 'string')).toBe(
+        false
+      );
+    });
+    it('multiple types: not number', async () => {
+      expect(schemaIsOfType({ type: ['object', 'array'] }, 'number')).toBe(
+        false
+      );
+    });
+    it('multiple types: not integer', async () => {
+      expect(schemaIsOfType({ type: ['number', 'boolean'] }, 'integer')).toBe(
+        false
+      );
+    });
+    it('multiple types: not object', async () => {
+      expect(schemaIsOfType({ type: ['array', 'null'] }, 'object')).toBe(false);
+    });
+    it('multiple types: not array', async () => {
+      expect(
+        schemaIsOfType(
+          {
+            type: ['null', 'string', 'integer', 'number', 'object', 'boolean'],
+          },
+          'array'
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -1,5 +1,6 @@
 # OpenAPI Validator
-The IBM OpenAPI Validator lets you validate OpenAPI 3.x documents according to the [OpenAPI 3.x specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md), as well as IBM-defined best practices.
+The IBM OpenAPI Validator lets you validate [OpenAPI 3.0.x](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
+and [OpenAPI 3.1.x](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md) documents for compliance with the OpenAPI specifications, as well as IBM-defined best practices.
 
 Note: this page displays abbreviated usage info for getting started. Visit [this page](../../README.md) for the full documentation.
 

--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -185,9 +185,9 @@ async function runValidator(cliArgs, parseOptions = {}) {
 
       if (
         typeof input.openapi !== 'string' ||
-        input.openapi.match(/3\.0\.[0-9]+/) === null
+        input.openapi.match(/3\.[0-1]\.[0-9]+/) === null
       ) {
-        throw 'Only OpenAPI 3.0.x documents are currently supported.';
+        throw 'Only OpenAPI 3.0.x and 3.1.x documents are currently supported.';
       }
     } catch (err) {
       logError(`Invalid input file: ${validFile}. See below for details.`, err);

--- a/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
@@ -1,0 +1,217 @@
+openapi: "3.1.0"
+info:
+  description: Sample API definition that validates cleanly
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  contact:
+    email: "apiteam@swagger.io"
+servers:
+  - url: http://petstore.swagger.io/v1
+tags:
+  - name: pets
+    description: A pet
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      description: List all pets
+      operationId: list_pets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            maximum: 100
+        - name: offset
+          in: query
+          description: Offset of first element to return in results.
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              schema:
+                type: string
+                description: A link to the next page of responses
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      description: Create a pet
+      operationId: create_pets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: success!
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{pet_id}:
+    get:
+      summary: Info for a specific pet
+      description: Get information about a specific pet
+      operationId: get_pet_by_id
+      tags:
+        - pets
+      parameters:
+        - name: pet_id
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+            pattern: '[0-9]+'
+            minLength: 1
+            maxLength: 100
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      description:
+        A pet
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: "id property"
+        name:
+          type: string
+          description: "name property"
+          pattern: '[a-zA-Z0-9]+'
+          minLength: 1
+          maxLength: 50
+        tag:
+          type: string
+          description: "tag property"
+          pattern: '[a-zA-Z0-9]+'
+          minLength: 1
+          maxLength: 50
+      example:
+        id: 1
+        name: doggie
+        tag: dog
+    Pets:
+      type: object
+      description:
+        A list of pets
+      required:
+        - pets
+        - limit
+        - offset
+      properties:
+        pets:
+          type: array
+          minItems: 0
+          maxItems: 20
+          description: "object containing a list of pets"
+          items:
+            $ref: "#/components/schemas/Pet"
+        limit:
+          type: integer
+          format: int32
+          description: limit
+        offset:
+          type: integer
+          format: int32
+          description: offset
+        next_token:
+          type: string
+          description: next token
+        first:
+          allOf:
+            - $ref: '#/components/schemas/PageLink'
+            - description: Link to the first page of results
+        last:
+          allOf:
+            - $ref: '#/components/schemas/PageLink'
+            - description: Link to the last page of results
+        previous:
+          allOf:
+            - $ref: '#/components/schemas/PageLink'
+            - description: Link to the previous page of results
+        next:
+          allOf:
+            - $ref: '#/components/schemas/PageLink'
+            - description: Link to the next page of results
+      example:
+        pets:
+        - id: 1
+          name: doggie
+          tag: dog
+        next_url: 'https://www.nexturl.com'
+        limit: 50
+        offset: 20
+        next_token: TOKEN_STRING
+    PageLink:
+      type: object
+      description: Link to a page of results
+      properties:
+        href:
+          description: Request URL string
+          type: string
+    Error:
+      type: object
+      description:
+        An error in processing a service request
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: "code property"
+        message:
+          type: string
+          description: "message property"
+          pattern: '^[a-zA-Z0-9_ ]*$'
+          minLength: 1
+          maxLength: 300
+      example:
+        code: 123
+        message: "error occurred"

--- a/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
@@ -31,13 +31,15 @@ paths:
             format: int32
             default: 10
             maximum: 100
-        - name: offset
+        - name: start
           in: query
-          description: Offset of first element to return in results.
+          description: A token which indicates the first item to return
           required: false
           schema:
-            type: integer
-            format: int32
+            type: string
+            pattern: '[a-zA-Z0-9 ]+'
+            minLength: 1
+            maxLength: 128
       responses:
         '200':
           description: A paged array of pets
@@ -142,7 +144,6 @@ components:
       required:
         - pets
         - limit
-        - offset
       properties:
         pets:
           type: array
@@ -155,10 +156,6 @@ components:
           type: integer
           format: int32
           description: limit
-        offset:
-          type: integer
-          format: int32
-          description: offset
         next_token:
           type: string
           description: next token
@@ -185,7 +182,6 @@ components:
           tag: dog
         next_url: 'https://www.nexturl.com'
         limit: 50
-        offset: 20
         next_token: TOKEN_STRING
     PageLink:
       type: object

--- a/packages/validator/test/cli-validator/mock-files/oas31/component-path-example.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/component-path-example.yaml
@@ -1,0 +1,141 @@
+openapi: "3.1.0"
+info:
+  description: Sample API definition with one problem in two instances
+  version: 1.0.0
+  title: Character Supply
+  license:
+    name: MIT
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  contact:
+    email: "apiteam@swagger.io"
+servers:
+  - url: http://chars.swagger.io/v1
+tags:
+  - name: letters
+    description: A letter
+  - name: special_characters
+    description: A special character
+paths:
+  /letters:
+    get:
+      summary: List all letters
+      description: List all letters
+      operationId: list_letters
+      tags:
+        - letters
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            maximum: 100
+        - name: offset
+          in: query
+          description: Offset of first element to return in results.
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          $ref: "#/components/responses/StringsResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /special_characters:
+    get:
+      summary: List all special characters
+      description: List all special characters
+      operationId: list_special_characters
+      tags:
+        - special_characters
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            maximum: 100
+        - name: offset
+          in: query
+          description: Offset of first element to return in results.
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          $ref: "#/components/responses/StringsResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  responses:
+    StringsResponse:
+      description: not very good
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ListOfCharacters"
+  schemas:
+    ListOfCharacters:
+      description: object holding a list of strings
+      type: object
+      required:
+        - chars
+        - limit
+        - offset
+      properties:
+        chars:
+          type: array
+          minItems: 0
+          maxItems: 200
+          description: all the characters
+          items:
+            type: string
+        limit:
+          type: integer
+          description: for pagination
+        offset:
+          type: integer
+          description: for pagination
+      example:
+        chars:
+          - a
+          - b
+          - c
+        limit: 100
+        offset: 10
+    Error:
+      description:
+        An error in processing a service request
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: "code property"
+        message:
+          type: string
+          description: "message property"
+          pattern: '^[a-zA-Z0-9_ ]*$'
+          minLength: 1
+          maxLength: 300
+      example:
+        code: 123
+        message: "error occurred"

--- a/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
@@ -1,0 +1,215 @@
+openapi: 3.1.0
+info:
+  description: "This is a sample server Petstore server.  You can find out more
+    about     Swagger at [http://swagger.io](http://swagger.io) or on
+    [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample,
+    you can use the api key `special-key` to test the
+    authorization     filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: " "
+      operationId: " "
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+      x-codegen-request-body-name: body
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: put new data for existing pet
+      operationId: " "
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+      x-codegen-request-body-name: body
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        "405":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/find_by_status:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: find_pets_by_status
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            minItems: 0
+            maxItems: 20
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                minItems: 0
+                maxItems: 20
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                minItems: 0
+                maxItems: 20
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: http://petstore.swagger.io/v2
+components:
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          description: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      description: string
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: string
+        name:
+          type: string
+          description: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      description: string
+      required:
+        - name
+        - photo_urls
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: string
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+          description: string
+        photo_urls:
+          type: array
+          description: string
+          minItems: 0
+          maxItems: 20
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          description: string
+          minItems: 0
+          maxItems: 20
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    UnusedString:
+      description: string
+      type: string

--- a/packages/validator/test/cli-validator/mock-files/oas31/warn-threshold.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/warn-threshold.yml
@@ -1,0 +1,310 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.",
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {
+            "email": "apiteam@swagger.io"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "tags": [
+        {
+            "name": "pet",
+            "description": "Everything about your Pets",
+            "externalDocs": {
+                "description": "Find out more",
+                "url": "http://swagger.io"
+            }
+        },
+        {
+            "name": "store",
+            "description": "Access to Petstore orders"
+        },
+        {
+            "name": "user",
+            "description": "Operations about user",
+            "externalDocs": {
+                "description": "Find out more about our store",
+                "url": "http://swagger.io"
+            }
+        }
+    ],
+    "paths": {
+        "/pet": {
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Add a new pet to the store",
+                "description": "post a pet to store",
+                "operationId": "  ",
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/Pet"
+                },
+                "x-codegen-request-body-name": "body",
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Update an existing pet",
+                "description": "put new data for existing pet",
+                "operationId": "update_pet",
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/Pet"
+                },
+                "x-codegen-request-body-name": "body",
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    },
+                    "405": {
+                        "description": "Validation exception"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pet/find_by_status": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by status",
+                "description": "Multiple status values can be provided with comma separated strings",
+                "operationId": "find_pets_by_status",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Status values that need to be considered for filter",
+                        "required": true,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "available",
+                                    "pending",
+                                    "sold"
+                                ],
+                                "default": "available"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pets": {
+                                            "type": "array",
+                                            "description": "list of pets",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Pet"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pets": {
+                                            "type": "array",
+                                            "description": "list of pets",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Pet"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid status value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+    },
+    "servers": [
+        {
+            "url": "http://petstore.swagger.io/v2"
+        }
+    ],
+    "components": {
+        "requestBodies": {
+            "Pet": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    },
+                    "application/xml": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    }
+                },
+                "description": "Pet object that needs to be added to the store",
+                "required": true
+            }
+        },
+        "securitySchemes": {
+            "petstore_auth": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                        "scopes": {
+                            "write:pets": "modify pets in your account",
+                            "read:pets": "read your pets"
+                        }
+                    }
+                }
+            }
+        },
+        "schemas": {
+            "Category": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "string"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Category"
+                }
+            },
+            "Tag": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "string"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Tag"
+                }
+            },
+            "Pet": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "photo_urls"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": ""
+                    },
+                    "category": {
+                        "$ref": "#/components/schemas/Category"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "doggie",
+                        "description": ""
+                    },
+                    "photo_urls": {
+                        "type": "array",
+                        "description": "",
+                        "xml": {
+                            "name": "photo_url",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "description": "",
+                        "xml": {
+                            "name": "tag",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "$ref": "#/components/schemas/Tag"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "",
+                        "enum": [
+                            "available",
+                            "pending",
+                            "sold"
+                        ]
+                    }
+                },
+                "xml": {
+                    "name": "Pet"
+                }
+            }
+        }
+    }
+}

--- a/packages/validator/test/cli-validator/tests/error-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/error-handling.test.js
@@ -130,29 +130,7 @@ describe('cli tool - test error handling', function () {
       '[ERROR] Invalid input file: ./test/cli-validator/mock-files/swagger-2.json. See below for details.'
     );
     expect(capturedText[4].trim()).toEqual(
-      '[ERROR] Only OpenAPI 3.0.x documents are currently supported.'
-    );
-  });
-
-  it('should return an error when a file contains an OpenAPI 3.1.x document', async function () {
-    let exitCode;
-    try {
-      exitCode = await testValidator([
-        './test/cli-validator/mock-files/openapi-3-1.json',
-      ]);
-    } catch (err) {
-      exitCode = err;
-    }
-
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-
-    expect(exitCode).toEqual(1);
-    expect(capturedText.length).toEqual(5);
-    expect(capturedText[3].trim()).toEqual(
-      '[ERROR] Invalid input file: ./test/cli-validator/mock-files/openapi-3-1.json. See below for details.'
-    );
-    expect(capturedText[4].trim()).toEqual(
-      '[ERROR] Only OpenAPI 3.0.x documents are currently supported.'
+      '[ERROR] Only OpenAPI 3.0.x and 3.1.x documents are currently supported.'
     );
   });
 

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -26,81 +26,85 @@ describe('Expected output tests', function () {
   });
 
   describe('OpenAPI 3', function () {
-    it('should not produce any errors or warnings from a clean file', async function () {
-      const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/clean.yml',
-      ]);
-      expect(exitCode).toEqual(0);
+    it.each(['oas3', 'oas31'])(
+      'should not produce any errors or warnings from a clean file',
+      async function (oasVersion) {
+        const filename = `./test/cli-validator/mock-files/${oasVersion}/clean.yml`;
+        const exitCode = await testValidator([filename]);
+        expect(exitCode).toEqual(0);
 
-      const capturedText = getCapturedText(consoleSpy.mock.calls);
-      const allOutput = capturedText.join('');
+        const capturedText = getCapturedText(consoleSpy.mock.calls);
+        const allOutput = capturedText.join('');
 
-      expect(allOutput).toContain(
-        './test/cli-validator/mock-files/oas3/clean.yml passed the validator'
-      );
-    });
+        expect(allOutput).toContain(`${filename} passed the validator`);
+      }
+    );
 
-    it('should produce errors, then warnings from mock-files/oas3/err-and-warn.yaml', async function () {
-      const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
-      ]);
+    it.each(['oas3', 'oas31'])(
+      'should produce errors and warnings from err-and-warn.yaml',
+      async function (oasVersion) {
+        const filename = `./test/cli-validator/mock-files/${oasVersion}/err-and-warn.yaml`;
+        const exitCode = await testValidator([filename]);
+        const capturedText = getCapturedText(consoleSpy.mock.calls);
+        // originalError('Captured text:\n', capturedText);
+        expect(exitCode).toEqual(1);
 
-      const capturedText = getCapturedText(consoleSpy.mock.calls);
-      // originalError('Captured text:\n', capturedText);
+        const whichProblems = [];
+        capturedText.forEach(function (line) {
+          if (line.includes('errors')) {
+            whichProblems.push('errors');
+          }
+          if (line.includes('warnings')) {
+            whichProblems.push('warnings');
+          }
+        });
 
-      expect(exitCode).toEqual(1);
+        expect(whichProblems[0]).toEqual('errors');
+        expect(whichProblems[1]).toEqual('warnings');
+      }
+    );
 
-      const whichProblems = [];
-      capturedText.forEach(function (line) {
-        if (line.includes('errors')) {
-          whichProblems.push('errors');
-        }
-        if (line.includes('warnings')) {
-          whichProblems.push('warnings');
-        }
-      });
+    it.each(['oas3', 'oas31'])(
+      'should print the correct line numbers for each error/warning',
+      async function (oasVersion) {
+        const filename = `./test/cli-validator/mock-files/${oasVersion}/err-and-warn.yaml`;
+        const exitCode = await testValidator([filename]);
+        expect(exitCode).toEqual(1);
 
-      expect(whichProblems[0]).toEqual('errors');
-      expect(whichProblems[1]).toEqual('warnings');
-    });
+        const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-    it('should print the correct line numbers for each error/warning', async function () {
-      const exitCode = await testValidator([
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
-      ]);
-      expect(exitCode).toEqual(1);
+        // This can be uncommented to display the output when adjustments to
+        // the expect statements below are needed.
+        // let textOutput = '';
+        // capturedText.forEach((elem, index) => {
+        //   textOutput += `[${index}]: ${elem}\n`;
+        // });
+        // originalError(textOutput);
 
-      const capturedText = getCapturedText(consoleSpy.mock.calls);
+        // errors
+        const errorStart = 3;
+        expect(capturedText[errorStart + 5].match(/\S+/g)[2]).toEqual('52');
+        expect(capturedText[errorStart + 10].match(/\S+/g)[2]).toEqual('96');
+        expect(capturedText[errorStart + 15].match(/\S+/g)[2]).toEqual('103');
 
-      // This can be uncommented to display the output when adjustments to
-      // the expect statements below are needed.
-      // let textOutput = '';
-      // capturedText.forEach((elem, index) => {
-      //   textOutput += `[${index}]: ${elem}\n`;
-      // });
-      // originalError(textOutput);
-
-      // errors
-      const errorStart = 3;
-      expect(capturedText[errorStart + 5].match(/\S+/g)[2]).toEqual('52');
-      expect(capturedText[errorStart + 10].match(/\S+/g)[2]).toEqual('96');
-      expect(capturedText[errorStart + 15].match(/\S+/g)[2]).toEqual('103');
-
-      // warnings
-      const warningStart = 20;
-      expect(capturedText[warningStart + 5].match(/\S+/g)[2]).toEqual('22');
-      expect(capturedText[warningStart + 10].match(/\S+/g)[2]).toEqual('24');
-      expect(capturedText[warningStart + 15].match(/\S+/g)[2]).toEqual('40');
-      expect(capturedText[warningStart + 20].match(/\S+/g)[2]).toEqual('41');
-      expect(capturedText[warningStart + 25].match(/\S+/g)[2]).toEqual('52');
-      expect(capturedText[warningStart + 30].match(/\S+/g)[2]).toEqual('56');
-      expect(capturedText[warningStart + 35].match(/\S+/g)[2]).toEqual('57');
-      expect(capturedText[warningStart + 40].match(/\S+/g)[2]).toEqual('59');
-      expect(capturedText[warningStart + 45].match(/\S+/g)[2]).toEqual('61');
-      expect(capturedText[warningStart + 50].match(/\S+/g)[2]).toEqual('96');
-      // Skip a few, then verify the last one.
-      expect(capturedText[warningStart + 145].match(/\S+/g)[2]).toEqual('213');
-    });
+        // warnings
+        const warningStart = 20;
+        expect(capturedText[warningStart + 5].match(/\S+/g)[2]).toEqual('22');
+        expect(capturedText[warningStart + 10].match(/\S+/g)[2]).toEqual('24');
+        expect(capturedText[warningStart + 15].match(/\S+/g)[2]).toEqual('40');
+        expect(capturedText[warningStart + 20].match(/\S+/g)[2]).toEqual('41');
+        expect(capturedText[warningStart + 25].match(/\S+/g)[2]).toEqual('52');
+        expect(capturedText[warningStart + 30].match(/\S+/g)[2]).toEqual('56');
+        expect(capturedText[warningStart + 35].match(/\S+/g)[2]).toEqual('57');
+        expect(capturedText[warningStart + 40].match(/\S+/g)[2]).toEqual('59');
+        expect(capturedText[warningStart + 45].match(/\S+/g)[2]).toEqual('61');
+        expect(capturedText[warningStart + 50].match(/\S+/g)[2]).toEqual('96');
+        // Skip a few, then verify the last one.
+        expect(capturedText[warningStart + 145].match(/\S+/g)[2]).toEqual(
+          '213'
+        );
+      }
+    );
 
     it('should catch problems in a multi-file spec from an outside directory', async function () {
       const exitCode = await testValidator([
@@ -120,34 +124,37 @@ describe('Expected output tests', function () {
       );
     });
 
-    it('should handle an array of file names', async function () {
-      const args = [
-        './test/cli-validator/mock-files/oas3/err-and-warn.yaml',
-        'notAFile.json',
-        './test/cli-validator/mock-files/oas3/clean.yml',
-      ];
-      const exitCode = await testValidator(args);
-      expect(exitCode).toEqual(1);
+    it.each(['oas3', 'oas31'])(
+      'should handle an array of file names',
+      async function (oasVersion) {
+        const args = [
+          `./test/cli-validator/mock-files/${oasVersion}/err-and-warn.yaml`,
+          'notAFile.json',
+          `./test/cli-validator/mock-files/${oasVersion}/clean.yml`,
+        ];
+        const exitCode = await testValidator(args);
+        expect(exitCode).toEqual(1);
 
-      const capturedText = getCapturedText(consoleSpy.mock.calls);
-      const allOutput = capturedText.join('');
+        const capturedText = getCapturedText(consoleSpy.mock.calls);
+        const allOutput = capturedText.join('');
 
-      expect(
-        allOutput.includes('[WARN] Skipping non-existent file: notAFile.json')
-      ).toEqual(true);
+        expect(
+          allOutput.includes('[WARN] Skipping non-existent file: notAFile.json')
+        ).toEqual(true);
 
-      expect(
-        allOutput.includes(
-          'Validation Results for ./test/cli-validator/mock-files/oas3/err-and-warn.yaml:'
-        )
-      ).toEqual(true);
+        expect(
+          allOutput.includes(
+            `Validation Results for ./test/cli-validator/mock-files/${oasVersion}/err-and-warn.yaml:`
+          )
+        ).toEqual(true);
 
-      expect(
-        allOutput.includes(
-          'Validation Results for ./test/cli-validator/mock-files/oas3/clean.yml:'
-        )
-      ).toEqual(true);
-    });
+        expect(
+          allOutput.includes(
+            `Validation Results for ./test/cli-validator/mock-files/${oasVersion}/clean.yml:`
+          )
+        ).toEqual(true);
+      }
+    );
 
     it('should not produce any errors or warnings from mock-files/oas3/clean-with-tabs.yml', async function () {
       const exitCode = await testValidator([
@@ -203,21 +210,24 @@ describe('Expected output tests', function () {
       expect(allOutput.includes('warnings')).toEqual(true);
     });
 
-    it('should include the path to the component (if it exists) when in json mode', async function () {
-      const exitCode = await testValidator([
-        '-j',
-        './test/cli-validator/mock-files/oas3/component-path-example.yaml',
-      ]);
-      expect(exitCode).toEqual(0);
+    it.each(['oas3', 'oas31'])(
+      'should include the path to the component (if it exists) when in json mode',
+      async function (oasVersion) {
+        const exitCode = await testValidator([
+          '-j',
+          `./test/cli-validator/mock-files/${oasVersion}/component-path-example.yaml`,
+        ]);
+        expect(exitCode).toEqual(0);
 
-      const capturedText = getCapturedText(consoleSpy.mock.calls);
+        const capturedText = getCapturedText(consoleSpy.mock.calls);
 
-      const jsonOutput = JSON.parse(capturedText);
-      const warningToCheck = jsonOutput.warning.results[0];
+        const jsonOutput = JSON.parse(capturedText);
+        const warningToCheck = jsonOutput.warning.results[0];
 
-      expect(warningToCheck.rule).toEqual('ibm-prefer-token-pagination');
-      expect(warningToCheck.path.join('.')).toBe('paths./letters.get');
-      expect(warningToCheck.line).toEqual(20);
-    });
+        expect(warningToCheck.rule).toEqual('ibm-prefer-token-pagination');
+        expect(warningToCheck.path.join('.')).toBe('paths./letters.get');
+        expect(warningToCheck.line).toEqual(20);
+      }
+    );
   });
 });

--- a/packages/validator/test/cli-validator/tests/run-validator.test.js
+++ b/packages/validator/test/cli-validator/tests/run-validator.test.js
@@ -25,20 +25,23 @@ describe('run-validator tests', function () {
     console.info = originalInfo;
   });
 
-  it('should show error/exit code 1 when warnings limit exceeded (config)', async function () {
-    const exitCode = await testValidator([
-      '--config',
-      './test/cli-validator/mock-files/config/five-warnings.json',
-      './test/cli-validator/mock-files/oas3/warn-threshold.yml',
-    ]);
-    const capturedText = getCapturedText(consoleSpy.mock.calls);
-    // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
-    expect(exitCode).toEqual(1);
+  it.each(['oas3', 'oas31'])(
+    'should show error/exit code 1 when warnings limit exceeded (config)',
+    async function (oasVersion) {
+      const exitCode = await testValidator([
+        '--config',
+        './test/cli-validator/mock-files/config/five-warnings.json',
+        `./test/cli-validator/mock-files/${oasVersion}/warn-threshold.yml`,
+      ]);
+      const capturedText = getCapturedText(consoleSpy.mock.calls);
+      // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
+      expect(exitCode).toEqual(1);
 
-    expect(capturedText[3]).toMatch(
-      /^\[ERROR\] Number of warnings .* exceeds warnings limit/
-    );
-  });
+      expect(capturedText[3]).toMatch(
+        /^\[ERROR\] Number of warnings .* exceeds warnings limit/
+      );
+    }
+  );
   it.each(['-w5', '--warnings-limit=5'])(
     'should show error/exit code 1 when -w/--warnings-limit used',
     async function (option) {


### PR DESCRIPTION
## PR summary
This commit modifies the validator so that it can be used to validate OpenAPI 3.1 documents.
This initial support does not yet include any
OpenAPI 3.1-specific rules in the IBM Validation Ruleset, so the same rules used to validate OpenAPI 3.0.x documents will be used to validate OpenAPI 3.1.x documents.
An exception to this is the set of rules inherited from the Spectral OAS ruleset, since they do in fact implement some OpenAPI 3.1-specific behavior within those rules.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
