### PR TITLE
feat(new-rule): ibm-prefer-token-pagination

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-05-18T14:27:14Z",
+  "generated_at": "2023-07-25T19:51:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -96,7 +96,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.60.dss",
+  "version": "0.13.1+ibm.56.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -71,6 +71,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-patch-request-content-type](#ibm-patch-request-content-type)
   * [ibm-path-segment-casing-convention](#ibm-path-segment-casing-convention)
   * [ibm-precondition-headers](#ibm-precondition-headers)
+  * [ibm-prefer-token-pagination](#ibm-prefer-token-pagination)
   * [ibm-property-attributes](#ibm-property-attributes)
   * [ibm-property-casing-convention](#ibm-property-casing-convention)
   * [ibm-property-consistent-name-and-type](#ibm-property-consistent-name-and-type)
@@ -377,6 +378,12 @@ or <code>application/merge-patch+json</code>.</td>
 <td><a href="#ibm-precondition-headers">ibm-precondition-headers</a></td>
 <td>error</td>
 <td>Operations that return a 412 status code must support at least one of the following header parameters: <code>If-Match</code>, <code>If-None-Match</code>, <code>If-Modified-Since</code>, <code>If-Unmodified-Since</code></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-prefer-token-pagination">ibm-prefer-token-pagination</a></td>
+<td>warn</td>
+<td>Paginated list operations should use token-based pagination, rather than offset/limit pagination</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -3770,9 +3777,9 @@ paths:
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>
-<td>Operations that return a 412 status code must support at least one of the following header parameters: <code>If-Match</code>, <code>If-None-Match</code>, <code>If-Modified-Since</code>, <code>If-Unmodified-Since</code></td>.
+<td>Operations that return a 412 status code must support at least one of the following header parameters: <code>If-Match</code>, <code>If-None-Match</code>, <code>If-Modified-Since</code>, <code>If-Unmodified-Since</code>.
 For more details, please see the API Handbook section on
-<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-headers#conditional-headers">Conditional headers</a>.
+<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-headers#conditional-headers">Conditional headers</a>.</td>
 </tr>
 <tr>
 <td><b>Severity:</b></td>
@@ -3831,6 +3838,106 @@ paths:
                 $ref: '#/components/schemas/Thing'
         '412':
           description: 'Resource current ETag matches If-None-Match value.'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-prefer-token-pagination
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-prefer-token-pagination</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>As per the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-pagination#token-based-pagination">API Handbook guidance on pagination</a>, paginated list operations should use token-based pagination, rather than offset/limit pagination, wherever feasible.</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/':
+    get:
+      operationId: list_things
+      parameters:
+        - name: offset
+          in: query
+          description: 'The offset of the first item to return.'
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - name: limit
+          in: query
+          description: 'The number of items to return per page.'
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 100
+            default: 10
+      responses:
+        '200':
+          description: 'Resources retrieved successfully!'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThingCollection'
+        '400':
+          description: 'List operation failed.'
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/':
+    get:
+      operationId: list_things
+      parameters:
+        - name: start
+          in: query
+          description: 'The token representing the first item to return.'
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: '[a-zA-Z0-9 ]+'
+        - name: limit
+          in: query
+          description: 'The number of items to return per page.'
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 100
+            default: 10
+      responses:
+        '200':
+          description: 'Resources retrieved successfully!'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThingCollection'
+        '400':
+          description: 'List operation failed.'
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -34,6 +34,7 @@ module.exports = {
   pathParameterNotCRN: require('./path-parameter-not-crn'),
   pathSegmentCasingConvention: require('./path-segment-casing-convention'),
   preconditionHeader: require('./precondition-header'),
+  preferTokenPagination: require('./prefer-token-pagination'),
   propertyAttributes: require('./property-attributes'),
   propertyCasingConvention: require('./property-casing-convention'),
   propertyConsistentNameAndType: require('./property-consistent-name-and-type'),

--- a/packages/ruleset/src/functions/prefer-token-pagination.js
+++ b/packages/ruleset/src/functions/prefer-token-pagination.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  getPaginatedOperationFromPath,
+  getOffsetParamIndex,
+  LoggerFactory,
+} = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (pathObj, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return checkTypeOfPagination(pathObj, context.path);
+};
+
+/**
+ * This function implements the prefer-token-pagination rule which checks
+ * a paginated list operation to see if it implements offset/limit style
+ * pagination, as we encourage the use of token-style pagination.
+ *
+ * An operation is considered to be a paginated "list"-type operation if:
+ * 1. The path doesn't end in a path param reference (e.g. /v1/drinks vs /v1/drinks/{drink_id})
+ * 2. The operation is a "get"
+ * 3. The operation's response schema is an object containing an array property.
+ * 4. The operation defines either an "offset" query param or a page token-type query param
+ *    whose name is in ['start', 'token', 'cursor', 'page', 'page_token'].
+ *
+ * @param {*} pathItem the path item that potentially contains a paginated "get" operation.
+ * @param {*} path the array of path segments indicating the "location" of the pathItem within the API definition
+ * @returns an array containing the violations found or [] if no violations
+ */
+function checkTypeOfPagination(pathItem, path) {
+  logger.debug(`${ruleId}: checking pathItem at location: ${path.join('.')}`);
+  const operation = getPaginatedOperationFromPath(pathItem, path, {
+    logger,
+    ruleId,
+  });
+
+  // If `operation` is null, this is not a paginated operation.
+  if (!operation) {
+    logger.debug(
+      `${ruleId}: no paginated operation found at path '${path.join('.')}'`
+    );
+    return [];
+  }
+
+  logger.debug(
+    `${ruleId}: checking paginated operation at path ${path.join('.')}.get`
+  );
+
+  // Note: any operation returned from `getPaginatedOperationFromPath`
+  // guarantees that the operation has defined parameters.
+  const params = operation.parameters;
+  logger.debug(
+    `${ruleId}: list of params: ${params.map(p => p.name).join(',')}`
+  );
+
+  // Assume the presence of a parameter called `offset` indicates offset/limit pagination.
+  const offsetParamIndex = getOffsetParamIndex(params);
+  logger.debug(
+    `${ruleId}: index of searched for 'offset' param: ${offsetParamIndex}`
+  );
+  if (offsetParamIndex >= 0) {
+    logger.debug(
+      `${ruleId}: 'offset' query param found at index ${offsetParamIndex}`
+    );
+    return [
+      {
+        message:
+          'Token-based pagination is recommended over offset/limit pagination',
+        path: [...path, 'get'],
+      },
+    ];
+  }
+
+  return [];
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -140,6 +140,7 @@ module.exports = {
     'ibm-patch-request-content-type': ibmRules.patchRequestContentType,
     'ibm-path-segment-casing-convention': ibmRules.pathSegmentCasingConvention,
     'ibm-precondition-headers': ibmRules.preconditionHeader,
+    'ibm-prefer-token-pagination': ibmRules.preferTokenPagination,
     'ibm-property-attributes': ibmRules.propertyAttributes,
     'ibm-property-casing-convention': ibmRules.propertyCasingConvention,
     'ibm-property-consistent-name-and-type':

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -45,6 +45,7 @@ module.exports = {
   pathParameterNotCRN: require('./path-parameter-not-crn'),
   pathSegmentCasingConvention: require('./path-segment-casing-convention'),
   preconditionHeader: require('./precondition-header'),
+  preferTokenPagination: require('./prefer-token-pagination'),
   propertyAttributes: require('./property-attributes'),
   propertyCasingConvention: require('./property-casing-convention'),
   propertyConsistentNameAndType: require('./property-consistent-name-and-type'),

--- a/packages/ruleset/src/rules/prefer-token-pagination.js
+++ b/packages/ruleset/src/rules/prefer-token-pagination.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  paths,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+const { oas3 } = require('@stoplight/spectral-formats');
+const { preferTokenPagination } = require('../functions');
+
+module.exports = {
+  description:
+    'Paginated list operations should use token-based pagination, rather than offset/limit pagination.',
+  message: '{{error}}',
+  given: paths,
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  then: {
+    function: preferTokenPagination,
+  },
+};

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -5,6 +5,7 @@
 
 module.exports = {
   getCompositeSchemaAttribute: require('./get-composite-schema-attribute'),
+  ...require('./pagination-utils'),
   isDeprecated: require('./is-deprecated'),
   isEmptyObjectSchema: require('./is-empty-object-schema'),
   isRefSiblingSchema: require('./is-ref-sibling-schema'),

--- a/packages/ruleset/src/utils/pagination-utils.js
+++ b/packages/ruleset/src/utils/pagination-utils.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const mergeAllOfSchemaProperties = require('./merge-allof-schema-properties');
+
+/**
+ * Looks for a query parameter called "offset" and returns the
+ * index of the parameter if it is found, -1 if it is not.
+ *
+ * @param {*} params a list of parameter objects
+ * @return integer the index of the searched-for parameter
+ */
+function getOffsetParamIndex(params) {
+  return params.findIndex(
+    param => param.name === 'offset' && param.in === 'query'
+  );
+}
+
+/**
+ * Looks for a query parameter with one of the pre-determined names
+ * expected for a page token and returns the index of the
+ * parameter if it is found, -1 if it is not.
+ *
+ * @param {*} params a list of parameter objects
+ * @return integer the index of the searched-for parameter
+ */
+function getPageTokenParamIndex(params) {
+  // The page token-type query param could have any of the names below.
+  const pageTokenParamNames = [
+    'start',
+    'token',
+    'cursor',
+    'page',
+    'page_token',
+  ];
+  return params.findIndex(
+    param =>
+      param.in === 'query' && pageTokenParamNames.indexOf(param.name) !== -1
+  );
+}
+
+/**
+ * Looks for a success response on an operation and returns the code if
+ * found, null if not.
+ *
+ * @param {*} operation an operation object
+ * @return string the success code, if found
+ */
+function getSuccessCode(operation) {
+  return Object.keys(operation.responses || {}).find(code =>
+    code.startsWith('2')
+  );
+}
+
+/**
+ * Looks for a JSON schema in a response and returns the schema
+ * if found, null if not.
+ *
+ * @param {*} response a response object
+ * @return object the schema object, if found
+ */
+function getResponseSchema(response) {
+  // Find the json content of the response.
+  const content = response.content;
+  const jsonResponse = content && content['application/json'];
+
+  if (!jsonResponse || !jsonResponse.schema) {
+    return;
+  }
+
+  // Get the response schema (while potentially taking into account allOf).
+  return mergeAllOfSchemaProperties(jsonResponse.schema);
+}
+
+/**
+ * A function that checks a path for a "get" operation that meets all of the conditions of
+ * a "paginated list operation". If it finds one, it returns the operation.
+ *
+ * An operation is considered to be a paginated "list"-type operation if:
+ * 1. The path doesn't end in a path param reference (e.g. /v1/drinks vs /v1/drinks/{drink_id})
+ * 2. The operation is a "get"
+ * 3. The operation's response schema is an object containing an array property.
+ * 4. The operation defines either an "offset" query param or a page token-type query param
+ *    whose name is in ['start', 'token', 'cursor', 'page', 'page_token'].
+ *
+ * @param {*} pathItem the path item that potentially contains a paginated "get" operation.
+ * @param {*} path the array of path segments indicating the "location" of the pathItem within the API definition
+ * @param {*} logInfo an object containing the logger and ruleId of the invoking rule
+ * @return object the operation object if found, null if not
+ */
+function getPaginatedOperationFromPath(pathItem, path, logInfo) {
+  // Use the invoking rule's logger, as the value of logging in this utility
+  // function exists primarily in the context of the rule.
+  const { logger, ruleId } = logInfo;
+
+  // The actual path string (e.g. '/v1/resources') will be the last element in 'path'.
+  const pathStr = path[path.length - 1];
+
+  // Retrieve this path item's 'get' operation.
+  const operation = pathItem.get;
+
+  // We'll bail out now if any of the following are true:
+  // 1. If the path string ends with a path param reference (e.g. '{resource_id}'
+  // 2. If the path item doesn't have a 'get' operation.
+  if (/}$/.test(pathStr) || !operation) {
+    logger.debug(
+      `${ruleId}: 'get' operation is absent or excluded at path '${pathStr}'`
+    );
+    return;
+  }
+
+  // Next, find the first success response code.
+  const successCode = getSuccessCode(operation);
+  if (!successCode) {
+    logger.debug(`${ruleId}: No success response code found!`);
+    return;
+  }
+
+  // Next, find the json content of that response and get the response schema.
+  const responseSchema = getResponseSchema(operation.responses[successCode]);
+
+  // If there's no response schema, then we can't check this operation so bail out now.
+  if (!responseSchema) {
+    logger.debug(`${ruleId}: No response schema found!`);
+    return;
+  }
+
+  if (!responseSchema.properties) {
+    logger.debug(`${ruleId}: Resolved response schema has no properties!`);
+    return;
+  }
+
+  // Next, make sure there is at least one array property in the response schema.
+  if (
+    !Object.values(responseSchema.properties).some(
+      prop => prop.type === 'array'
+    )
+  ) {
+    logger.debug(`${ruleId}: Response schema has no array property!`);
+    return;
+  }
+
+  // Next, make sure this operation has parameters.
+  const params = operation.parameters;
+  if (!params) {
+    logger.debug(`${ruleId}: Operation has no parameters!`);
+    return;
+  }
+
+  // Check to see if the operation defines a page token-type query param.
+  const pageTokenParamIndex = getPageTokenParamIndex(params);
+
+  // Check to see if the operation defines an "offset" query param.
+  const offsetParamIndex = getOffsetParamIndex(params);
+
+  // If the operation doesn't define a page token-type query param or an "offset" query param,
+  // then bail out now as pagination isn't supported by this operation.
+  if (pageTokenParamIndex < 0 && offsetParamIndex < 0) {
+    logger.debug(`${ruleId}: No start or offset query param!`);
+    return;
+  }
+
+  return operation;
+}
+
+module.exports = {
+  getOffsetParamIndex,
+  getPageTokenParamIndex,
+  getSuccessCode,
+  getResponseSchema,
+  getPaginatedOperationFromPath,
+};

--- a/packages/ruleset/test/pagination-style.test.js
+++ b/packages/ruleset/test/pagination-style.test.js
@@ -4,7 +4,18 @@
  */
 
 const { paginationStyle } = require('../src/rules');
-const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+const {
+  makeCopy,
+  rootDocument,
+  testRule,
+  severityCodes,
+  helperArtifacts,
+} = require('./utils');
+
+// These are pre-defined objects with correct style for offset/limit pagination
+// to use as a baseline. They aren't used in the root document because overall,
+// we prefer token-based pagination and validate for that elsewhere.
+const { offsetPaginationBase, offsetParameter } = helperArtifacts;
 
 const rule = paginationStyle;
 const ruleId = 'ibm-pagination-style';
@@ -19,10 +30,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Valid pagination with no "previous" or "last" properties', async () => {
       const testDocument = makeCopy(rootDocument);
 
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
       // Delete the "previous" and "last" properties from our two pagination base schemas.
-      delete testDocument.components.schemas.OffsetPaginationBase.properties
+      delete testDocument.components.schemas.DrinkCollection.allOf[0].properties
         .previous;
-      delete testDocument.components.schemas.OffsetPaginationBase.properties
+      delete testDocument.components.schemas.DrinkCollection.allOf[0].properties
         .last;
       delete testDocument.components.schemas.TokenPaginationBase.properties
         .previous;
@@ -34,6 +48,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     });
     it('Invalid pagination on non-get operation', async () => {
       const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
 
       // Create new path with a non-get operation with an "invalid" limit param.
       // This should not be an error as it's not a get operation.
@@ -59,6 +76,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Invalid pagination within excluded path', async () => {
       const testDocument = makeCopy(rootDocument);
 
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
       // Make a copy of a valid get operation, then make it invalid.
       const invalidGet = makeCopy(testDocument.paths['/v1/drinks'].get);
       invalidGet.parameters[0].required = true;
@@ -74,6 +94,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Invalid pagination on get w/no success response code', async () => {
       const testDocument = makeCopy(rootDocument);
 
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
       // Make the get operation invalid by marking offset param as required.
       testDocument.paths['/v1/drinks'].get.parameters[0].required = true;
 
@@ -86,6 +109,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Invalid pagination on get w/no success response content', async () => {
       const testDocument = makeCopy(rootDocument);
 
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
       // Make the get operation invalid by marking offset param as required.
       testDocument.paths['/v1/drinks'].get.parameters[0].required = true;
 
@@ -97,6 +123,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     });
     it('Invalid pagination on get w/no success response schema', async () => {
       const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
 
       // Make the get operation invalid by marking offset param as required.
       testDocument.paths['/v1/drinks'].get.parameters[0].required = true;
@@ -111,6 +140,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     });
     it('Invalid pagination on get w/non-json response schema', async () => {
       const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
 
       // Make the get operation invalid by marking offset param as required.
       testDocument.paths['/v1/drinks'].get.parameters[0].required = true;
@@ -133,6 +165,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Invalid pagination on get w/no response properties', async () => {
       const testDocument = makeCopy(rootDocument);
 
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
       // Make the get operation invalid by marking offset param as required.
       testDocument.paths['/v1/drinks'].get.parameters[0].required = true;
 
@@ -149,6 +184,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     });
     it('Invalid pagination on get w/no response array property', async () => {
       const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
 
       // Make the get operation invalid by marking offset param as required.
       testDocument.paths['/v1/drinks'].get.parameters[0].required = true;
@@ -171,6 +209,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Invalid pagination on get operation w/ no offset or start param', async () => {
       const testDocument = makeCopy(rootDocument);
 
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
       // Create an "invalid" limit parameter, but this operation should not be
       // flagged since it doesn't define an "offset" or "start" param.
       const get = testDocument.paths['/v1/drinks'].get;
@@ -192,6 +233,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Valid pagination on get operation w/ no limit param or response property', async () => {
       const testDocument = makeCopy(rootDocument);
 
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
       // Remove the limit param and limit response property from the "list_movies" operation.
       testDocument.paths['/v1/movies'].get.parameters.splice(2, 1);
       delete testDocument.components.schemas['TokenPaginationBase'].properties
@@ -206,6 +250,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
     });
     it('Response indicates pagination, but operation has no parameters', async () => {
       const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
 
       // Remove the operation's entire parameters field.
       delete testDocument.paths['/v1/drinks'].get.parameters;
@@ -223,6 +270,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"limit" param not an integer', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         testDocument.paths['/v1/drinks'].get.parameters[1].schema = {
           type: 'boolean',
         };
@@ -238,6 +290,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"limit" param not optional', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         testDocument.paths['/v1/drinks'].get.parameters[1].required = true;
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -250,6 +307,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       });
       it('"limit" param w/no default', async () => {
         const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
 
         delete testDocument.paths['/v1/drinks'].get.parameters[1].schema
           .default;
@@ -264,6 +326,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       });
       it('"limit" param w/no maximum', async () => {
         const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
 
         delete testDocument.paths['/v1/drinks'].get.parameters[1].schema
           .maximum;
@@ -281,6 +348,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"offset" param not an integer', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         testDocument.paths['/v1/drinks'].get.parameters[0].schema = {
           type: 'string',
         };
@@ -296,6 +368,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"offset" param not optional', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         testDocument.paths['/v1/drinks'].get.parameters[0].required = true;
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -310,6 +387,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
     describe('Check #3 - if offset param defined, then limit param should be defined', () => {
       it('"limit" param missing', async () => {
         const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
 
         // Remove the "limit" query param.
         testDocument.paths['/v1/drinks'].get.parameters.splice(1, 1);
@@ -370,9 +452,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"limit" response property missing', async () => {
         const testDocument = makeCopy(rootDocument);
 
-        delete testDocument.components.schemas['OffsetPaginationBase']
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
+        delete testDocument.components.schemas.DrinkCollection.allOf[0]
           .properties.limit;
-        testDocument.components.schemas['OffsetPaginationBase'].required.splice(
+        testDocument.components.schemas.DrinkCollection.allOf[0].required.splice(
           1,
           1
         );
@@ -390,11 +477,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"limit" response property not an integer', async () => {
         const testDocument = makeCopy(rootDocument);
 
-        testDocument.components.schemas[
-          'OffsetPaginationBase'
-        ].properties.limit = {
-          type: 'string',
-        };
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
+        testDocument.components.schemas.DrinkCollection.allOf[0].properties.limit =
+          {
+            type: 'string',
+          };
 
         const results = await testRule(ruleId, rule, testDocument);
         expect(results).toHaveLength(1);
@@ -409,8 +500,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"limit" response property not required', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         // Remove "limit" from required list.
-        testDocument.components.schemas['OffsetPaginationBase'].required = [
+        testDocument.components.schemas.DrinkCollection.allOf[0].required = [
           'offset',
           'total_count',
         ];
@@ -430,7 +526,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"offset" response property missing', async () => {
         const testDocument = makeCopy(rootDocument);
 
-        delete testDocument.components.schemas['OffsetPaginationBase']
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
+        delete testDocument.components.schemas.DrinkCollection.allOf[0]
           .properties.offset;
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -446,11 +547,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"offset" response property not an integer', async () => {
         const testDocument = makeCopy(rootDocument);
 
-        testDocument.components.schemas[
-          'OffsetPaginationBase'
-        ].properties.offset = {
-          type: 'boolean',
-        };
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
+        testDocument.components.schemas.DrinkCollection.allOf[0].properties.offset =
+          {
+            type: 'boolean',
+          };
 
         const results = await testRule(ruleId, rule, testDocument);
         expect(results).toHaveLength(1);
@@ -465,8 +570,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"offset" response property not required', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         // Remove "offset" from required list.
-        testDocument.components.schemas['OffsetPaginationBase'].required = [
+        testDocument.components.schemas.DrinkCollection.allOf[0].required = [
           'limit',
           'total_count',
         ];
@@ -486,11 +596,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"total_count" response property not an integer', async () => {
         const testDocument = makeCopy(rootDocument);
 
-        testDocument.components.schemas[
-          'OffsetPaginationBase'
-        ].properties.total_count = {
-          type: 'boolean',
-        };
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
+        testDocument.components.schemas.DrinkCollection.allOf[0].properties.total_count =
+          {
+            type: 'boolean',
+          };
 
         const results = await testRule(ruleId, rule, testDocument);
         expect(results).toHaveLength(1);
@@ -505,8 +619,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('"total_count" response property not required', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         // Remove "total_count" from required list.
-        testDocument.components.schemas['OffsetPaginationBase'].required = [
+        testDocument.components.schemas.DrinkCollection.allOf[0].required = [
           'limit',
           'offset',
         ];
@@ -526,13 +645,18 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('pagelink properties missing', async () => {
         const testDocument = makeCopy(rootDocument);
 
-        delete testDocument.components.schemas['OffsetPaginationBase']
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
+        delete testDocument.components.schemas.DrinkCollection.allOf[0]
           .properties.first;
-        delete testDocument.components.schemas['OffsetPaginationBase']
+        delete testDocument.components.schemas.DrinkCollection.allOf[0]
           .properties.last;
-        delete testDocument.components.schemas['OffsetPaginationBase']
+        delete testDocument.components.schemas.DrinkCollection.allOf[0]
           .properties.previous;
-        delete testDocument.components.schemas['OffsetPaginationBase']
+        delete testDocument.components.schemas.DrinkCollection.allOf[0]
           .properties.next;
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -549,8 +673,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('pagelink properties not an object', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         const paginationProps =
-          testDocument.components.schemas['OffsetPaginationBase'].properties;
+          testDocument.components.schemas.DrinkCollection.allOf[0].properties;
 
         // Define new pagelink properties as strings.
         const stringSchema = {
@@ -564,7 +693,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         };
 
         // Overlay the new pagelink properties onto the schema.
-        testDocument.components.schemas['OffsetPaginationBase'].properties = {
+        testDocument.components.schemas.DrinkCollection.allOf[0].properties = {
           ...paginationProps,
           ...newPageLinks,
         };
@@ -583,8 +712,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('pagelink properties object w/no properties', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         const paginationProps =
-          testDocument.components.schemas['OffsetPaginationBase'].properties;
+          testDocument.components.schemas.DrinkCollection.allOf[0].properties;
 
         // Define pagelink properties as objects with no properties.
         const pageLinkSchema = {
@@ -598,7 +732,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         };
 
         // Overlay the new pagelink properties onto the schema.
-        testDocument.components.schemas['OffsetPaginationBase'].properties = {
+        testDocument.components.schemas.DrinkCollection.allOf[0].properties = {
           ...paginationProps,
           ...newPageLinks,
         };
@@ -617,8 +751,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('pagelink properties object w/no "href" property', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         const paginationProps =
-          testDocument.components.schemas['OffsetPaginationBase'].properties;
+          testDocument.components.schemas.DrinkCollection.allOf[0].properties;
 
         // Define pagelink properties as objects no "href" property.
         const pageLinkSchema = {
@@ -637,7 +776,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         };
 
         // Overlay the new pagelink properties onto the schema.
-        testDocument.components.schemas['OffsetPaginationBase'].properties = {
+        testDocument.components.schemas.DrinkCollection.allOf[0].properties = {
           ...paginationProps,
           ...newPageLinks,
         };
@@ -656,8 +795,13 @@ describe(`Spectral rule: ${ruleId}`, () => {
       it('pagelink properties object w/non-string "href" property', async () => {
         const testDocument = makeCopy(rootDocument);
 
+        testDocument.components.schemas.DrinkCollection.allOf[0] =
+          makeCopy(offsetPaginationBase);
+        testDocument.paths['/v1/drinks'].get.parameters[0] =
+          makeCopy(offsetParameter);
+
         const paginationProps =
-          testDocument.components.schemas['OffsetPaginationBase'].properties;
+          testDocument.components.schemas.DrinkCollection.allOf[0].properties;
 
         // Define pagelink properties as objects no "href" property.
         const pageLinkSchema = {
@@ -676,7 +820,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         };
 
         // Overlay the new pagelink properties onto the schema.
-        testDocument.components.schemas['OffsetPaginationBase'].properties = {
+        testDocument.components.schemas.DrinkCollection.allOf[0].properties = {
           ...paginationProps,
           ...newPageLinks,
         };

--- a/packages/ruleset/test/prefer-token-pagination.test.js
+++ b/packages/ruleset/test/prefer-token-pagination.test.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { preferTokenPagination } = require('../src/rules');
+const {
+  makeCopy,
+  rootDocument,
+  testRule,
+  severityCodes,
+  helperArtifacts,
+} = require('./utils');
+const { offsetPaginationBase, offsetParameter } = helperArtifacts;
+
+const rule = preferTokenPagination;
+const ruleId = 'ibm-prefer-token-pagination';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg =
+  'Token-based pagination is recommended over offset/limit pagination';
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Warn for paginated operation with offset/limit style pagination', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Set up offset/limit pagination
+      testDocument.paths['/v1/drinks'].get.parameters[0] =
+        makeCopy(offsetParameter);
+      testDocument.components.schemas.DrinkCollection.allOf[0] =
+        makeCopy(offsetPaginationBase);
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toBe(expectedMsg);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe('paths./v1/drinks.get');
+    });
+  });
+});

--- a/packages/ruleset/test/ref-sibling-duplicate-description.test.js
+++ b/packages/ruleset/test/ref-sibling-duplicate-description.test.js
@@ -55,12 +55,15 @@ describe(`Spectral rule: ${ruleId}`, () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
+
+      // The second result is for list movies, which also uses the PageLink schema.
+      // This applies to all tests below, as well.
+      expect(results).toHaveLength(2);
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsg);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.0.properties.last'
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.0.properties.last'
       );
     });
     it('Duplicate description inside allOf multiple', async () => {
@@ -81,12 +84,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
+      expect(results).toHaveLength(2);
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsg);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.0.properties.last'
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.0.properties.last'
       );
     });
     it('Duplicate description outside allOf', async () => {
@@ -102,12 +105,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
+      expect(results).toHaveLength(2);
       expect(results[0].code).toBe(ruleId);
       expect(results[0].message).toBe(expectedMsg);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.0.properties.last'
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.0.properties.last'
       );
     });
   });

--- a/packages/ruleset/test/required-property-missing.test.js
+++ b/packages/ruleset/test/required-property-missing.test.js
@@ -172,7 +172,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       description: 'A single page of results containing Drink instances.',
       allOf: [
         {
-          $ref: '#/components/schemas/OffsetPaginationBase',
+          $ref: '#/components/schemas/TokenPaginationBase',
         },
         {
           type: 'object',
@@ -191,7 +191,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
           },
         },
         {
-          // The "first" property is defined in OffsetPaginationBase.
+          // The "first" property is defined in TokenPaginationBase.
           required: ['first'],
         },
       ],

--- a/packages/ruleset/test/utils/helper-artifacts.js
+++ b/packages/ruleset/test/utils/helper-artifacts.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+// Copied from `root-document.js`
+const pageLink = {
+  description: 'Contains a link to a page of paginated results',
+  type: 'object',
+  properties: {
+    href: {
+      description: 'The link value',
+      type: 'string',
+      pattern: '[a-zA-Z0-9 ]+',
+      minLength: 1,
+      maxLength: 30,
+    },
+  },
+};
+
+// These "Offset*" objects exist to provide artifacts that act as a correct
+// baseline for offset/limit style pagination. They are not in the root
+// document because we encourage the use of token-based pagination.
+module.exports.offsetParameter = {
+  name: 'offset',
+  in: 'query',
+  description: 'The offset (origin 0) of the first item to return.',
+  required: false,
+  schema: {
+    type: 'integer',
+    format: 'int32',
+    minimum: 0,
+  },
+};
+
+module.exports.offsetPaginationBase = {
+  description:
+    'A base schema containing properties that support offset-limit pagination.',
+  type: 'object',
+  required: ['offset', 'limit', 'total_count'],
+  properties: {
+    offset: {
+      description:
+        'The offset (origin 0) of the first item returned in the result page.',
+      type: 'integer',
+      format: 'int32',
+    },
+    limit: {
+      description: 'The number of items returned in the result page.',
+      type: 'integer',
+      format: 'int32',
+    },
+    total_count: {
+      description: 'The total number of items across all result pages.',
+      type: 'integer',
+      format: 'int32',
+    },
+    first: pageLink,
+    next: pageLink,
+    previous: pageLink,
+    last: pageLink,
+  },
+};

--- a/packages/ruleset/test/utils/index.js
+++ b/packages/ruleset/test/utils/index.js
@@ -8,6 +8,7 @@ const makeCopy = require('./make-copy');
 const testRule = require('./test-rule');
 const rootDocument = require('./root-document');
 const severityCodes = require('./severity-codes');
+const helperArtifacts = require('./helper-artifacts');
 
 module.exports = {
   allSchemasDocument,
@@ -15,4 +16,5 @@ module.exports = {
   rootDocument,
   testRule,
   severityCodes,
+  helperArtifacts,
 };

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -88,14 +88,15 @@ module.exports = {
         ],
         parameters: [
           {
-            name: 'offset',
+            name: 'start',
             in: 'query',
-            description: 'The offset (origin 0) of the first item to return.',
+            description: 'A token which indicates the first item to return.',
             required: false,
             schema: {
-              type: 'integer',
-              format: 'int32',
-              minimum: 0,
+              type: 'string',
+              pattern: '[a-zA-Z0-9 ]+',
+              minLength: 1,
+              maxLength: 128,
             },
           },
           {
@@ -355,7 +356,6 @@ module.exports = {
                   $ref: '#/components/schemas/MovieCollection',
                 },
                 example: {
-                  offset: 0,
                   limit: 2,
                   total_count: 2,
                   first: {
@@ -751,7 +751,7 @@ module.exports = {
         description: 'A single page of results containing Drink instances.',
         allOf: [
           {
-            $ref: '#/components/schemas/OffsetPaginationBase',
+            $ref: '#/components/schemas/TokenPaginationBase',
           },
           {
             type: 'object',
@@ -771,7 +771,6 @@ module.exports = {
           },
         ],
         example: {
-          offset: 0,
           limit: 1,
           total_count: 1,
           first: {
@@ -895,42 +894,6 @@ module.exports = {
         minLength: 1,
         maxLength: 32,
         pattern: '.*',
-      },
-      OffsetPaginationBase: {
-        description:
-          'A base schema containing properties that support offset-limit pagination.',
-        type: 'object',
-        required: ['offset', 'limit', 'total_count'],
-        properties: {
-          offset: {
-            description:
-              'The offset (origin 0) of the first item returned in the result page.',
-            type: 'integer',
-            format: 'int32',
-          },
-          limit: {
-            description: 'The number of items returned in the result page.',
-            type: 'integer',
-            format: 'int32',
-          },
-          total_count: {
-            description: 'The total number of items across all result pages.',
-            type: 'integer',
-            format: 'int32',
-          },
-          first: {
-            $ref: '#/components/schemas/PageLink',
-          },
-          next: {
-            $ref: '#/components/schemas/PageLink',
-          },
-          previous: {
-            $ref: '#/components/schemas/PageLink',
-          },
-          last: {
-            $ref: '#/components/schemas/PageLink',
-          },
-        },
       },
       TokenPaginationBase: {
         description:

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean-with-tabs.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean-with-tabs.yml
@@ -31,13 +31,15 @@ paths:
 						format: int32
 						default: 10
 						maximum: 100
-				- name: offset
+				- name: start
 					in: query
-					description: Offset of first element to return in results.
+					description: A token which indicates the first item to return
 					required: false
 					schema:
-						type: integer
-						format: int32
+						type: string
+						pattern: '[a-zA-Z0-9 ]+'
+						minLength: 1
+						maxLength: 128
 			responses:
 				'200':
 					description: A paged array of pets
@@ -142,7 +144,6 @@ components:
 			required:
 				- pets
 				- limit
-				- offset
 			properties:
 				pets:
 					type: array
@@ -155,10 +156,6 @@ components:
 					type: integer
 					format: int32
 					description: limit
-				offset:
-					type: integer
-					format: int32
-					description: offset
 				next_token:
 					type: string
 					description: next token
@@ -185,7 +182,6 @@ components:
 					tag: dog
 				next_url: 'https://www.nexturl.com'
 				limit: 50
-				offset: 20
 				next_token: TOKEN_STRING
 		PageLink:
 			type: object

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
@@ -31,13 +31,15 @@ paths:
             format: int32
             default: 10
             maximum: 100
-        - name: offset
+        - name: start
           in: query
-          description: Offset of first element to return in results.
+          description: A token which indicates the first item to return
           required: false
           schema:
-            type: integer
-            format: int32
+            type: string
+            pattern: '[a-zA-Z0-9 ]+'
+            minLength: 1
+            maxLength: 128
       responses:
         '200':
           description: A paged array of pets
@@ -142,7 +144,6 @@ components:
       required:
         - pets
         - limit
-        - offset
       properties:
         pets:
           type: array
@@ -155,10 +156,6 @@ components:
           type: integer
           format: int32
           description: limit
-        offset:
-          type: integer
-          format: int32
-          description: offset
         next_token:
           type: string
           description: next token
@@ -185,7 +182,6 @@ components:
           tag: dog
         next_url: 'https://www.nexturl.com'
         limit: 50
-        offset: 20
         next_token: TOKEN_STRING
     PageLink:
       type: object

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -215,11 +215,9 @@ describe('Expected output tests', function () {
       const jsonOutput = JSON.parse(capturedText);
       const warningToCheck = jsonOutput.warning.results[0];
 
-      expect(warningToCheck.rule).toEqual('ibm-collection-array-property');
-      expect(warningToCheck.path.join('.')).toBe(
-        'components.schemas.ListOfCharacters'
-      );
-      expect(warningToCheck.line).toEqual(94);
+      expect(warningToCheck.rule).toEqual('ibm-prefer-token-pagination');
+      expect(warningToCheck.path.join('.')).toBe('paths./letters.get');
+      expect(warningToCheck.line).toEqual(20);
     });
   });
 });


### PR DESCRIPTION
Adds a rule to check paginated list operations for offset/limit style pagination. If found, a warning is given encouraging the user to use token-based pagination instead.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
