### PR TITLE
feat(ibm-pattern-properties): add new spectral-style rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -71,6 +71,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-parameter-schema-or-content](#ibm-parameter-schema-or-content)
   * [ibm-patch-request-content-type](#ibm-patch-request-content-type)
   * [ibm-path-segment-casing-convention](#ibm-path-segment-casing-convention)
+  * [ibm-pattern-properties](#ibm-pattern-properties)
   * [ibm-precondition-headers](#ibm-precondition-headers)
   * [ibm-property-attributes](#ibm-property-attributes)
   * [ibm-property-casing-convention](#ibm-property-casing-convention)
@@ -380,6 +381,12 @@ or <code>application/merge-patch+json</code>.</td>
 <td>error</td>
 <td>Path segments must follow a specific case convention.</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-pattern-properties">ibm-pattern-properties</a></td>
+<td>error</td>
+<td>Enforces certain restrictions on the use of <code>patternProperties</code> within a schema.</td>
+<td>oas3_1</td>
 </tr>
 <tr>
 <td><a href="#ibm-precondition-headers">ibm-precondition-headers</a></td>
@@ -3831,6 +3838,74 @@ paths:
 <pre>
 paths:
   '/v1/some_things/{thing_id}':
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-pattern-properties
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-pattern-properties</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule enforces certain restrictions related to the use of the <code>patternProperties</code> field
+within a schema:
+<ul>
+<li>The <code>patternProperties</code> field must be an object with exactly one entry.
+<li>The <code>patternProperties</code> and <code>additionalProperties</code> fields are mutually exclusive within a particular schema.
+</ul>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3_1</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+          patternProperties:
+            '^foo.*$':
+              type: string
+            '^bar.*$':
+              type: integer
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+          patternProperties:
+            '^(foo|bar).*$':
+              type: string
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -34,6 +34,7 @@ module.exports = {
   patchRequestContentType: require('./patch-request-content-type'),
   pathParameterNotCRN: require('./path-parameter-not-crn'),
   pathSegmentCasingConvention: require('./path-segment-casing-convention'),
+  patternPropertiesCheck: require('./pattern-properties'),
   preconditionHeader: require('./precondition-header'),
   propertyAttributes: require('./property-attributes'),
   propertyCasingConvention: require('./property-casing-convention'),

--- a/packages/ruleset/src/functions/pattern-properties.js
+++ b/packages/ruleset/src/functions/pattern-properties.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  isObject,
+  validateNestedSchemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateNestedSchemas(
+    schema,
+    context.path,
+    patternPropertiesCheck,
+    true,
+    false
+  );
+};
+
+/**
+ * Enforces certain restrictions on the use of "patternProperties" within a schema:
+ * 1. patternProperties and additionalProperties are mutually exclusive
+ * 2. patternProperties must be an object
+ * 3. patternProperties must not be empty
+ * 4. patternProperties must have at most one entry
+ *
+ * @param {*} schema the schema to check
+ * @param {*} path the array of path segments indicating the location of "schema" within the API definition
+ * @returns an array of zero or more errors
+ */
+function patternPropertiesCheck(schema, path) {
+  logger.debug(
+    `${ruleId}: checking 'patternProperties' in schema at location: ${path.join(
+      '.'
+    )}`
+  );
+
+  // We're only interested in this schema if it defines "patternProperties".
+  if (!('patternProperties' in schema)) {
+    return [];
+  }
+
+  if ('additionalProperties' in schema) {
+    logger.debug(
+      `${ruleId}: Error: found patternProperties and additionalProperties`
+    );
+    return [
+      {
+        message:
+          'patternProperties and additionalProperties are mutually exclusive',
+        path,
+      },
+    ];
+  }
+
+  if (!isObject(schema.patternProperties)) {
+    logger.debug(`${ruleId}: Error: patternProperties is not an object!`);
+    return [
+      {
+        message: 'patternProperties must be an object',
+        path: [...path, 'patternProperties'],
+      },
+    ];
+  }
+
+  const keys = Object.keys(schema.patternProperties);
+  if (!keys.length) {
+    logger.debug(`${ruleId}: Error: patternProperties is empty!`);
+    return [
+      {
+        message: 'patternProperties must be a non-empty object',
+        path: [...path, 'patternProperties'],
+      },
+    ];
+  }
+
+  if (keys.length > 1) {
+    logger.debug(
+      `${ruleId}: Error: patternProperties has more than one entry!`
+    );
+    return [
+      {
+        message: 'patternProperties must be an object with at most one entry',
+        path: [...path, 'patternProperties'],
+      },
+    ];
+  }
+
+  logger.debug(`${ruleId}: PASSED!`);
+
+  return [];
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -140,6 +140,7 @@ module.exports = {
     'ibm-parameter-schema-or-content': ibmRules.parameterSchemaOrContentExists,
     'ibm-patch-request-content-type': ibmRules.patchRequestContentType,
     'ibm-path-segment-casing-convention': ibmRules.pathSegmentCasingConvention,
+    'ibm-pattern-properties': ibmRules.patternProperties,
     'ibm-precondition-headers': ibmRules.preconditionHeader,
     'ibm-property-attributes': ibmRules.propertyAttributes,
     'ibm-property-casing-convention': ibmRules.propertyCasingConvention,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -45,6 +45,7 @@ module.exports = {
   patchRequestContentType: require('./patch-request-content-type'),
   pathParameterNotCRN: require('./path-parameter-not-crn'),
   pathSegmentCasingConvention: require('./path-segment-casing-convention'),
+  patternProperties: require('./pattern-properties'),
   preconditionHeader: require('./precondition-header'),
   propertyAttributes: require('./property-attributes'),
   propertyCasingConvention: require('./property-casing-convention'),

--- a/packages/ruleset/src/rules/pattern-properties.js
+++ b/packages/ruleset/src/rules/pattern-properties.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3_1 } = require('@stoplight/spectral-formats');
+const { patternPropertiesCheck } = require('../functions');
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+
+module.exports = {
+  description:
+    'Enforces certain restrictions on the use of "patternProperties" within a schema.',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'error',
+  formats: [oas3_1],
+  resolved: true,
+  then: {
+    function: patternPropertiesCheck,
+  },
+};

--- a/packages/ruleset/test/array-attributes.test.js
+++ b/packages/ruleset/test/array-attributes.test.js
@@ -435,20 +435,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsgItems);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/drinks',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'allOf',
-        '1',
-        'properties',
-        'drinks',
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks'
+      );
     });
     it('Response schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
@@ -462,16 +451,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsgItems);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.get.responses.200.content.application/json.schema'
+      );
     });
     it('Request schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
@@ -487,16 +469,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsgItems);
       expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-      ]);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies.post.requestBody.content.application/json.schema'
+      );
     });
+
     it('Request schema with non-object items property', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -507,21 +484,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
         items: 'not a schema!',
       };
 
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgItems);
-      expect(results[0].severity).toBe(expectedSeverity);
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-      ]);
+      await expect(async () => {
+        await testRule(ruleId, rule, testDocument);
+      }).rejects.toThrow();
     });
+
     it('additionalProperties schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -531,69 +498,20 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(5);
-      for (const result of results) {
-        expect(result.code).toBe(ruleId);
-        expect(result.message).toBe(expectedMsgItems);
-        expect(result.severity).toBe(expectedSeverity);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.additionalProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.additionalProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.additionalProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.additionalProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.additionalProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsgItems);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
       }
-      expect(results[0].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
-      expect(results[1].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'post',
-        'responses',
-        '201',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
-      expect(results[2].path).toStrictEqual([
-        'paths',
-        '/v1/movies',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'allOf',
-        '1',
-        'properties',
-        'movies',
-        'items',
-        'additionalProperties',
-      ]);
-      expect(results[3].path).toStrictEqual([
-        'paths',
-        '/v1/movies/{movie_id}',
-        'get',
-        'responses',
-        '200',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
-      expect(results[4].path).toStrictEqual([
-        'paths',
-        '/v1/movies/{movie_id}',
-        'put',
-        'requestBody',
-        'content',
-        'application/json',
-        'schema',
-        'additionalProperties',
-      ]);
     });
     it('minItems > maxItems', async () => {
       const testDocument = makeCopy(rootDocument);

--- a/packages/ruleset/test/inline-schemas.test.js
+++ b/packages/ruleset/test/inline-schemas.test.js
@@ -353,6 +353,39 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+
+    it('Inline primitive in additionalProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Car.additionalProperties = {
+        description: 'Inline string schema within additionalProperties',
+        type: 'string',
+        pattern: '^blah.*$',
+        minLength: 0,
+        maxLength: 64,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Inline primitive in patternProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.openapi = '3.1.0';
+      testDocument.components.schemas.Car.patternProperties = {
+        '^foo.*$': {
+          description: 'Inline object schema within additionalProperties',
+          type: 'string',
+          pattern: '^blah.*$',
+          minLength: 0,
+          maxLength: 64,
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {
@@ -526,6 +559,32 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
         'components.schemas.Car.additionalProperties'
+      );
+    });
+
+    it('Inline object in patternProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.openapi = '3.1.0';
+      testDocument.components.schemas.Car.patternProperties = {
+        '^foo.*$': {
+          description: 'Inline object schema within additionalProperties',
+          properties: {
+            prop1: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsgProperty);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'components.schemas.Car.patternProperties.^foo.*$'
       );
     });
 

--- a/packages/ruleset/test/pattern-properties.test.js
+++ b/packages/ruleset/test/pattern-properties.test.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { patternProperties } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = patternProperties;
+const ruleId = 'ibm-patternProperties';
+const expectedSeverity = severityCodes.error;
+const expectedMessage1 = `patternProperties and additionalProperties are mutually exclusive`;
+const expectedMessage2 = `patternProperties must be an object`;
+const expectedMessage3 = `patternProperties must be a non-empty object`;
+const expectedMessage4 = `patternProperties must be an object with at most one entry`;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  beforeAll(() => {
+    rootDocument.openapi = '3.1.0';
+  });
+
+  describe('Should not yield errors', () => {
+    it('Clean spec - no patternProperties', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Valid patternProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        '^str.*$': {
+          type: 'string',
+        },
+      };
+      testDocument.components.schemas['Juice'].patternProperties = {
+        '^is.*$': {
+          type: 'boolean',
+        },
+      };
+      testDocument.components.schemas['Soda'].patternProperties = {
+        '^int.*$': {
+          type: 'integer',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('patternProperties specified with additionalProperties', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        '^str.*$': {
+          type: 'string',
+        },
+      };
+      testDocument.components.schemas['Movie'].additionalProperties = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema',
+        'paths./v1/movies.post.responses.201.content.application/json.schema',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage1);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties is not an object', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = 'foo';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage2);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties is an empty object', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage3);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties contains > 1 entry', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        '^str.*$': {
+          type: 'string',
+        },
+        '^bool.*$': {
+          type: 'boolean',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage4);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});

--- a/packages/ruleset/test/utils/test-rule.js
+++ b/packages/ruleset/test/utils/test-rule.js
@@ -21,11 +21,6 @@ module.exports = async (ruleName, rule, doc) => {
     },
   });
 
-  try {
-    const results = await spectral.run(doc);
-    return results;
-  } catch (err) {
-    console.error(err);
-    throw err;
-  }
+  const results = await spectral.run(doc);
+  return results;
 };

--- a/packages/utilities/src/utils/get-schema-type.js
+++ b/packages/utilities/src/utils/get-schema-type.js
@@ -295,7 +295,8 @@ const isObjectSchema = schema => {
       (!('type' in s) &&
         (isObject(s.properties) ||
           s.additionalProperties === true ||
-          isObject(s.additionalProperties)))
+          isObject(s.additionalProperties) ||
+          isObject(s.patternProperties)))
     );
   });
 };

--- a/packages/utilities/src/utils/validate-nested-schemas.js
+++ b/packages/utilities/src/utils/validate-nested-schemas.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
+const isObject = require('./is-object');
+
 /*
  * Performs validation on a schema and all of its nested schemas.
  *
@@ -29,6 +31,13 @@ const validateNestedSchemas = (
   includeSelf = true,
   includeNot = false
 ) => {
+  // Make sure 'schema' is an object.
+  if (!isObject(schema)) {
+    throw new Error(
+      `the entity at location ${path.join('.')} must be a schema object`
+    );
+  }
+
   // If "schema" is a $ref, that means it didn't get resolved
   // properly (perhaps due to a circular ref), so just ignore it.
   if (schema.$ref) {
@@ -107,6 +116,23 @@ const validateNestedSchemas = (
           )
         );
       });
+    }
+  }
+
+  if (
+    schema.patternProperties &&
+    typeof schema.patternProperties === 'object'
+  ) {
+    for (const entry of Object.entries(schema.patternProperties)) {
+      errors.push(
+        ...validateNestedSchemas(
+          entry[1],
+          [...path, 'patternProperties', entry[0]],
+          validate,
+          true,
+          includeNot
+        )
+      );
     }
   }
 

--- a/packages/utilities/test/is-object-schema.test.js
+++ b/packages/utilities/test/is-object-schema.test.js
@@ -41,8 +41,30 @@ describe('Utility function: isObjectSchema()', () => {
     expect(isObjectSchema({ additionalProperties: {} })).toBe(true);
   });
 
-  it('should return `false` for an object with non-"object" `type` and an `properties` object', async () => {
+  it('should return `false` for an object with no `type` and an `additionalProperties` of `false`', async () => {
+    expect(isObjectSchema({ additionalProperties: false })).toBe(false);
+  });
+
+  it('should return `true` for an object with no `type` and a `patternProperties` object', async () => {
+    expect(
+      isObjectSchema({ patternProperties: { '.*': { type: 'string' } } })
+    ).toBe(true);
+  });
+
+  it('should return `false` for an object with no `type` and a `patternProperties` not an object', async () => {
+    expect(
+      isObjectSchema({
+        patternProperties: 'bad patternProperties object!',
+      })
+    ).toBe(false);
+  });
+
+  it('should return `false` for an object with non-"object" `type` and a `properties` object', async () => {
     expect(isObjectSchema({ type: 'array', properties: {} })).toBe(false);
+  });
+
+  it('should return `false` for a non-object value for "schema"', async () => {
+    expect(isObjectSchema('this is not a schema object')).toBe(false);
   });
 
   it('should return `false` for an object with no `type` and a non-object `properties`', async () => {


### PR DESCRIPTION
## PR summary
This commit introduces a new spectral-style rule named "ibm-pattern-properties" which enforces specific restrictions on the use of the "patternProperties" field within a schema.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
