### PR TITLE
feat(new-rule): ibm-schema-casing-convention

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-07T18:22:20Z",
+  "generated_at": "2023-09-08T20:22:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-08T20:22:11Z",
+  "generated_at": "2023-09-11T17:13:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -84,6 +84,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-requestbody-name](#ibm-requestbody-name)
   * [ibm-resource-response-consistency](#ibm-resource-response-consistency)
   * [ibm-response-status-codes](#ibm-response-status-codes)
+  * [ibm-schema-casing-convention](#ibm-schema-casing-convention)
   * [ibm-schema-description](#ibm-schema-description)
   * [ibm-schema-naming-convention](#ibm-schema-naming-convention)
   * [ibm-schema-type](#ibm-schema-type)
@@ -464,6 +465,12 @@ has non-form content.</td>
 <td><a href="#ibm-response-status-codes">ibm-response-status-codes</a></td>
 <td>warn</td>
 <td>Performs multiple checks on the status codes used in operation responses.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-schema-casing-convention">ibm-schema-casing-convention</a></td>
+<td>warm</td>
+<td>Schema names should follow a specific case convention.</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -4823,6 +4830,81 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-schema-casing-convention
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-schema-casing-convention</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>
+Schema names (the keys in `components -> schemas`) should follow the "upper camel case" convention
+as required by the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-schemas#naming">IBM Cloud API Handbook</a>.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Configuration:</b></td>
+<td>This rule can be configured to enforce a specific case convention for schema name values.
+To configure the rule, set the <code>functionOptions</code> field within the rule definition to be an object
+that is the appropriate configuration to be used by Spectral's <code>casing()</code> function
+[<a href="https://meta.stoplight.io/docs/spectral/ZG9jOjExNg-core-functions#casing">1</a>]
+to enforce the desired case convention for schema name values.
+<p>The default configuration object provided in the rule definition is:
+<pre>
+{
+  type: 'pascal'
+}
+</pre>
+<p>To enforce a different case convention for schema name values, you'll need to
+<a href="#replace-a-rule-from-ibm-cloudopenapi-ruleset">replace this rule with a new rule within your
+custom ruleset</a> and modify the configuration such that the value of the <code>type</code> field 
+specifies the desired case convention.
+For example, to enforce snake case for schema names, the configuration object would look like this:
+<pre>
+{
+  type: 'snake'
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    specific_thing:
+      type: object
+      properties:
+        ...
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    SpecificThing:
+      type: object
+      properties:
+        ...
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -49,6 +49,7 @@ module.exports = {
   resourceResponseConsistency: require('./resource-response-consistency'),
   responseExampleExists: require('./response-example-exists'),
   responseStatusCodes: require('./response-status-codes'),
+  schemaCasingConvention: require('./schema-casing-convention'),
   schemaDescriptionExists: require('./schema-description-exists'),
   schemaNamingConvention: require('./schema-naming-convention'),
   schemaOrContentProvided: require('./schema-or-content-provided'),

--- a/packages/ruleset/src/functions/schema-casing-convention.js
+++ b/packages/ruleset/src/functions/schema-casing-convention.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { casing } = require('@stoplight/spectral-functions');
+const { LoggerFactory } = require('../utils');
+
+let casingConfig;
+let ruleId;
+let logger;
+
+module.exports = function (components, options, context) {
+  // Save this rule's "functionOptions" value since we need
+  // to pass it on to Spectral's "casing" function.
+  casingConfig = options;
+
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+
+  return schemaCaseConvention(components, context.path);
+};
+
+function schemaCaseConvention(components, path) {
+  if (!components.schemas && !isObject(components.schemas)) {
+    logger.debug(`${ruleId}: no schemas to validate, skipping rule`);
+    return [];
+  }
+
+  const errors = [];
+
+  Object.keys(components.schemas).forEach(schemaName => {
+    const result = casing(schemaName, casingConfig);
+    if (result) {
+      logger.debug(`${ruleId}: failed casing check: ${JSON.stringify(result)}`);
+      errors.push({
+        message: `Schema names ${result[0].message.replace(
+          'pascal',
+          'upper camel'
+        )}`,
+        path: [...path, 'schemas', schemaName],
+      });
+    }
+  });
+
+  return errors;
+}

--- a/packages/ruleset/src/functions/schema-casing-convention.js
+++ b/packages/ruleset/src/functions/schema-casing-convention.js
@@ -11,6 +11,13 @@ let casingConfig;
 let ruleId;
 let logger;
 
+/**
+ * The implementation for this rule makes assumptions that are dependent on the
+ * presence of the following other rules:
+ *
+ * - ibm-avoid-inline-schemas: all relevant schemas are named (defined with references)
+ */
+
 module.exports = function (components, options, context) {
   // Save this rule's "functionOptions" value since we need
   // to pass it on to Spectral's "casing" function.

--- a/packages/ruleset/src/functions/schema-casing-convention.js
+++ b/packages/ruleset/src/functions/schema-casing-convention.js
@@ -25,7 +25,7 @@ module.exports = function (components, options, context) {
 };
 
 function schemaCaseConvention(components, path) {
-  if (!components.schemas && !isObject(components.schemas)) {
+  if (!components.schemas || !isObject(components.schemas)) {
     logger.debug(`${ruleId}: no schemas to validate, skipping rule`);
     return [];
   }

--- a/packages/ruleset/src/functions/schema-naming-convention.js
+++ b/packages/ruleset/src/functions/schema-naming-convention.js
@@ -29,7 +29,7 @@ let logger;
  * - ibm-collection-array-property: the presence and correct name of the
  *   property in a collection schema that holds the resource list
  *
- * - (yet to be developed): schema names use upper camel case
+ * - ibm-schema-casing-convention: schema names use upper camel case
  */
 
 module.exports = function schemaNames(apidef, options, context) {

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -154,6 +154,7 @@ module.exports = {
     'ibm-requestbody-name': ibmRules.requestBodyNameExists,
     'ibm-resource-response-consistency': ibmRules.resourceResponseConsistency,
     'ibm-response-status-codes': ibmRules.responseStatusCodes,
+    'ibm-schema-casing-convention': ibmRules.schemaCasingConvention,
     'ibm-schema-description': ibmRules.schemaDescriptionExists,
     'ibm-schema-naming-convention': ibmRules.schemaNamingConvention,
     'ibm-schema-type': ibmRules.schemaTypeExists,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -61,6 +61,7 @@ module.exports = {
   resourceResponseConsistency: require('./resource-response-consistency'),
   responseExampleExists: require('./response-example-exists'),
   responseStatusCodes: require('./response-status-codes'),
+  schemaCasingConvention: require('./schema-casing-convention'),
   schemaDescriptionExists: require('./schema-description-exists'),
   schemaNamingConvention: require('./schema-naming-convention'),
   schemaTypeExists: require('./schema-type-exists'),

--- a/packages/ruleset/src/rules/schema-casing-convention.js
+++ b/packages/ruleset/src/rules/schema-casing-convention.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3 } = require('@stoplight/spectral-formats');
+const { schemaCasingConvention } = require('../functions');
+
+module.exports = {
+  description: 'Schema names must follow a specified case convention',
+  message: '{{error}}',
+  formats: [oas3],
+  given: ['$.components'],
+  severity: 'warn',
+  then: {
+    function: schemaCasingConvention,
+    functionOptions: {
+      type: 'pascal',
+    },
+  },
+};

--- a/packages/ruleset/test/schema-casing-convention.test.js
+++ b/packages/ruleset/test/schema-casing-convention.test.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { schemaCasingConvention } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = schemaCasingConvention;
+const ruleId = 'ibm-schema-casing-convention';
+const expectedMsg = 'Schema names must be upper camel case';
+const expectedSeverity = severityCodes.warning;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('No components', async () => {
+      const testDocument = {
+        openapi: '3.0',
+        paths: {
+          '/v1/things': {
+            post: {},
+          },
+        },
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('No schemas', async () => {
+      const testDocument = {
+        openapi: '3.0',
+        paths: {
+          '/v1/things': {
+            post: {
+              requestBody: {
+                $ref: '#/components/requestBodies/CreateThingRequest',
+              },
+            },
+          },
+        },
+        components: {
+          requestBodies: {
+            CreateThingRequest: {},
+          },
+        },
+      };
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Lower camel case schema name', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.movieCollection = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      const expectedPaths = ['components.schemas.movieCollection'];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('Multiple schema names with incorrect casing', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.movieCollection = {};
+      testDocument.components.schemas['Drink-Collection'] = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(2);
+
+      const expectedPaths = [
+        'components.schemas.movieCollection',
+        'components.schemas.Drink-Collection',
+      ];
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
This adds a new rule to verify that schema names (i.e. the keys in the 'schemas' object in the 'components' object) are upper camel case, as specified in the API Handbook.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
