### PR TITLE
ibm-etag-headers bug fix

### DIFF
--- a/packages/ruleset/src/functions/array-of-arrays.js
+++ b/packages/ruleset/src/functions/array-of-arrays.js
@@ -20,20 +20,20 @@ module.exports = function (schema, _opts, context) {
 };
 
 function arrayOfArrays(schema, path) {
-  const errors = [];
-
   if (isArraySchema(schema) && schema.items) {
     logger.debug(
       `${ruleId}: checking array schema at location: ${path.join('.')}`
     );
     if (isArraySchema(schema.items)) {
       logger.debug('Found an array of arrays!');
-      errors.push({
-        message: 'Array schemas should avoid having items of type array',
-        path,
-      });
+      return [
+        {
+          message: 'Array schemas should avoid having items of type array',
+          path,
+        },
+      ];
     }
   }
 
-  return errors;
+  return [];
 }

--- a/packages/ruleset/src/functions/etag-header-exists.js
+++ b/packages/ruleset/src/functions/etag-header-exists.js
@@ -8,7 +8,7 @@ const { LoggerFactory } = require('../utils');
 let ruleId;
 let logger;
 
-module.exports = function (pathItem, options, context) {
+module.exports = function etagHeaderExists(pathItem, options, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
@@ -138,9 +138,9 @@ function isETagNeeded(pathItem) {
 function headerParamsPresent(paramList, headerNames) {
   if (Array.isArray(paramList)) {
     for (const p of paramList) {
-      if (p.in.toLowerCase() === 'header') {
+      if (p.in && p.in.toLowerCase() === 'header') {
         for (const headerName of headerNames) {
-          if (headerName.toLowerCase() === p.name.toLowerCase()) {
+          if (p.name && headerName.toLowerCase() === p.name.toLowerCase()) {
             return true;
           }
         }


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

The rule function did not account for missing required properties in parameter
objects and as a result, would crash when they were encountered. This commit
adds handling for this edge case, so that the rule will not crash.

Additionally, errors coming from the `nimma` package in Spectral bury the relevant info
and have been notoriously unhelpful for users and developers alike. This
commit updates the logic to parse out the helpful information and display
it in the error logs.

Resolves #616 