### PR TITLE
feat(ibm-unevaluated-properties): add new spectral-style rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -93,6 +93,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-string-attributes](#ibm-string-attributes)
   * [ibm-success-response-example](#ibm-success-response-example)
   * [ibm-summary-sentence-style](#ibm-summary-sentence-style)
+  * [ibm-unevaluated-properties](#ibm-unevaluated-properties)
   * [ibm-unique-parameter-request-property-names](#ibm-unique-parameter-request-property-names)
   * [ibm-valid-path-segments](#ibm-valid-path-segments)
 
@@ -516,6 +517,12 @@ has non-form content.</td>
 <td>warn</td>
 <td>An operation's <code>summary</code> field should not have a trailing period.</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-unevaluated-properties">ibm-unevaluated-properties</a></td>
+<td>error</td>
+<td>Ensures that <code>unevaluatedProperties</code> is not enabled within a schema.</td>
+<td>oas3_1</td>
 </tr>
 <tr>
 <td><a href="#ibm-unique-parameter-request-property-names">ibm-unique-parameter-request-property-names</a></td>
@@ -5360,6 +5367,66 @@ paths:
       operationId: list_things
       summary: List things
       description: Retrieve a paginated collection of Thing instances.
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-unevaluated-properties
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-unevaluated-properties</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule ensures that <code>unevaluatedProperties</code> is not enabled within a schema.
+It checks to make sure that if the <code>unevaluatedProperties</code> field
+is set on a schema, then it is set to the value <code>false</code> (i.e. disabled).
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3_1</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+      unevaluatedProperties:
+        type: string
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        metadata:
+          description: additional info about the thing
+          type: object
+      unevaluatedProperties: false
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -55,6 +55,7 @@ module.exports = {
   securitySchemeAttributes: require('./securityscheme-attributes'),
   securitySchemes: require('./securityschemes'),
   stringAttributes: require('./string-attributes'),
+  unevaluatedProperties: require('./unevaluated-properties'),
   uniqueParameterRequestPropertyNames: require('./unique-parameter-request-property-names'),
   unusedTags: require('./unused-tags'),
   validatePathSegments: require('./valid-path-segments'),

--- a/packages/ruleset/src/functions/pattern-properties.js
+++ b/packages/ruleset/src/functions/pattern-properties.js
@@ -5,7 +5,7 @@
 
 const {
   isObject,
-  validateNestedSchemas,
+  validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
@@ -17,7 +17,7 @@ module.exports = function (schema, _opts, context) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
   }
-  return validateNestedSchemas(
+  return validateSubschemas(
     schema,
     context.path,
     patternPropertiesCheck,

--- a/packages/ruleset/src/functions/unevaluated-properties.js
+++ b/packages/ruleset/src/functions/unevaluated-properties.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { validateSubschemas } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateSubschemas(
+    schema,
+    context.path,
+    unevaluatedProperties,
+    true,
+    false
+  );
+};
+
+/**
+ * If 'unevaluatedProperties' is specified within "schema" then it must be set to false.
+ *
+ * @param {*} schema the schema to check
+ * @param {*} path the array of path segments indicating the location of "schema" within the API definition
+ * @returns an array of zero or more errors
+ */
+function unevaluatedProperties(schema, path) {
+  logger.debug(
+    `${ruleId}: checking 'unevaluatedProperties' in schema at location: ${path.join(
+      '.'
+    )}`
+  );
+
+  // If "unevaluatedProperties" is specified and it is NOT false, we have an error.
+  if (
+    'unevaluatedProperties' in schema &&
+    schema.unevaluatedProperties !== false
+  ) {
+    logger.debug(`${ruleId}: Error: unevaluatedProperties !== false!`);
+    return [
+      {
+        message: 'unevaluatedProperties must be set to false, if present',
+        path: [...path, 'unevaluatedProperties'],
+      },
+    ];
+  }
+
+  logger.debug(`${ruleId}: PASSED!`);
+  return [];
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -163,6 +163,7 @@ module.exports = {
     'ibm-string-attributes': ibmRules.stringAttributes,
     'ibm-success-response-example': ibmRules.responseExampleExists,
     'ibm-summary-sentence-style': ibmRules.summarySentenceStyle,
+    'ibm-unevaluated-properties': ibmRules.unevaluatedProperties,
     'ibm-unique-parameter-request-property-names':
       ibmRules.uniqueParameterRequestPropertyNames,
     'ibm-valid-path-segments': ibmRules.validPathSegments,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -68,6 +68,7 @@ module.exports = {
   serverVariableDefaultValue: require('./server-variable-default-value'),
   stringAttributes: require('./string-attributes'),
   summarySentenceStyle: require('./summary-sentence-style'),
+  unevaluatedProperties: require('./unevaluated-properties'),
   unusedTags: require('./unused-tags'),
   uniqueParameterRequestPropertyNames: require('./unique-parameter-request-property-names'),
   validPathSegments: require('./valid-path-segments'),

--- a/packages/ruleset/src/rules/unevaluated-properties.js
+++ b/packages/ruleset/src/rules/unevaluated-properties.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3_1 } = require('@stoplight/spectral-formats');
+const { unevaluatedProperties } = require('../functions');
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+
+module.exports = {
+  description:
+    'Enforces certain restrictions on the use of "unevaluatedProperties" within a schema.',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'error',
+  formats: [oas3_1],
+  resolved: true,
+  then: {
+    function: unevaluatedProperties,
+  },
+};

--- a/packages/ruleset/test/pattern-properties.test.js
+++ b/packages/ruleset/test/pattern-properties.test.js
@@ -7,7 +7,7 @@ const { patternProperties } = require('../src/rules');
 const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
 
 const rule = patternProperties;
-const ruleId = 'ibm-patternProperties';
+const ruleId = 'ibm-pattern-properties';
 const expectedSeverity = severityCodes.error;
 const expectedMessage1 = `patternProperties and additionalProperties are mutually exclusive`;
 const expectedMessage2 = `patternProperties must be an object`;

--- a/packages/ruleset/test/unevaluated-properties.test.js
+++ b/packages/ruleset/test/unevaluated-properties.test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { unevaluatedProperties } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = unevaluatedProperties;
+const ruleId = 'ibm-unevaluated-properties';
+const expectedSeverity = severityCodes.error;
+const expectedMsg = `unevaluatedProperties must be set to false, if present`;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  beforeAll(() => {
+    rootDocument.openapi = '3.1.0';
+  });
+
+  describe('Should not yield errors', () => {
+    it('Clean spec - no unevaluatedProperties', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('unevaluatedProperties set to false', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].unevaluatedProperties = false;
+      testDocument.components.schemas['Juice'].unevaluatedProperties = false;
+      testDocument.components.schemas['Soda'].unevaluatedProperties = false;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('unevaluatedProperties set to true', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].unevaluatedProperties = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(5);
+
+      const expectedPaths = [
+        'paths./v1/movies.post.requestBody.content.application/json.schema.unevaluatedProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.unevaluatedProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.unevaluatedProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.unevaluatedProperties',
+        'paths./v1/movies/{movie_id}.put.requestBody.content.application/json.schema.unevaluatedProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('unevaluatedProperties set to a schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas[
+        'DrinkCollection'
+      ].allOf[1].unevaluatedProperties = {
+        type: 'string',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(expectedMsg);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.unevaluatedProperties'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
This commit introduces the new "ibm-unevaluated-properties" spectral-stye rule to the ruleset.  This rule will make sure that "unevaluatedProperties" is not enabled within a schema.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
