### PR TITLE
feat(ibm-no-operation-requestbody): add new spectral rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage/
 .spectral.yml
 .spectral.js
 .nvmrc
+.vscode/

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -58,6 +58,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-no-duplicate-description-with-ref-sibling](#ibm-no-duplicate-description-with-ref-sibling)
   * [ibm-no-if-modified-since-header](#ibm-no-if-modified-since-header)
   * [ibm-no-if-unmodified-since-header](#ibm-no-if-unmodified-since-header)
+  * [ibm-no-operation-requestbody](#ibm-no-operation-requestbody)
   * [ibm-no-optional-properties-in-required-body](#ibm-no-optional-properties-in-required-body)
   * [ibm-no-space-in-example-name](#ibm-no-space-in-example-name)
   * [ibm-openapi-tags-used](#ibm-openapi-tags-used)
@@ -252,7 +253,9 @@ for any resources (paths) that support the <code>If-Match</code> and/or <code>If
 <tr>
 <td><a href="#ibm-no-body-for-delete">ibm-no-body-for-delete</a></td>
 <td>warn</td>
-<td>DELETE operations should not contain a requestBody.</td>
+<td>[Deprecated] DELETE operations should not contain a requestBody.  This rule has been deprecated; please use
+the <code>ibm-no-operation-requestbody</code> rule instead.
+</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -303,6 +306,12 @@ which is not allowed.</td>
 <td><a href="#ibm-no-if-unmodified-since-header">ibm-no-if-unmodified-since-header</a></td>
 <td>warn</td>
 <td>Operations should avoid supporting the <code>If-Unmodified-Since</code> header parameter.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-no-operation-requestbody">ibm-no-operation-requestbody</a></td>
+<td>warn</td>
+<td>Ensures that DELETE, GET, HEAD, and OPTIONS operations do not define a <code>requestBody</code>.</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -2268,11 +2277,13 @@ paths:
 <table>
 <tr>
 <td><b>Rule id:</b></td>
-<td><b>ibm-no-body-for-delete</b></td>
+<td><b>ibm-no-body-for-delete [Deprecated]</b></td>
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>
-<td>This rule checks each DELETE operation and will return a warning if the operation contains a <code>requestBody</code>.</td>
+<td>This rule checks each DELETE operation and will return a warning if the operation contains a <code>requestBody</code>.
+<p>This rule has been deprecated and is now disabled in the IBM Cloud Validation Ruleset. Please use the <code>ibm-no-operation-requestbody</code> rule instead.
+</td>
 </tr>
 <tr>
 <td><b>Severity:</b></td>
@@ -2974,6 +2985,108 @@ paths:
           description: 'Resource was deleted successfully!'
         '412':
           description: 'Resource current ETag value does not match the If-Match value.'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-no-operation-requestbody
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-no-operation-requestbody</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>
+The <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-methods#summary">API Handbook</a>
+provides guidance related to the use of various HTTP methods.
+In particular, the API Handbook discourages the use of a <code>requestBody</code>
+with <code>DELETE</code>, <code>GET</code>, <code>HEAD</code> and <code>OPTIONS</code> operations.
+This rule ensures that these operations do not define a <code>requestBody</code>.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Configuration:</b></td>
+<td>This rule supports a configuration that specifies the set of HTTP methods that are checked
+for a <code>requestBody</code>.
+<p>The default configuration object provided with the rule is:
+<pre>
+{
+  httpMethods: ['delete', 'get', 'head', 'options']
+}
+</pre>
+<p>To configure the rule with a different set of HTTP methods, you'll need to
+<a href="#replace-a-rule-from-ibm-cloudopenapi-ruleset">replace this rule with a new rule within your
+custom ruleset</a> and modify the configuration such that the value of the <code>httpMethods</code> field 
+specifies the desired set of HTTP methods to be checked.
+For example, to enforce the rule for DELETE, HEAD and OPTIONS operations, the configuration object would look like this:
+<pre>
+{
+  httpMethods: ['delete', 'head', 'options']
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/search':
+    get:
+      operationId: search_things
+      requestBody:
+        description: 'An object containing the search-related properties: filter, sort'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThingSearchRequest'
+      responses:
+        '200':
+          description: 'Search completed successfully'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThingSearchResponse'
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/search':
+    get:
+      parameters:
+        - name: filter
+          in: query
+          description: The search filter to use.
+          schema:
+            type: string
+        - name: sort
+          in: query
+          description: The sort order.
+          schema:
+            type: string
+      operationId: search_things
+      responses:
+        '200':
+          description: 'Search completed successfully'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThingSearchResponse'
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/delete-body.js
+++ b/packages/ruleset/src/functions/delete-body.js
@@ -12,6 +12,22 @@ module.exports = function (operation, _opts, context) {
   if (!logger) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
+
+    // This rule has been deprecated and is disabled by default (i.e. severity set to 'off'),
+    // but spectral will still invoke the rule despite the severity setting.
+    // If a user enables this rule in their custom ruleset, we'll want to log a warning
+    // to alert them to the deprecation status.
+    if (context.rule && context.rule.definition) {
+      const severity = context.rule.definition.severity;
+      if (
+        (typeof severity === 'number' && severity >= 0) ||
+        (typeof severity === 'string' && severity !== 'off')
+      ) {
+        logger.warn(
+          `The '${ruleId}' rule is deprecated.  Please use the 'ibm-no-operation-requestbody' rule instead.`
+        );
+      }
+    }
   }
   return deleteBody(operation, context.path);
 };

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -22,6 +22,7 @@ module.exports = {
   etagHeaderExists: require('./etag-header-exists'),
   inlineSchemas: require('./inline-schemas'),
   mergePatchProperties: require('./merge-patch-properties'),
+  noOperationRequestBody: require('./no-operation-requestbody'),
   operationIdCasingConvention: require('./operationid-casing-convention'),
   operationIdNamingConvention: require('./operationid-naming-convention'),
   operationSummaryExists: require('./operation-summary-exists'),

--- a/packages/ruleset/src/functions/no-operation-requestbody.js
+++ b/packages/ruleset/src/functions/no-operation-requestbody.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (operation, options, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return noOperationRequestBody(operation, context.path, options);
+};
+
+/**
+ * This function will check to make sure that certain operations do not have a requestBody.
+ * @param {*} operation the operation object to check
+ * @param {*} path the location of 'operation' within the OpenAPI document
+ * @param {*} config this is the value of the 'functionOptions' field
+ * within this rule's definition (see src/rules/operation-requestbody.js).
+ * This should be an object with the following fields:
+ *   - 'httpMethods': an array of strings which are the http methods that should be checked
+ * @returns an array containing zero or more error objects
+ */
+function noOperationRequestBody(operation, path, options) {
+  logger.debug(`${ruleId}: checking operation located at: ${path.join('.')}`);
+
+  // Grab the operation's http method from the end of the path.
+  const method = path[path.length - 1].trim().toLowerCase();
+
+  // Make sure this is a method that we want to check.
+  const shouldCheck = options.httpMethods.find(element => {
+    return method === element.trim().toLowerCase();
+  });
+  if (!shouldCheck) {
+    logger.debug(`Skip check!`);
+    return [];
+  }
+
+  // Return a warning if we're looking at a requestBody.
+  if ('requestBody' in operation) {
+    logger.debug(`Found a requestBody!`);
+    return [
+      {
+        message: `${method.toUpperCase()} operations should not define a requestBody`,
+        path: [...path, 'requestBody'],
+      },
+    ];
+  }
+
+  logger.debug(`PASSED!`);
+  return [];
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -127,6 +127,7 @@ module.exports = {
       ibmRules.refSiblingDuplicateDescription,
     'ibm-no-if-modified-since-header': ibmRules.ifModifiedSinceHeader,
     'ibm-no-if-unmodified-since-header': ibmRules.ifUnmodifiedSinceHeader,
+    'ibm-no-operation-requestbody': ibmRules.noOperationRequestBody,
     'ibm-no-optional-properties-in-required-body': ibmRules.optionalRequestBody,
     'ibm-no-space-in-example-name': ibmRules.examplesNameContainsSpace,
     'ibm-openapi-tags-used': ibmRules.unusedTags,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -34,6 +34,7 @@ module.exports = {
   mergePatchProperties: require('./merge-patch-properties'),
   operationIdCasingConvention: require('./operationid-casing-convention'),
   operationIdNamingConvention: require('./operationid-naming-convention'),
+  noOperationRequestBody: require('./no-operation-requestbody'),
   operationSummaryExists: require('./operation-summary-exists'),
   optionalRequestBody: require('./optional-request-body'),
   paginationStyle: require('./pagination-style'),

--- a/packages/ruleset/src/rules/no-operation-requestbody.js
+++ b/packages/ruleset/src/rules/no-operation-requestbody.js
@@ -7,16 +7,20 @@ const {
   operations,
 } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
-const { deleteBody } = require('../functions');
+const { noOperationRequestBody } = require('../functions');
 
 module.exports = {
-  description: 'Delete operations should not contain a requestBody.',
+  description: 'Certain operations should not contain a requestBody',
   message: '{{error}}',
-  severity: 'off',
+  severity: 'warn',
   formats: [oas3],
   resolved: true,
   given: operations,
   then: {
-    function: deleteBody,
+    function: noOperationRequestBody,
+    functionOptions: {
+      // HTTP methods that should NOT have a requestBody:
+      httpMethods: ['delete', 'get', 'head', 'options'],
+    },
   },
 };

--- a/packages/ruleset/test/array-attributes.test.js
+++ b/packages/ruleset/test/array-attributes.test.js
@@ -484,11 +484,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
         items: 'not a schema!',
       };
 
-      await expect(async () => {
-        await testRule(ruleId, rule, testDocument);
-      }).rejects.toThrow();
+      // If the API definition contains an array schema with the items
+      // field set to something other than an object (e.g. a string),
+      // then spectral will throw an exception and we want to verify that
+      // behavior here.
+      await expect(
+        testRule(ruleId, rule, testDocument, true)
+      ).rejects.toThrow();
     });
-
     it('additionalProperties schema without items property', async () => {
       const testDocument = makeCopy(rootDocument);
 

--- a/packages/ruleset/test/delete-body.test.js
+++ b/packages/ruleset/test/delete-body.test.js
@@ -11,6 +11,9 @@ const ruleId = 'ibm-no-body-for-delete';
 const expectedSeverity = severityCodes.warning;
 const expectedMsg = 'DELETE operations should not contain a requestBody';
 
+// We need to set this because the rule is now deprecated and disabled.
+rule.severity = 'warn';
+
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {

--- a/packages/ruleset/test/no-operation-requestbody.test.js
+++ b/packages/ruleset/test/no-operation-requestbody.test.js
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+let rule = require('../src/rules').noOperationRequestBody;
+
+const ruleId = 'ibm-no-operation-requestbody';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg = 'operations should not define a requestBody';
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    afterEach(() => {
+      jest.resetModules();
+      rule = require('../src/rules').noOperationRequestBody;
+    });
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Delete operation w/requestBody - delete not in config', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // omit 'delete' from the list of methods.
+      rule.then.functionOptions.httpMethods = ['get', 'head', 'options'];
+
+      testDocument.paths['/v1/drinks/{drink_id}'].delete = {
+        operationId: 'delete_drink',
+        summary: 'Pour a drink',
+        description: 'Pour a drink down the drain',
+        tags: ['TestTag'],
+        requestBody: {
+          content: {
+            'text/html': {
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        responses: {
+          204: {
+            description: 'Drink successfully poured!',
+          },
+          400: {
+            $ref: '#/components/responses/BarIsClosed',
+          },
+        },
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('DELETE operation w/requestBody', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].delete = {
+        operationId: 'delete_drink',
+        summary: 'Pour a drink down the drain',
+        description: 'Pour a drink down the drain',
+        tags: ['TestTag'],
+        requestBody: {
+          content: {
+            'text/html': {
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        responses: {
+          204: {
+            description: 'Drink successfully poured!',
+          },
+          400: {
+            $ref: '#/components/responses/BarIsClosed',
+          },
+        },
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(`DELETE ${expectedMsg}`);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.delete.requestBody'
+      );
+    });
+    it('GET operation w/requestBody', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].get = {
+        operationId: 'imagine_drink',
+        summary: 'Imagine the drink',
+        description: 'Imagine consuming the drink',
+        tags: ['TestTag'],
+        requestBody: {
+          content: {
+            'text/html': {
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        responses: {
+          204: {
+            description: 'Drink successfully imagined!',
+          },
+          400: {
+            $ref: '#/components/responses/BarIsClosed',
+          },
+        },
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(`GET ${expectedMsg}`);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.get.requestBody'
+      );
+    });
+    it('HEAD operation w/requestBody', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].head = {
+        operationId: 'evaporate_drink',
+        summary: 'Evaporate the drink',
+        description: 'Evaporate the drink',
+        tags: ['TestTag'],
+        requestBody: {
+          content: {
+            'text/html': {
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        responses: {
+          204: {
+            description: 'Drink successfully evaporated!',
+          },
+          400: {
+            $ref: '#/components/responses/BarIsClosed',
+          },
+        },
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(`HEAD ${expectedMsg}`);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.head.requestBody'
+      );
+    });
+    it('OPTIONS operation w/requestBody', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}'].options = {
+        operationId: 'needa_drink',
+        summary: 'Need a drink',
+        description: 'Need a drink',
+        tags: ['TestTag'],
+        requestBody: {
+          content: {
+            'text/html': {
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        responses: {
+          204: {
+            description: 'Drink successfully needed!',
+          },
+          400: {
+            $ref: '#/components/responses/BarIsClosed',
+          },
+        },
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      expect(results[0].code).toBe(ruleId);
+      expect(results[0].message).toBe(`OPTIONS ${expectedMsg}`);
+      expect(results[0].severity).toBe(expectedSeverity);
+      expect(results[0].path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}.options.requestBody'
+      );
+    });
+    it('POST operation w/requestBody - post in config', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      rule.then.functionOptions.httpMethods = [
+        'delete',
+        'get',
+        'head',
+        'options',
+        'POST',
+      ];
+
+      // No need to change testDocument because there are plenty of post
+      // operations with a requestBody :)
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(3);
+
+      const expectedPaths = [
+        'paths./v1/drinks.post.requestBody',
+        'paths./v1/movies.post.requestBody',
+        'paths./v1/cars.post.requestBody',
+      ];
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`POST ${expectedMsg}`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});

--- a/packages/ruleset/test/utils/test-rule.js
+++ b/packages/ruleset/test/utils/test-rule.js
@@ -5,22 +5,31 @@
 
 const { Spectral } = require('@stoplight/spectral-core');
 
-// this module provides a reusable function that sets up spectral
-// with the given ruleset, runs the tool, then returns the results.
+/**
+ * This is a test utility function that uses spectral to invoke the specified rule
+ * on the specified API definition.
+ * @param {*} ruleName the name of the rule (e.g. 'ibm-string-attributes')
+ * @param {*} rule the rule object
+ * @param {*} apidef the API definition
+ * @param {*} exceptionIsExpected if true, exceptions are not displayed on console
+ */
+async function testRule(ruleName, rule, apidef, exceptionIsExpected = false) {
+  try {
+    const spectral = new Spectral();
+    spectral.setRuleset({
+      rules: {
+        [ruleName]: rule,
+      },
+    });
 
-// 'ruleName' is the name of the rule. this would be the key in a ruleset file
-// 'rule' is the actual rule object
-// 'doc' is the API definition, in programmatic JSON format, to validate
+    const results = await spectral.run(apidef);
+    return results;
+  } catch (err) {
+    if (!exceptionIsExpected) {
+      console.error(err);
+    }
+    throw err;
+  }
+}
 
-module.exports = async (ruleName, rule, doc) => {
-  const spectral = new Spectral();
-
-  spectral.setRuleset({
-    rules: {
-      [ruleName]: rule,
-    },
-  });
-
-  const results = await spectral.run(doc);
-  return results;
-};
+module.exports = testRule;


### PR DESCRIPTION
## PR summary
This commit introduces a new spectral-style rule
'ibm-no-operation-requestbody' which will check to make sure that certain operations (delete, get, head, options) do not have a requestBody defined (as recommended by the API Handbook).

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
