### PR TITLE
feat(new-rule): ibm-resource-response-consistency

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -82,6 +82,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-request-and-response-content](#ibm-request-and-response-content)
   * [ibm-requestbody-is-object](#ibm-requestbody-is-object)
   * [ibm-requestbody-name](#ibm-requestbody-name)
+  * [ibm-resource-response-consistency](#ibm-resource-response-consistency)
   * [ibm-response-status-codes](#ibm-response-status-codes)
   * [ibm-schema-description](#ibm-schema-description)
   * [ibm-schema-type](#ibm-schema-type)
@@ -450,6 +451,12 @@ or <code>application/merge-patch+json</code>.</td>
 <td>warn</td>
 <td>An operation should specify a request body name (with the <code>x-codegen-request-body-name</code> extension) if its requestBody
 has non-form content.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-resource-response-consistency">ibm-resource-response-consistency</a></td>
+<td>warn</td>
+<td>Operations that create or update a resource should return the same schema as the "GET" request for the resource.</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -4611,6 +4618,87 @@ paths:
 </tr>
 </table>
 
+### ibm-resource-response-consistency
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-requestbody-name</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>Synchronous responses for create-style POST or update (PUT/PATCH) operations on a given resource should return the canonical schema for the resource. As in, the same schema as the "GET" request for the same resource.</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/thing':
+    post:
+      operationId: create_thing
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ThingPrototype'
+      responses:
+        201:
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/OtherThing' # should be a ref to 'Thing'
+  '/v1/thing/{id}':
+    get:
+      operationId: get_thing
+      responses:
+        200:
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Thing'
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/thing':
+    post:
+      operationId: create_thing
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ThingPrototype'
+      responses:
+        201:
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Thing'
+  '/v1/thing/{id}':
+    get:
+      operationId: get_thing
+      responses:
+        200:
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Thing'
+</pre>
+</td>
+</tr>
+</table>
 
 ### ibm-response-status-codes
 <table>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -46,6 +46,7 @@ module.exports = {
   refSiblingDuplicateDescription: require('./ref-sibling-duplicate-description'),
   requestBodyNameExists: require('./requestbody-name-exists'),
   requiredProperty: require('./required-property'),
+  resourceResponseConsistency: require('./resource-response-consistency'),
   responseExampleExists: require('./response-example-exists'),
   responseStatusCodes: require('./response-status-codes'),
   schemaDescriptionExists: require('./schema-description-exists'),

--- a/packages/ruleset/src/functions/resource-response-consistency.js
+++ b/packages/ruleset/src/functions/resource-response-consistency.js
@@ -1,0 +1,250 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isEqual } = require('lodash');
+const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+const {
+  getResourceSpecificSiblingPath,
+  getResponseCodes,
+  isCreateOperation,
+  isJsonMimeType,
+  isOperationOfType,
+  LoggerFactory,
+} = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (operation, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+
+  return resourceResponseConsistency(
+    operation,
+    context.path,
+    context.documentInventory.resolved
+  );
+};
+
+/**
+ * Checks that operations that create or update a resource should
+ * return the same schema as the "GET" request for the resource.
+ *
+ * An operation is considered to be a "create" operation if the operationId
+ * starts with "create" OR it's a POST request and there is a similar path
+ * but with a trailing path parameter reference.
+ *
+ * An operation is considered to be an "update" operation if the method type
+ * is "put" or "patch".
+ *
+ * @param {*} operation an operation within the API definition
+ * @param {*} path the array of path segments indicating the "location" of the operation within the API definition
+ * @param {*} apidef the resolved API spec
+ * @returns an array containing the violations found or [] if no violations
+ */
+function resourceResponseConsistency(operation, path, apidef) {
+  logger.debug(
+    `${ruleId}: checking responses for operation at location: ${path.join('.')}`
+  );
+
+  // This rule only applies to POSTs if they are determined to be "create" operations.
+  if (
+    isOperationOfType('post', path) &&
+    !isCreateOperation(operation, path, apidef)
+  ) {
+    // In this case, no need to check the responses.
+    logger.debug(
+      `${ruleId}: operation is not a "create", PUT, or PATCH - no need to check`
+    );
+    return [];
+  }
+
+  const canonicalSchema = getCanonicalSchema(path, apidef);
+
+  // If the GET request does not define a schema in its response, there is nothing left to check.
+  if (!canonicalSchema) {
+    logger.debug(
+      `${ruleId}: no response schema found for GET request - abandoning check for this operation`
+    );
+    return [];
+  }
+
+  // If there are no responses defined, there is nothing to check.
+  // We validate for that issue elsewhere.
+  if (!operation.responses) {
+    logger.debug(
+      `${ruleId}: no responses object found on operation at location: ${path.join(
+        '.'
+      )}`
+    );
+    return [];
+  }
+
+  const [, successCodes] = getResponseCodes(operation.responses);
+  logger.debug(
+    `${ruleId}: operation has the following successCodes codes: ${successCodes.join(
+      ', '
+    )}`
+  );
+
+  // If there are no success code responses, there is nothing to check.
+  // We validate for that issue elsewhere.
+  if (!successCodes || !successCodes.length) {
+    logger.debug(
+      `${ruleId}: no success codes found on operation at location: ${path.join(
+        '.'
+      )}`
+    );
+    return [];
+  }
+
+  const errors = [];
+
+  // Check defined, synchronous success responses for schema content that is equivalent
+  // to the canonical schema, as defined by the corresponding GET request.
+  // Appropriate use of other codes that don't define body content, like 202 or 204,
+  // is validated for elsewhere.
+  ['200', '201'].forEach(code => {
+    if (successCodes.includes(code)) {
+      const successResponse = operation.responses[code];
+      if (
+        !isObject(successResponse) ||
+        !successResponse.content ||
+        !isObject(successResponse.content)
+      ) {
+        logger.debug(
+          `${ruleId}: operation's ${code} response is missing a 'content' object, nothing to check`
+        );
+
+        // Return from this loop iteration (i.e. continue). We check for missing content elsewhere.
+        return;
+      }
+
+      // Only checking JSON content objects that define a schema.
+      Object.keys(successResponse.content)
+        .filter(mimeType => isJsonMimeType(mimeType))
+        .forEach(mimeType => {
+          logger.debug(
+            `${ruleId}: checking responses's ${mimeType} content object`
+          );
+
+          const jsonContent = successResponse.content[mimeType];
+          if (!isObject(jsonContent) || !jsonContent.schema) {
+            logger.debug(
+              `${ruleId}: responses's ${mimeType} content is missing a 'schema' object, nothing to check`
+            );
+
+            // Return from this loop iteration (i.e. continue). We check for a missing schema elsewhere.
+            return;
+          }
+
+          if (!isEqual(canonicalSchema, jsonContent.schema)) {
+            logger.debug(
+              `${ruleId}: success response schema for this operation does not match the corresponding GET response schema`
+            );
+            errors.push({
+              message:
+                'Operations on a resource should return the same schema as the resource "get" request',
+              path: [...path, 'responses', code, 'content', mimeType, 'schema'],
+            });
+          }
+        });
+    }
+  });
+
+  if (errors.length === 0) {
+    logger.debug(
+      `${ruleId}: operation at location "${path.join('.')}" passed!`
+    );
+  }
+
+  return errors;
+}
+
+function getCanonicalSchema(path, apidef) {
+  const resourceSpecificPath = isOperationOfType('post', path)
+    ? getResourceSpecificSiblingPath(path, apidef)
+    : // This is a PUT or PATCH and should already be on the path we need
+      path[path.length - 2].toString().trim();
+
+  logger.debug(
+    `${ruleId}: calculated resource-specific path to be "${resourceSpecificPath}"`
+  );
+
+  if (!resourceSpecificPath || !apidef.paths[resourceSpecificPath]) {
+    logger.debug(
+      `${ruleId}: resource-specific path "${resourceSpecificPath}" does not exist`
+    );
+    return;
+  }
+
+  const resourceGetOperation = apidef.paths[resourceSpecificPath].get;
+  if (!resourceGetOperation) {
+    logger.debug(
+      `${ruleId}: no GET operation found at path "${resourceSpecificPath}"`
+    );
+    return;
+  }
+  if (!resourceGetOperation.responses) {
+    logger.debug(
+      `${ruleId}: no responses defined on GET operation at path "${resourceSpecificPath}"`
+    );
+    return;
+  }
+
+  const [, getOpSuccessCodes] = getResponseCodes(
+    resourceGetOperation.responses
+  );
+
+  logger.debug(
+    `${ruleId}: corresponding GET operation has the following status codes: ${getOpSuccessCodes.join(
+      ', '
+    )}`
+  );
+
+  if (
+    !getOpSuccessCodes ||
+    !getOpSuccessCodes.length ||
+    !getOpSuccessCodes.includes('200')
+  ) {
+    logger.debug(
+      `${ruleId}: no 200 success code found in responses defined on GET operation at path "${resourceSpecificPath}"`
+    );
+    return;
+  }
+
+  const successResponse = resourceGetOperation.responses['200'];
+  if (!successResponse.content || !isObject(successResponse.content)) {
+    return;
+  }
+
+  // Find the first content object determined to be JSON -
+  // we are only interested in JSON content.
+  const jsonMimeType = Object.keys(successResponse.content).find(mimeType =>
+    isJsonMimeType(mimeType)
+  );
+  if (!jsonMimeType) {
+    logger.debug(
+      `${ruleId}: no JSON content found on 200 response defined on GET operation at path "${resourceSpecificPath}"`
+    );
+    return;
+  }
+
+  const jsonContent = successResponse.content[jsonMimeType];
+  if (!isObject(jsonContent) || !jsonContent.schema) {
+    logger.debug(
+      `${ruleId}: no JSON content schema found in 200 response defined on GET operation at path "${resourceSpecificPath}"`
+    );
+    return;
+  }
+
+  logger.debug(
+    `${ruleId}: found schema in ${jsonMimeType} content object in 200 response defined on GET operation at path "${resourceSpecificPath}"`
+  );
+
+  return jsonContent.schema;
+}

--- a/packages/ruleset/src/functions/response-status-codes.js
+++ b/packages/ruleset/src/functions/response-status-codes.js
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const { LoggerFactory } = require('../utils');
+const {
+  LoggerFactory,
+  isCreateOperation,
+  getResponseCodes,
+} = require('../utils');
 
 let ruleId;
 let logger;
@@ -129,37 +133,4 @@ function responseStatusCodes(operation, path, apidef) {
   }
 
   return errors;
-}
-
-function isCreateOperation(operation, path, apidef) {
-  // 1. If operationId starts with "create", we'll assume it's a create operation.
-  if (
-    operation.operationId &&
-    operation.operationId.toString().trim().toLowerCase().startsWith('create')
-  ) {
-    return true;
-  }
-
-  // 2. If not a POST, then it's not a create operation.
-  const method = path[path.length - 1].toString().trim().toLowerCase();
-  if (method !== 'post') {
-    return false;
-  }
-
-  // 3. Does this operation's path have a sibling path with a trailing path param reference?
-  const thisPath = path[path.length - 2].toString().trim();
-  const siblingPathRE = new RegExp(`^${thisPath}/{[^{}/]+}$`);
-  const siblingPath = Object.keys(apidef.paths).find(p =>
-    siblingPathRE.test(p)
-  );
-
-  return !!siblingPath;
-}
-
-function getResponseCodes(responses) {
-  const statusCodes = Object.keys(responses).filter(code =>
-    code.match(/^[1-5][0-9][0-9]$/)
-  );
-  const successCodes = statusCodes.filter(code => code.match(/^2[0-9][0-9]$/));
-  return [statusCodes, successCodes];
 }

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -152,6 +152,7 @@ module.exports = {
     'ibm-request-and-response-content': ibmRules.contentExists,
     'ibm-requestbody-is-object': ibmRules.requestBodyIsObject,
     'ibm-requestbody-name': ibmRules.requestBodyNameExists,
+    'ibm-resource-response-consistency': ibmRules.resourceResponseConsistency,
     'ibm-response-status-codes': ibmRules.responseStatusCodes,
     'ibm-schema-description': ibmRules.schemaDescriptionExists,
     'ibm-schema-type': ibmRules.schemaTypeExists,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -58,6 +58,7 @@ module.exports = {
   requestBodyIsObject: require('./requestbody-is-object'),
   requestBodyNameExists: require('./requestbody-name-exists'),
   requiredPropertyMissing: require('./required-property-missing'),
+  resourceResponseConsistency: require('./resource-response-consistency'),
   responseExampleExists: require('./response-example-exists'),
   responseStatusCodes: require('./response-status-codes'),
   schemaDescriptionExists: require('./schema-description-exists'),

--- a/packages/ruleset/src/rules/resource-response-consistency.js
+++ b/packages/ruleset/src/rules/resource-response-consistency.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3 } = require('@stoplight/spectral-formats');
+const { resourceResponseConsistency } = require('../functions');
+
+module.exports = {
+  description:
+    'Operations that create or update a resource should return the same schema as the "GET" request for the resource.',
+  message: '{{error}}',
+  formats: [oas3],
+  given: [`$.paths[*][put,post,patch]`],
+  severity: 'warn',
+  resolved: true,
+  then: {
+    function: resourceResponseConsistency,
+  },
+};

--- a/packages/ruleset/src/utils/get-resource-specific-sibling-path.js
+++ b/packages/ruleset/src/utils/get-resource-specific-sibling-path.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+
+/**
+ * Given an operation on a generic resource path (e.g. /foo) to an operation,
+ * look for a specific resource path that is a sibling (e.g. /foo/{id}); if
+ * found, return the sibling path as a string.
+ *
+ * Note: the given path MUST be to an operation object.
+ *
+ * @param {*} path the array of path segments indicating the "location" of an operation within the API definition
+ * @param {*} apidef the resolved API spec, as an object
+ * @returns the specific resource path, as a string
+ */
+function getResourceSpecificSiblingPath(path, apidef) {
+  // Paths are expected to be arrays, API def is expected to be an object
+  if (!Array.isArray(path) || !isObject(apidef)) {
+    return;
+  }
+
+  // If this path already ends with a path parameter, return 'undefined'.
+  // This function should only find a path if it is a sibling of the current path.
+  if (path[path.length - 2].toString().trim().endsWith('}')) {
+    return;
+  }
+
+  const thisPath = path[path.length - 2].toString().trim();
+  const siblingPathRE = new RegExp(`^${thisPath}/{[^{}/]+}$`);
+  return Object.keys(apidef.paths).find(p => siblingPathRE.test(p));
+}
+
+module.exports = getResourceSpecificSiblingPath;

--- a/packages/ruleset/src/utils/get-response-codes.js
+++ b/packages/ruleset/src/utils/get-response-codes.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+
+/**
+ * For an OpenAPI 'responses' object, gather all of the defined
+ * status codes, as well as the success (2XX) codes, and return
+ * them together as a tuple.
+ */
+function getResponseCodes(responses) {
+  if (!isObject(responses)) {
+    return [[], []];
+  }
+  const statusCodes = Object.keys(responses).filter(code =>
+    code.match(/^[1-5][0-9][0-9]$/)
+  );
+  const successCodes = statusCodes.filter(code => code.match(/^2[0-9][0-9]$/));
+  return [statusCodes, successCodes];
+}
+
+module.exports = getResponseCodes;

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -5,14 +5,18 @@
 
 module.exports = {
   getCompositeSchemaAttribute: require('./get-composite-schema-attribute'),
-  ...require('./pagination-utils'),
+  getResourceSpecificSiblingPath: require('./get-resource-specific-sibling-path'),
+  getResponseCodes: require('./get-response-codes'),
+  isCreateOperation: require('./is-create-operation'),
   isDeprecated: require('./is-deprecated'),
   isEmptyObjectSchema: require('./is-empty-object-schema'),
+  isOperationOfType: require('./is-operation-of-type'),
   isRefSiblingSchema: require('./is-ref-sibling-schema'),
   isRequestBodyExploded: require('./is-requestbody-exploded'),
   LoggerFactory: require('./logger-factory'),
   mergeAllOfSchemaProperties: require('./merge-allof-schema-properties'),
-  ...require('./mimetype-utils'),
   operationMethods: require('./constants'),
   pathMatchesRegexp: require('./path-matches-regexp'),
+  ...require('./mimetype-utils'),
+  ...require('./pagination-utils'),
 };

--- a/packages/ruleset/src/utils/is-create-operation.js
+++ b/packages/ruleset/src/utils/is-create-operation.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+const isOperationOfType = require('./is-operation-of-type');
+const getResourceSpecificSiblingPath = require('./get-resource-specific-sibling-path');
+
+/**
+ * Returns `true` if the operation represents a "create" operation.
+ *
+ * An operation is considered to be a "create" operation if the operationId starts with "create"
+ *    OR it's a POST request and there is a similar path but with a trailing path parameter reference.
+ *
+ * Note: the given path MUST be to an operation object.
+ */
+function isCreateOperation(operation, path, apidef) {
+  // Paths are expected to be arrays, API def and operation are expected to be objects
+  if (!Array.isArray(path) || !isObject(operation) || !isObject(apidef)) {
+    return false;
+  }
+
+  // 1. If operationId starts with "create", we'll assume it's a create operation.
+  if (
+    operation.operationId &&
+    operation.operationId.toString().trim().toLowerCase().startsWith('create')
+  ) {
+    return true;
+  }
+
+  // 2. If not a POST, then it's not a create operation.
+  if (!isOperationOfType('post', path)) {
+    return false;
+  }
+
+  // 3. Does this operation's path have a sibling path with a trailing path param reference?
+  const siblingPath = getResourceSpecificSiblingPath(path, apidef);
+  return !!siblingPath;
+}
+
+module.exports = isCreateOperation;

--- a/packages/ruleset/src/utils/is-operation-of-type.js
+++ b/packages/ruleset/src/utils/is-operation-of-type.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+/**
+ * Checks a path to a given operation to determine if it is an
+ * operation of a given type (e.g. 'post', 'patch', etc.)
+ *
+ * Note: the given path MUST be to an operation object.
+ *
+ * @param {*} type an operation method type,  like 'get' or 'put'
+ * @param {*} path the array of path segments indicating the "location" of the operation within the API definition
+ * @returns a boolean value indicating if the operation is of the given type, based on the path
+ */
+function isOperationOfType(type, path) {
+  if (typeof type !== 'string' || !Array.isArray(path)) {
+    return false;
+  }
+
+  return type === path[path.length - 1].toString().trim().toLowerCase();
+}
+
+module.exports = isOperationOfType;

--- a/packages/ruleset/test/array-attributes.test.js
+++ b/packages/ruleset/test/array-attributes.test.js
@@ -497,7 +497,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
 
       const expectedPaths = [
         'paths./v1/movies.post.requestBody.content.application/json.schema.additionalProperties',
@@ -505,6 +505,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.additionalProperties',
         'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.additionalProperties',
         'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.additionalProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.additionalProperties',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);

--- a/packages/ruleset/test/array-of-arrays.test.js
+++ b/packages/ruleset/test/array-of-arrays.test.js
@@ -143,7 +143,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMessage);

--- a/packages/ruleset/test/avoid-multiple-types.test.js
+++ b/packages/ruleset/test/avoid-multiple-types.test.js
@@ -91,7 +91,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       ];
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMessage);
@@ -111,6 +111,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       );
       expect(results[4].path.join('.')).toBe(
         'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.properties.imdb_url.type'
+      );
+      expect(results[5].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.properties.imdb_url.type'
       );
     });
     it('Multiple values in type list - parameter', async () => {

--- a/packages/ruleset/test/get-resource-specific-sibling-path.test.js
+++ b/packages/ruleset/test/get-resource-specific-sibling-path.test.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { getResourceSpecificSiblingPath } = require('../src/utils');
+
+describe('Utility function: getResourceSpecificSiblingPath', () => {
+  it('should find sibling path when present', () => {
+    const path = ['paths', '/v1/things', 'post'];
+    const apidef = {
+      paths: {
+        '/v1/things': {
+          post: {},
+        },
+        '/v1/things/{id}': {
+          get: {},
+        },
+        '/v1/other_things/{id}': {
+          get: {},
+        },
+      },
+    };
+
+    expect(getResourceSpecificSiblingPath(path, apidef)).toBe(
+      '/v1/things/{id}'
+    );
+  });
+
+  it('should return undefined when sibling path is not present', () => {
+    const path = ['paths', '/v1/things', 'post'];
+    const apidef = {
+      paths: {
+        '/v1/things': {
+          post: {},
+        },
+        '/v1/other_things/{id}': {
+          get: {},
+        },
+      },
+    };
+
+    expect(getResourceSpecificSiblingPath(path, apidef)).toBeUndefined();
+  });
+
+  it('should return undefined when there are no other paths', () => {
+    const path = ['paths', '/v1/things', 'post'];
+    const apidef = {
+      paths: {
+        '/v1/things': {
+          post: {},
+        },
+      },
+    };
+
+    expect(getResourceSpecificSiblingPath(path, apidef)).toBeUndefined();
+  });
+
+  it('should return undefined when given path already ends in a path parameter', () => {
+    const path = ['paths', '/v1/things/{id}', 'get'];
+    const apidef = {
+      paths: {
+        '/v1/things/{id}': {
+          get: {},
+        },
+      },
+    };
+
+    expect(getResourceSpecificSiblingPath(path, apidef)).toBeUndefined();
+  });
+
+  it('should return undefined when path is not an array', () => {
+    const path = 'wrong';
+    const apidef = {
+      paths: {
+        '/v1/things': {
+          post: {},
+        },
+      },
+    };
+
+    expect(getResourceSpecificSiblingPath(path, apidef)).toBeUndefined();
+  });
+
+  it('should return undefined when apidef is not an object', () => {
+    const path = ['paths', '/v1/things', 'post'];
+    const apidef = 'wrong';
+    expect(getResourceSpecificSiblingPath(path, apidef)).toBeUndefined();
+  });
+});

--- a/packages/ruleset/test/get-response-codes.test.js
+++ b/packages/ruleset/test/get-response-codes.test.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { getResponseCodes } = require('../src/utils');
+
+describe('Utility function: getResponseCodes', () => {
+  it('should return a tuple of empty arrays if responses is undefined', () => {
+    const responses = undefined;
+    const [statusCodes, successCodes] = getResponseCodes(responses);
+    expect(Array.isArray(statusCodes)).toBe(true);
+    expect(statusCodes.length).toBe(0);
+    expect(Array.isArray(successCodes)).toBe(true);
+    expect(successCodes.length).toBe(0);
+  });
+
+  it('should return a populated status array and empty success array', () => {
+    const responses = {
+      400: {},
+      401: {},
+      500: {},
+    };
+    const [statusCodes, successCodes] = getResponseCodes(responses);
+    expect(Array.isArray(statusCodes)).toBe(true);
+    expect(statusCodes).toStrictEqual(['400', '401', '500']);
+    expect(Array.isArray(successCodes)).toBe(true);
+    expect(successCodes.length).toBe(0);
+  });
+
+  it('should populate both success and status array with correct codes', () => {
+    const responses = {
+      200: {},
+      201: {},
+      400: {},
+      401: {},
+      500: {},
+    };
+    const [statusCodes, successCodes] = getResponseCodes(responses);
+    expect(Array.isArray(statusCodes)).toBe(true);
+    expect(statusCodes).toStrictEqual(['200', '201', '400', '401', '500']);
+    expect(Array.isArray(successCodes)).toBe(true);
+    expect(successCodes).toStrictEqual(['200', '201']);
+  });
+});

--- a/packages/ruleset/test/is-create-operation.test.js
+++ b/packages/ruleset/test/is-create-operation.test.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isCreateOperation } = require('../src/utils');
+
+describe('Utility function: isCreateOperation', () => {
+  it(`should return true if given operation's id starts with 'create'`, () => {
+    const operation = {
+      operationId: 'create_drink',
+    };
+    const path = [];
+    const apidef = {};
+    expect(isCreateOperation(operation, path, apidef)).toBe(true);
+  });
+
+  it('should return true if op is a post and there is a resource-specific sibling path', () => {
+    const operation = {
+      operationId: 'add_drink',
+    };
+    const path = ['paths', '/v1/drinks', 'post'];
+    const apidef = {
+      paths: {
+        '/v1/drinks': {
+          post: {},
+        },
+        '/v1/drinks/{id}': {},
+      },
+    };
+    expect(isCreateOperation(operation, path, apidef)).toBe(true);
+  });
+
+  it('should return false if op is not a post', () => {
+    const operation = {
+      operationId: 'replace_drink',
+    };
+    const path = ['paths', '/v1/drinks', 'put'];
+    const apidef = {
+      paths: {
+        '/v1/drinks': {
+          put: {},
+        },
+        '/v1/drinks/{id}': {},
+      },
+    };
+    expect(isCreateOperation(operation, path, apidef)).toBe(false);
+  });
+
+  it('should return false if op is a post but there is no resource-specific sibling path', () => {
+    const operation = {
+      operationId: 'add_drink',
+    };
+    const path = ['paths', '/v1/drinks', 'post'];
+    const apidef = {
+      paths: {
+        '/v1/drinks': {
+          post: {},
+        },
+      },
+    };
+    expect(isCreateOperation(operation, path, apidef)).toBe(false);
+  });
+
+  it('should return false if op is a post on a resource-specific sibling path', () => {
+    const operation = {
+      operationId: 'do_something_with_a_drink',
+    };
+    const path = ['paths', '/v1/drinks/{id}', 'post'];
+    const apidef = {
+      paths: {
+        '/v1/drinks/{id}': {
+          post: {},
+        },
+      },
+    };
+    expect(isCreateOperation(operation, path, apidef)).toBe(false);
+  });
+
+  it('should return false if path is not an array', () => {
+    const operation = {
+      operationId: 'add_drink',
+    };
+    const path = 'paths./v1/drinks.post';
+    const apidef = {
+      paths: {
+        '/v1/drinks': {
+          post: {},
+        },
+        '/v1/drinks/{id}': {},
+      },
+    };
+    expect(isCreateOperation(operation, path, apidef)).toBe(false);
+  });
+
+  it('should return false if operation is not an object', () => {
+    const operation = undefined;
+    const path = ['paths', '/v1/drinks', 'post'];
+    const apidef = {
+      paths: {
+        '/v1/drinks': {
+          post: {},
+        },
+        '/v1/drinks/{id}': {},
+      },
+    };
+    expect(isCreateOperation(operation, path, apidef)).toBe(false);
+  });
+
+  it('should return false if apidef is not an object', () => {
+    const operation = {
+      operationId: 'add_drink',
+    };
+    const path = ['paths', '/v1/drinks', 'post'];
+    const apidef = null;
+    expect(isCreateOperation(operation, path, apidef)).toBe(false);
+  });
+});

--- a/packages/ruleset/test/is-operation-of-type.test.js
+++ b/packages/ruleset/test/is-operation-of-type.test.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isOperationOfType } = require('../src/utils');
+
+describe('Utility function: getResourceSpecificSiblingPath', () => {
+  it('should return `true` when path matches the given type', () => {
+    expect(isOperationOfType('get', ['paths', '/v1/things', 'get'])).toBe(true);
+  });
+
+  it('should return `false` when path does not match the given type', () => {
+    expect(isOperationOfType('post', ['paths', '/v1/things', 'get'])).toBe(
+      false
+    );
+  });
+
+  it('should return `false` when type is not a string', () => {
+    expect(isOperationOfType(42, ['paths', '/v1/things', 'get'])).toBe(false);
+  });
+
+  it('should return `false` when path is not an array', () => {
+    expect(isOperationOfType('get', 'not an array')).toBe(false);
+  });
+});

--- a/packages/ruleset/test/pattern-properties.test.js
+++ b/packages/ruleset/test/pattern-properties.test.js
@@ -59,7 +59,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Movie'].additionalProperties = true;
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
 
       const expectedPaths = [
         'paths./v1/movies.post.requestBody.content.application/json.schema',
@@ -67,6 +67,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items',
         'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema',
         'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);
@@ -81,7 +82,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Movie'].patternProperties = 'foo';
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
 
       const expectedPaths = [
         'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
@@ -89,6 +90,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
         'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
         'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.patternProperties',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);
@@ -103,7 +105,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Movie'].patternProperties = {};
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
 
       const expectedPaths = [
         'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
@@ -111,6 +113,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
         'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
         'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.patternProperties',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);
@@ -132,7 +135,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
 
       const expectedPaths = [
         'paths./v1/movies.post.requestBody.content.application/json.schema.patternProperties',
@@ -140,6 +143,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
         'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
         'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.patternProperties',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);

--- a/packages/ruleset/test/property-description.test.js
+++ b/packages/ruleset/test/property-description.test.js
@@ -176,7 +176,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['IdString'].description = '';
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toBe(expectedMsg);

--- a/packages/ruleset/test/property-name-collision.test.js
+++ b/packages/ruleset/test/property-name-collision.test.js
@@ -44,7 +44,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
     const results = await testRule(ruleId, rule, testDocument);
 
-    expect(results).toHaveLength(5);
+    expect(results).toHaveLength(6);
 
     const validation = results[0];
     expect(validation.code).toBe(ruleId);

--- a/packages/ruleset/test/resource-response-consistency.test.js
+++ b/packages/ruleset/test/resource-response-consistency.test.js
@@ -1,0 +1,276 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { resourceResponseConsistency } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = resourceResponseConsistency;
+const ruleId = 'ibm-resource-response-consistency';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg =
+  'Operations on a resource should return the same schema as the resource "get" request';
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('202 create response does not need to match canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/drinks'].post.responses['201'];
+      testDocument.paths['/v1/drinks'].post.responses['202'] = {
+        description: 'Asynchronous success!',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              description: 'object containing status of creation operation',
+              properties: {
+                status: {
+                  type: 'string',
+                  description: 'current state of resource',
+                  enum: ['pending', 'failed', 'created'],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('create operation defines no responses', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/drinks'].post.responses;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('create operation defines no success codes', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/drinks'].post.responses['201'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('create operation defines no success response content', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/drinks'].post.responses['201'].content;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('create operation defines no JSON response content', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('create operation defines no schema for JSON response content', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      delete testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('200 create request that does not return canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // convert 201 response into 200
+      testDocument.paths['/v1/drinks'].post.responses['200'] =
+        testDocument.paths['/v1/drinks'].post.responses['201'];
+      delete testDocument.paths['/v1/drinks'].post.responses['201'];
+
+      // redo the response schema
+      testDocument.paths['/v1/drinks'].post.responses['200'].content[
+        'application/json'
+      ].schema.$ref = '#/components/schemas/Car';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.200.content.application/json.schema'
+      );
+    });
+
+    it('201 create request that does not return canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema.$ref = '#/components/schemas/Car';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema'
+      );
+    });
+
+    it('warns for all JSON content schemas on creat that do not match canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema.$ref = '#/components/schemas/Car';
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json; charset=utf-8'
+      ] = {
+        schema: {
+          $ref: '#/components/schemas/Car',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema'
+      );
+
+      expect(results[1].code).toBe(ruleId);
+      expect(results[1].message).toBe(expectedMsg);
+      expect(results[1].severity).toBe(expectedSeverity);
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json; charset=utf-8.schema'
+      );
+    });
+
+    it('warns for both 200 and 201 responses on create that do not match the canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].post.responses['200'] = {
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Car',
+            },
+          },
+        },
+      };
+
+      testDocument.paths['/v1/drinks'].post.responses['201'].content[
+        'application/json'
+      ].schema.$ref = '#/components/schemas/Car';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.200.content.application/json.schema'
+      );
+
+      expect(results[1].code).toBe(ruleId);
+      expect(results[1].message).toBe(expectedMsg);
+      expect(results[1].severity).toBe(expectedSeverity);
+      expect(results[1].path.join('.')).toBe(
+        'paths./v1/drinks.post.responses.201.content.application/json.schema'
+      );
+    });
+
+    it('200 PUT request that does not return canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies/{movie_id}'].put.responses['200'] = {
+        content: {
+          'application/json; charset=utf-8': {
+            schema: {
+              $ref: '#/components/schemas/Car',
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json; charset=utf-8.schema'
+      );
+    });
+
+    it('200 PATCH request that does not return canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/cars/{car_id}'].patch.responses['200'].content[
+        'application/json'
+      ].schema.$ref = '#/components/schemas/Movie';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema'
+      );
+    });
+
+    it('Specific JSON content on GET request is found for comparison', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/cars/{car_id}'].patch.responses['200'].content[
+        'application/json'
+      ].schema.$ref = '#/components/schemas/Movie';
+
+      testDocument.paths['/v1/cars/{car_id}'].get.responses['200'].content = {
+        'application/json; charset=utf-8': {
+          schema: '#/components/schemas/Car',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema'
+      );
+    });
+  });
+});

--- a/packages/ruleset/test/schema-type-format.test.js
+++ b/packages/ruleset/test/schema-type-format.test.js
@@ -424,7 +424,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       };
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
       for (const result of results) {
         expect(result.code).toBe(ruleId);
         expect(result.message).toMatch(errorMsgIntegerFormat);

--- a/packages/ruleset/test/unevaluated-properties.test.js
+++ b/packages/ruleset/test/unevaluated-properties.test.js
@@ -39,7 +39,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       testDocument.components.schemas['Movie'].unevaluatedProperties = true;
 
       const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(6);
 
       const expectedPaths = [
         'paths./v1/movies.post.requestBody.content.application/json.schema.unevaluatedProperties',
@@ -47,6 +47,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.unevaluatedProperties',
         'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.unevaluatedProperties',
         'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.unevaluatedProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.unevaluatedProperties',
       ];
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -434,8 +434,8 @@ module.exports = {
           },
         },
         responses: {
-          204: {
-            description: 'The movie was successfully updated.',
+          200: {
+            $ref: '#/components/responses/MovieWithETag',
           },
           400: {
             description: 'Didnt work!',


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

Synchronous responses for create-style POST or update (PUT/PATCH) operations on a given resource should return the canonical schema for the resource. As in, the same schema as the "GET" request for the same resource.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
