### PR TITLE
feat(ibm-avoid-multiple-types): add new openapi 3.1 rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -30,6 +30,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
 - [Reference](#reference)
   * [ibm-array-attributes](#ibm-array-attributes)
   * [ibm-avoid-inline-schemas](#ibm-avoid-inline-schemas)
+  * [ibm-avoid-multiple-types](#ibm-avoid-multiple-types)
   * [ibm-avoid-property-name-collision](#ibm-avoid-property-name-collision)
   * [ibm-avoid-repeating-path-parameters](#ibm-avoid-repeating-path-parameters)
   * [ibm-binary-schemas](#ibm-binary-schemas)
@@ -124,6 +125,13 @@ is provided in the [Reference](#reference) section below.
 Instead, use a ref to a named schema.
 </td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-avoid-multiple-types">ibm-avoid-multiple-types</a></td>
+<td>warn</td>
+<td>Multiple types within a schema's <code>type</code> field should be avoided because it creates ambiguity.
+</td>
+<td>oas3_1</td>
 </tr>
 <tr>
 <td><a href="#ibm-avoid-property-name-collision">ibm-avoid-property-name-collision</a></td>
@@ -866,6 +874,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Thing'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-avoid-multiple-types
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-avoid-multiple-types</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>The OpenAPI 3.1 Specification allows multiple types to be used within a schema's <code>type</code> field, but this can create
+ambiguity in an API definition.  Therefore, multiple types should be avoided.
+<p>This rule will return an error for schemas that are defined with multiple types (e.g. <code>['string', 'integer', 'boolean']</code>).
+One exception to this is that the special type <code>"null"</code> is simply ignored by the rule when counting 
+the number of elements in the schema's <code>type</code> field.  So, the type value <code>['string', 'integer']</code>
+would cause an error, but the type value <code>['string', 'null']</code> would not.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3_1</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type:
+            - string
+            - boolean
+            - integer
+            - null
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type:
+            - string
+            - null
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/avoid-multiple-types.js
+++ b/packages/ruleset/src/functions/avoid-multiple-types.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  validateNestedSchemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateNestedSchemas(
+    schema,
+    context.path,
+    avoidMultipleTypes,
+    true,
+    false
+  );
+};
+
+/**
+ * Warns about the presence of multiple types within a schema's "type" field.
+ * @param {*} schema the schema to check
+ * @param {*} path the array of path segments indicating the location of "schema" within the API definition
+ * @returns an array of zero or more errors
+ */
+function avoidMultipleTypes(schema, path) {
+  logger.debug(
+    `${ruleId}: checking 'type' in schema at location: ${path.join('.')}`
+  );
+
+  if (!schema.type || typeof schema.type === 'string') {
+    return [];
+  }
+
+  const errors = [];
+
+  if (Array.isArray(schema.type)) {
+    const filteredTypes = schema.type.filter(t => t !== 'null');
+
+    if (filteredTypes.length > 1) {
+      logger.debug(
+        `${ruleId}: detected multiple types at location: ${path.join('.')}.type`
+      );
+      errors.push({
+        message: `Avoid multiple types in schema 'type' field`,
+        path: [...path, 'type'],
+      });
+    }
+  }
+
+  return errors;
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -7,6 +7,7 @@ module.exports = {
   arrayAttributes: require('./array-attributes'),
   arrayOfArrays: require('./array-of-arrays'),
   arrayResponses: require('./array-responses'),
+  avoidMultipleTypes: require('./avoid-multiple-types'),
   binarySchemas: require('./binary-schemas'),
   checkMajorVersion: require('./check-major-version'),
   circularRefs: require('./circular-refs'),

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -97,6 +97,7 @@ module.exports = {
     // IBM Custom Rules
     'ibm-array-attributes': ibmRules.arrayAttributes,
     'ibm-avoid-inline-schemas': ibmRules.inlineSchemas,
+    'ibm-avoid-multiple-types': ibmRules.avoidMultipleTypes,
     'ibm-avoid-property-name-collision': ibmRules.propertyNameCollision,
     'ibm-avoid-repeating-path-parameters': ibmRules.duplicatePathParameter,
     'ibm-binary-schemas': ibmRules.binarySchemas,

--- a/packages/ruleset/src/rules/avoid-multiple-types.js
+++ b/packages/ruleset/src/rules/avoid-multiple-types.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3_1 } = require('@stoplight/spectral-formats');
+const { avoidMultipleTypes } = require('../functions');
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+
+module.exports = {
+  description:
+    'OpenAPI 3.1 documents should avoid multiple types in the schema "type" field.',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'error',
+  formats: [oas3_1],
+  resolved: true,
+  then: {
+    function: avoidMultipleTypes,
+  },
+};

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -9,6 +9,7 @@ module.exports = {
   arrayOfArrays: require('./array-of-arrays'),
   arrayResponses: require('./array-responses'),
   authorizationHeader: require('./authorization-header'),
+  avoidMultipleTypes: require('./avoid-multiple-types'),
   binarySchemas: require('./binary-schemas'),
   circularRefs: require('./circular-refs'),
   collectionArrayProperty: require('./collection-array-property'),

--- a/packages/ruleset/test/avoid-multiple-types.test.js
+++ b/packages/ruleset/test/avoid-multiple-types.test.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { avoidMultipleTypes } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = avoidMultipleTypes;
+const ruleId = 'ibm-avoid-multiple-types';
+const expectedSeverity = severityCodes.error;
+const expectedMessage = `Avoid multiple types in schema 'type' field`;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  beforeAll(() => {
+    rootDocument.openapi = '3.1.0';
+  });
+
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('One-element type list - property', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['NormalString'].type = ['string'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('One-element type list - parameter', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: ['string'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('Two-element type list includes "null" - property', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['NormalString'].type = ['null', 'string'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('Two-element type list includes "null" - parameter', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter1',
+          in: 'query',
+          schema: {
+            type: ['string', 'null'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+        {
+          name: 'filter2',
+          in: 'query',
+          schema: {
+            type: ['null', 'string'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Multiple values in type list - property', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['UrlString'].type = [
+        'integer',
+        'string',
+        'null',
+        'boolean',
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+      for (const result of results) {
+        expect(result.code).toBe(ruleId);
+        expect(result.message).toBe(expectedMessage);
+        expect(result.severity).toBe(expectedSeverity);
+      }
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.application/json.schema.properties.imdb_url.type'
+      );
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/movies.post.responses.201.content.application/json.schema.properties.imdb_url.type'
+      );
+      expect(results[2].path.join('.')).toBe(
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.properties.imdb_url.type'
+      );
+      expect(results[3].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.properties.imdb_url.type'
+      );
+      expect(results[4].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.properties.imdb_url.type'
+      );
+    });
+    it('Multiple values in type list - parameter', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.paths['/v1/movies'].post.parameters = [
+        {
+          name: 'filter',
+          in: 'query',
+          schema: {
+            type: ['integer', 'string', 'null', 'boolean'],
+            minLength: 1,
+            maxLength: 15,
+          },
+        },
+      ];
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.code).toBe(ruleId);
+      expect(result.message).toBe(expectedMessage);
+      expect(result.severity).toBe(expectedSeverity);
+      expect(result.path.join('.')).toBe(
+        'paths./v1/movies.post.parameters.0.schema.type'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
This commit adds a new spectral style rule
"ibm-avoid-multiple-types".  This rule will warn about
any schema that defines multiple non-null type values
in its "type" field.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
