### PR TITLE
fix(imports): use correct imports for lodash modules

### DIFF
--- a/packages/ruleset/src/functions/array-attributes.js
+++ b/packages/ruleset/src/functions/array-attributes.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const isPlainObject = require('lodash/isPlainObject');
+const { isPlainObject } = require('lodash');
 const {
   validateNestedSchemas,
   isArraySchema,

--- a/packages/ruleset/src/functions/duplicate-path-parameter.js
+++ b/packages/ruleset/src/functions/duplicate-path-parameter.js
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const flatten = require('lodash/flatten');
-const isEqual = require('lodash/isEqual');
-const uniqWith = require('lodash/uniqWith');
+const { flatten, isEqual, uniqWith } = require('lodash');
 const { operationMethods, LoggerFactory } = require('../utils');
 
 let ruleId;

--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const pickBy = require('lodash/pickBy');
-const reduce = require('lodash/reduce');
-const merge = require('lodash/merge');
-const each = require('lodash/each');
+const { each, merge, pickBy, reduce } = require('lodash');
 const { operationMethods } = require('../utils');
 
 module.exports = function (rootDocument) {

--- a/packages/validator/.releaserc
+++ b/packages/validator/.releaserc
@@ -3,7 +3,7 @@
     [
       "@semantic-release/exec",
       {
-        "successCmd": "cd ../.. && ./scripts/deploy-container-image.sh ${nextRelease.version}
+        "successCmd": "cd ../.. && ./scripts/deploy-container-image.sh ${nextRelease.version}"
       }
     ]
   ]


### PR DESCRIPTION
The `lodash` packages supports installing individual modules via NPM but we use enough modules that we install the whole package. However, we were using the import style for individual modules, which didn't break because the path in `node_modules` was still correct but caused warnings in Spectral (when using custom YAML or JSON rulesets) because of the incorrect names.

This resolves those warnings, which are annoying to users.

Resolves #534
