### PR TITLE
fix(build): run all release steps for validator build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "version": "0.0.0",
   "license": "Apache-2.0",
   "private": true,
-  "repository": "https://github.com/IBM/openapi-validator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IBM/openapi-validator.git"
+  },
   "scripts": {
     "clean": "rm -rf node_modules/ && npm run clean --workspaces",
     "build-docker": "docker build -t ibmdevxsdk/openapi-validator:latest .",

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "private": false,
   "main": "./src/ibm-oas.js",
-  "repository": "https://github.com/IBM/openapi-validator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IBM/openapi-validator.git",
+    "directory": "packages/ruleset"
+  },
   "scripts": {
     "clean": "rm -rf node_modules",
     "link": "npm install -g",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "private": false,
   "main": "./src/index.js",
-  "repository": "https://github.com/IBM/openapi-validator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IBM/openapi-validator.git",
+    "directory": "packages/utilities"
+  },
   "scripts": {
     "clean": "rm -rf node_modules",
     "jest": "jest",

--- a/packages/validator/.releaserc
+++ b/packages/validator/.releaserc
@@ -1,5 +1,24 @@
 {
   "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/git",
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "npm run pkg"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          "bin/*"
+        ]
+      }
+    ],
     [
       "@semantic-release/exec",
       {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -3,7 +3,11 @@
   "description": "Configurable and extensible validator/linter for OpenAPI documents",
   "version": "1.6.0",
   "private": false,
-  "repository": "https://github.com/IBM/openapi-validator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IBM/openapi-validator.git",
+    "directory": "packages/validator"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf node_modules",


### PR DESCRIPTION
The multi-sem-rel package we use merges the individual release configs into the base project's config. I thought that it deep-merged the arrays but it turns out that the validator package's `plugins` field was overriding the whole `plugins` field in the root config and so we were never actually going to release the package (because the NPM plugin would never be called).

This adds the rest of the plugins we call in the base config to the validator config, so things should return to normal.
