### PR TITLE
feat(ibm-no-nullable-properties): add new spectral-style rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -58,6 +58,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-no-duplicate-description-with-ref-sibling](#ibm-no-duplicate-description-with-ref-sibling)
   * [ibm-no-if-modified-since-header](#ibm-no-if-modified-since-header)
   * [ibm-no-if-unmodified-since-header](#ibm-no-if-unmodified-since-header)
+  * [ibm-no-nullable-properties](#ibm-no-nullable-properties)
   * [ibm-no-operation-requestbody](#ibm-no-operation-requestbody)
   * [ibm-no-optional-properties-in-required-body](#ibm-no-optional-properties-in-required-body)
   * [ibm-no-space-in-example-name](#ibm-no-space-in-example-name)
@@ -306,6 +307,13 @@ which is not allowed.</td>
 <td><a href="#ibm-no-if-unmodified-since-header">ibm-no-if-unmodified-since-header</a></td>
 <td>warn</td>
 <td>Operations should avoid supporting the <code>If-Unmodified-Since</code> header parameter.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-no-nullable-properties">ibm-no-nullable-properties</a></td>
+<td>warn</td>
+<td>Ensures that nullable properties are defined only within JSON merge-patch requestBody schemas, per API Handbook guidance.
+</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -2985,6 +2993,135 @@ paths:
           description: 'Resource was deleted successfully!'
         '412':
           description: 'Resource current ETag value does not match the If-Match value.'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-no-nullable-properties
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-no-nullable-properties</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>
+The <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-models#required-optional-and-nullable">API Handbook</a>
+provides guidance related to the use of <code>nullable</code> schema properties.  Specifically, the API Handbook
+allows nullable schema properties to be defined only within JSON merge-patch request body schemas.
+This rule ensures that nullable properties are not defined elsewhere.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        thing_id:
+          type: string
+        thing_name:
+          type: string
+        thing_size:
+          type: integer
+        thing_type:
+          type: string
+          nullable: true   &lt;&lt;&lt; not valid in a response schema
+    ThingPatch:
+      type: object
+      properties:
+        thing_name:
+          type: string
+           nullable: true   &lt;&lt;&lt; valid only in a merge-path requestBody schema
+        thing_size:
+          type: integer
+          nullable: true   &lt;&lt;&lt; valid only in a merge-path requestBody schema
+        thing_type:
+          type: string
+          nullable: true   &lt;&lt;&lt; valid only in a merge-path requestBody schema
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#/components/parameters/ThingIdParameter'
+    patch:
+      operationId: update_thing
+      requestBody:
+        description: An object used to modify an existing Thing instance
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/ThingPatch'
+      responses:
+        '200':
+          description: Thing instance was updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        thing_id:
+          type: string
+        thing_name:
+          type: string
+        thing_size:
+          type: integer
+        thing_type:    &lt;&lt;&lt; property is no longer nullable
+          type: string
+    ThingPatch:
+      type: object
+      properties:
+        thing_name:
+          type: string
+           nullable: true
+        thing_size:
+          type: integer
+          nullable: true
+        thing_type:
+          type: string
+          nullable: true
+paths:
+  '/v1/things/{thing_id}':
+    parameters:
+      - $ref: '#/components/parameters/ThingIdParameter'
+    patch:
+      operationId: update_thing
+      requestBody:
+        description: An object used to modify an existing Thing instance
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/ThingPatch'
+      responses:
+        '200':
+          description: Thing instance was updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -22,6 +22,7 @@ module.exports = {
   etagHeaderExists: require('./etag-header-exists'),
   inlineSchemas: require('./inline-schemas'),
   mergePatchProperties: require('./merge-patch-properties'),
+  noNullableProperties: require('./no-nullable-properties'),
   noOperationRequestBody: require('./no-operation-requestbody'),
   operationIdCasingConvention: require('./operationid-casing-convention'),
   operationIdNamingConvention: require('./operationid-naming-convention'),

--- a/packages/ruleset/src/functions/no-nullable-properties.js
+++ b/packages/ruleset/src/functions/no-nullable-properties.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  schemaHasConstraint,
+  validateSubschemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
+const {
+  isMergePatchMimeType,
+  LoggerFactory,
+  operationMethods,
+} = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _options, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateSubschemas(schema, context.path, noNullableProperties);
+};
+
+/**
+ * This function will check to make sure that nullable properties exist only
+ * within a JSON merge-patch operation's requestBody schema, per API Handbook guidance.
+ * @param {*} schema the schema to check
+ * @param {*} path the location of 'schema' within the OpenAPI document
+ * @returns an array containing zero or more error objects
+ */
+function noNullableProperties(schema, path) {
+  logger.debug(`${ruleId}: checking schema located at: ${path.join('.')}`);
+
+  // Bail out immediately if 'schema' is within a JSON merge-patch requestBody,
+  // as this is the only location where a nullable property is allowed.
+  if (isInMergePatchBody(path)) {
+    logger.debug(`${ruleId}: inside JSON merge-patch requestBody!`);
+    return [];
+  }
+
+  logger.debug(`${ruleId}: looking at: ${JSON.stringify(schema, null, 2)}`);
+
+  // Check if nullable is set on 'schema'.
+  // Per the OpenAPI Specification (https://spec.openapis.org/oas/v3.0.3#schemaNullable),
+  // the 'nullable' field is only applicable if the same schema object also explicitly contains
+  // the 'type' field as well.
+  if (schemaHasConstraint(schema, isNullable)) {
+    logger.debug(`${ruleId}: found a nullable property: ${path.join('.')}`);
+    return [
+      {
+        message:
+          'nullable properties should be defined only within a JSON merge-patch request body schema',
+        path,
+      },
+    ];
+  }
+
+  logger.debug(`PASSED!`);
+  return [];
+}
+
+/**
+ * Returns true iff schema 's' is declared to be 'nullable'.
+ * In this context, a schema is nullable if one of the following is true:
+ * 1. (openapi <= 3.0) the schema's 'type' field is explicitly defined (a string value)
+ *    AND the schema's 'nullable' field is explicitly set to true.
+ * 2. (openapi >= 3.1) the schema's 'type' field is an array and contains 'null' as a value
+ * @param {*} s the schema to check
+ * @returns true if 's' is defined as nullable, false otherwise
+ */
+function isNullable(s) {
+  return (
+    (Array.isArray(s.type) && s.type.includes('null')) ||
+    (typeof s.type === 'string' && s.type && s.nullable === true)
+  );
+}
+
+/**
+ * Checks to see if 'path' is the location of a schema property within a
+ * JSON merge-patch operation's requestBody schema.
+ * @param {*} path the jsonpath location to check
+ * @returns true if 'path' specifies a location within a JSON merge-patch requestBody schema, false otherwise.
+ *
+ */
+function isInMergePatchBody(path) {
+  return (
+    Array.isArray(path) &&
+    path.length >= 7 &&
+    path[0] === 'paths' &&
+    operationMethods.includes(path[2]) &&
+    path[3] === 'requestBody' &&
+    isMergePatchMimeType(path[5]) &&
+    path[6] === 'schema'
+  );
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -127,6 +127,7 @@ module.exports = {
       ibmRules.refSiblingDuplicateDescription,
     'ibm-no-if-modified-since-header': ibmRules.ifModifiedSinceHeader,
     'ibm-no-if-unmodified-since-header': ibmRules.ifUnmodifiedSinceHeader,
+    'ibm-no-nullable-properties': ibmRules.noNullableProperties,
     'ibm-no-operation-requestbody': ibmRules.noOperationRequestBody,
     'ibm-no-optional-properties-in-required-body': ibmRules.optionalRequestBody,
     'ibm-no-space-in-example-name': ibmRules.examplesNameContainsSpace,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -34,6 +34,7 @@ module.exports = {
   mergePatchProperties: require('./merge-patch-properties'),
   operationIdCasingConvention: require('./operationid-casing-convention'),
   operationIdNamingConvention: require('./operationid-naming-convention'),
+  noNullableProperties: require('./no-nullable-properties'),
   noOperationRequestBody: require('./no-operation-requestbody'),
   operationSummaryExists: require('./operation-summary-exists'),
   optionalRequestBody: require('./optional-request-body'),

--- a/packages/ruleset/src/rules/no-nullable-properties.js
+++ b/packages/ruleset/src/rules/no-nullable-properties.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3 } = require('@stoplight/spectral-formats');
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+const { noNullableProperties } = require('../functions');
+
+module.exports = {
+  description:
+    'Nullable properties should exist only in JSON merge-patch request bodies',
+  message: '{{error}}',
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  given: schemas,
+  then: {
+    function: noNullableProperties,
+  },
+};

--- a/packages/ruleset/test/no-nullable-properties.test.js
+++ b/packages/ruleset/test/no-nullable-properties.test.js
@@ -1,0 +1,237 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+const { noNullableProperties } = require('../src/rules');
+
+const rule = noNullableProperties;
+const ruleId = 'ibm-no-nullable-properties';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg =
+  'nullable properties should be defined only within a JSON merge-patch request body schema';
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      // rootDocument contains a nullable property in the CarPatch schema.
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('nullable specified without a corresponding type value', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Car.properties.make.nullable = true;
+      delete testDocument.components.schemas.Car.properties.make.type;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('nullable property in non-patch request/response (type is a string)', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Car.properties.make.nullable = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      const expectedPaths = [
+        'paths./v1/cars.post.requestBody.content.application/json.schema.properties.make',
+        'paths./v1/cars.post.responses.201.content.application/json.schema.properties.make',
+        'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.make',
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.make',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('property contains null in type array', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.openapi = '3.1.0';
+      testDocument.components.schemas.Car.properties.make.type = [
+        'string',
+        'null',
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      const expectedPaths = [
+        'paths./v1/cars.post.requestBody.content.application/json.schema.properties.make',
+        'paths./v1/cars.post.responses.201.content.application/json.schema.properties.make',
+        'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.make',
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.make',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('nullable used in parameter schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.parameters.VerboseParam.schema.nullable = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/drinks/{drink_id}.get.parameters.0.schema',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('nullable used in oneOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Soda.properties.type.nullable = true;
+      testDocument.components.schemas.Juice.properties.type.nullable = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(8);
+      const expectedPaths = [
+        'paths./v1/drinks.post.requestBody.content.application/json.schema.oneOf.0.properties.type',
+        'paths./v1/drinks.post.requestBody.content.application/json.schema.oneOf.1.properties.type',
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.oneOf.0.properties.type',
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.oneOf.1.properties.type',
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks.items.oneOf.0.properties.type',
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks.items.oneOf.1.properties.type',
+        'paths./v1/drinks/{drink_id}.get.responses.200.content.application/json.schema.oneOf.0.properties.type',
+        'paths./v1/drinks/{drink_id}.get.responses.200.content.application/json.schema.oneOf.1.properties.type',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('nullable used in allOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[1].properties.drinks.nullable = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('nullable used in allOf (type is an array)', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[1].properties.drinks.type =
+        ['array', 'null'];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('nullable used in additionalProperties (string schema)', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Car.additionalProperties = {
+        type: 'string',
+        nullable: true,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      const expectedPaths = [
+        'paths./v1/cars.post.requestBody.content.application/json.schema.additionalProperties',
+        'paths./v1/cars.post.responses.201.content.application/json.schema.additionalProperties',
+        'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.additionalProperties',
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.additionalProperties',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('nullable used in additionalProperties (object schema)', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Car.additionalProperties = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            nullable: true,
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      const expectedPaths = [
+        'paths./v1/cars.post.requestBody.content.application/json.schema.additionalProperties.properties.foo',
+        'paths./v1/cars.post.responses.201.content.application/json.schema.additionalProperties.properties.foo',
+        'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.additionalProperties.properties.foo',
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.additionalProperties.properties.foo',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('patternProperties schema contains type array that includes "null")', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.openapi = '3.1.0';
+      testDocument.components.schemas.Car.patternProperties = {
+        foo: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: ['string', 'null'],
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      const expectedPaths = [
+        'paths./v1/cars.post.requestBody.content.application/json.schema.patternProperties.foo.properties.foo',
+        'paths./v1/cars.post.responses.201.content.application/json.schema.patternProperties.foo.properties.foo',
+        'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.patternProperties.foo.properties.foo',
+        'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.patternProperties.foo.properties.foo',
+      ];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -882,6 +882,7 @@ module.exports = {
             minLength: 1,
             maxLength: 32,
             pattern: '.*',
+            nullable: true,
           },
           model: {
             $ref: '#/components/schemas/CarModelType',

--- a/packages/utilities/src/collections/index.js
+++ b/packages/utilities/src/collections/index.js
@@ -12,6 +12,9 @@ const operations = [`$.paths[*][get,put,post,delete,options,head,patch,trace]`];
 // A collection of locations of top-level response schemas
 const responseSchemas = [`${operations[0]}[responses][*].content[*].schema`];
 
+// A collection of locations of top-level requestBody schemas.
+const requestBodySchemas = [`${operations[0]}[requestBody].content[*].schema`];
+
 // A collection of locations where a JSON Schema object can be *used*.
 // Note that this does not include "components.schemas" to avoid duplication.
 // this collection should be used in a rule that has "resolved" set to "true".
@@ -22,7 +25,7 @@ const schemas = [
   `${operations[0]}[parameters][*].schema`,
   `${operations[0]}[parameters,responses][*].content[*].schema`,
   `${operations[0]}.responses[*].headers[*].schema`,
-  `${operations[0]}[requestBody].content[*].schema`,
+  ...requestBodySchemas,
 ];
 
 // A collection of locations where a parameter object might be defined.
@@ -47,7 +50,7 @@ const unresolvedResponseSchemas = [
 // A collection of locations where a requestBody schema could be defined
 // within an unresolved API definition.
 const unresolvedRequestBodySchemas = [
-  `${operations[0]}.requestBody.content[*].schema`,
+  ...requestBodySchemas,
   `$.components.requestBodies[*].content[*].schema`,
 ];
 
@@ -85,6 +88,7 @@ module.exports = {
   parameters,
   patchOperations,
   paths,
+  requestBodySchemas,
   responseSchemas,
   schemas,
   securitySchemes,

--- a/packages/utilities/src/utils/validate-nested-schemas.js
+++ b/packages/utilities/src/utils/validate-nested-schemas.js
@@ -8,7 +8,8 @@ const isObject = require('./is-object');
 /*
  * Performs validation on a schema and all of its nested schemas.
  *
- * Nested schemas include property schemas (for an object schema), items schemas (for an array
+ * Nested schemas include property schemas, 'additionalProperties', and 'patternProperties' schemas
+ * (for an object schema), 'items' schemas (for an array
  * schema), plus all nested schemas of those schemas.
  *
  * Nested schemas included via `allOf`, `oneOf`, and `anyOf` are validated, but composed schemas

--- a/packages/utilities/src/utils/validate-subschemas.js
+++ b/packages/utilities/src/utils/validate-subschemas.js
@@ -9,8 +9,9 @@ const validateNestedSchemas = require('./validate-nested-schemas');
 /*
  * Performs validation on a schema and all of its subschemas.
  *
- * Subschemas include property schemas (for an object schema), item schemas (for an array schema),
- * and applicator schemas (such as those in an `allOf` or `oneOf` property), plus all subschemas
+ * Subschemas include property schemas, 'additionalProperties', and 'patternProperties' schemas
+ * (for an object schema), 'items' schemas (for an array schema), and applicator schemas
+ * (such as those in an 'allOf', 'anyOf' or 'oneOf' property), plus all subschemas
  * of those schemas.
  *
  * Note: it is only safe to use this method within functions operating on the "resolved" specification,


### PR DESCRIPTION
## PR summary
This commit introduces the new spectral-style rule 'ibm-no-nullable-properties', which will warn about the presence of nullable schema properties in schemas other than JSON merge/patch requestBody schemas (where nullable properties are allowed).


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
