### PR TITLE
feat(ibm-no-ambiguous-paths): introduce new validator rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -46,6 +46,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-etag-header](#ibm-etag-header)
   * [ibm-major-version-in-path](#ibm-major-version-in-path)
   * [ibm-no-accept-header](#ibm-no-accept-header)
+  * [ibm-no-ambiguous-paths](#ibm-no-ambiguous-paths)
   * [ibm-no-array-of-arrays](#ibm-no-array-of-arrays)
   * [ibm-no-array-responses](#ibm-no-array-responses)
   * [ibm-no-authorization-header](#ibm-no-authorization-header)
@@ -231,6 +232,12 @@ for any resources (paths) that support the <code>If-Match</code> and/or <code>If
 <td><a href="#ibm-no-accept-header">ibm-no-accept-header</a></td>
 <td>warn</td>
 <td>Operations should not explicitly define the <code>Accept</code> header parameter.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-no-ambiguous-paths">ibm-no-ambiguous-paths</a></td>
+<td>warn</td>
+<td>Checks for the presence of ambiguous path strings.</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -2070,6 +2077,73 @@ paths:
               schema:
                 $ref: '#/components/schemas/ThingCollection'
 
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-no-ambiguous-paths
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-no-ambiguous-paths</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>The path strings defined within an OpenAPI document must be unique and <code>unambiguous</code>.
+In general, two paths are ambiguous if the following are true:
+<ul>
+<li>the two paths contain the same number of path segments (e.g. /v1/foo, /v1/{foo})</li>
+<li>when comparing each of the respective path segments in each path string:
+<ol>
+<li>both path segments are non-parameterized and are equal (e.g. 'foo' vs 'foo')</li>
+<li>one or the other of the path segments is parameterized (e.g. 'foo' vs '{foo_id}')</li>
+<li>both of the path segments are parameterized (e.g. '{foo_id}' vs '{id}')</li>
+</ol>
+</ul>
+Here are examples of paths that are ambiguous despite being unique:
+<ul>
+<li><code>/v1/things/{thing_id}</code>, <code>/v1/things/{id}</code>
+<li><code>/v1/things/{thing_id}</code>, <code>/v1/things/other_things</code>
+<li><code>/{version}/things</code>, <code>/v1/{things}</code>
+</ul>
+Each of the pairs of path strings above would be considered ambiguous.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    ...
+  '/v1/things/{foo_id}':
+    ...
+  '/v1/things/other_things':
+    ...
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+paths:
+  '/v1/things/{thing_id}':
+    ...
+  '/v1/foos/{foo_id}':
+    ...
+  '/v1/things/{thing_id}/other_things':
+    ...
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -22,6 +22,7 @@ module.exports = {
   etagHeaderExists: require('./etag-header-exists'),
   inlineSchemas: require('./inline-schemas'),
   mergePatchProperties: require('./merge-patch-properties'),
+  noAmbiguousPaths: require('./no-ambiguous-paths'),
   noNullableProperties: require('./no-nullable-properties'),
   noOperationRequestBody: require('./no-operation-requestbody'),
   operationIdCasingConvention: require('./operationid-casing-convention'),

--- a/packages/ruleset/src/functions/no-ambiguous-paths.js
+++ b/packages/ruleset/src/functions/no-ambiguous-paths.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (paths, _options, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return checkAmbiguousPaths(paths);
+};
+
+/**
+ * This function will check for "ambiguous" paths within the API definition.
+ * In this context, two paths are "ambiguous" if they have the same number of path segments
+ * and they differ only due to the presence of a path parameter reference within a
+ * path segment.
+ * For example, each of the following pairs of path strings would be considered
+ * "ambiguous":
+ * 1. "/v1/clouds/{id}", "/v1/clouds/{cloud_id}"
+ * 2. "/v1/clouds/foo", "/v1/clouds/{cloud_id}"
+ * 3. "/v1/{resource_type}/foo", "/v1/users/{user_id}"
+ * @param {*} apidef the entire API definition
+ * @returns an array containing zero or more error objects
+ */
+function checkAmbiguousPaths(paths) {
+  logger.debug(`${ruleId}: checking for ambiguous paths...`);
+
+  // Bail out immediately if 'paths' is not an object or has <= 1 key.
+  if (!isObject(paths) || Object.keys(paths).length <= 1) {
+    logger.debug(`${ruleId}: No paths to check!`);
+    return [];
+  }
+
+  // Collect all the path strings, canonicalize them, then compare each pair
+  // of path strings to determine if any are ambiguous.
+  const rawPaths = Object.keys(paths);
+  const canonicalizedPaths = getCanonicalizedPaths(rawPaths);
+
+  // Walk through the array and compare each element with the rest of the array.
+  const errors = [];
+  for (let i = 0; i < canonicalizedPaths.length - 1; i++) {
+    logger.debug(
+      `${ruleId}: visiting canonicalizedPaths[${i.toString()}]: ${JSON.stringify(
+        canonicalizedPaths[i]
+      )}`
+    );
+    for (let j = i + 1; j < canonicalizedPaths.length; j++) {
+      if (pathsAreAmbiguous(canonicalizedPaths[i], canonicalizedPaths[j])) {
+        logger.debug(
+          `${ruleId}: Found ambiguous paths: ${rawPaths[i]}, ${rawPaths[j]}`
+        );
+        errors.push({
+          message: `Paths are ambiguous: '${rawPaths[i]}', '${rawPaths[j]}'`,
+          path: ['paths', rawPaths[i]],
+        });
+      }
+    }
+  }
+
+  if (!errors.length) {
+    logger.debug(`${ruleId}: PASSED!`);
+  }
+
+  return errors;
+}
+
+/**
+ * Canonicalize the set of path strings to make it easier to compare
+ * them for ambiguity.  We'll do this by converting each path string into
+ * an array of path segments, and also convert each path param reference to null.
+ * @param {*} pathStrings the array of path strings from the API definition
+ * @returns an array containing the canonicalized paths, with each element
+ * being an array of path segments
+ */
+function getCanonicalizedPaths(pathStrings) {
+  const paths = [];
+
+  for (let p of pathStrings) {
+    // Convert each path string into an array of path segments.
+    if (p.startsWith('/')) {
+      p = p.slice(1);
+    }
+    const pathSegs = p.split('/');
+
+    // Convert any path parameter references to null.
+    for (let i = 0; i < pathSegs.length; i++) {
+      if (pathSegs[i].trim().match(/^{.*}$/)) {
+        pathSegs[i] = null;
+      }
+    }
+
+    paths.push(pathSegs);
+  }
+
+  return paths;
+}
+
+/**
+ * Check two paths to see if they are "ambiguous".
+ * @param {*} path1 array of path segments for first path to check
+ * @param {*} path2 array of path segments for second path to check
+ * @returns true if the two paths are ambiguous, false otherwise
+ */
+function pathsAreAmbiguous(path1, path2) {
+  if (path1.length !== path2.length) {
+    // The paths can't be ambiguous if they have a different # of path segments.
+    return false;
+  }
+
+  // Compare the respective elements within path1 and path2
+  // to see if the path segments are ambiguous.
+  // We'll walk through the path segments of path1 and path2, and if we find
+  // a respective pair of path segments that are both truthy (which means
+  // they did NOT contain path param references) and are NOT the same string,
+  // we know that the two paths are not ambiguous.
+  // If we make it through all of the path segments and do not find any such
+  // "differences", then the two paths are "ambiguous".
+  for (let i = 0; i < path1.length; i++) {
+    // If both paths have a non-param path segment at element 'i'
+    // AND those path segments are not the same string, then this pair of
+    // paths cannot be ambiguous.
+    if (path1[i] && path2[i] && path1[i] !== path2[i]) {
+      return false;
+    }
+
+    // Otherwise, we're looking at one of these scenarios:
+    // 1. path1[i] is truthy, path2[i] is falsy -> ambiguous
+    // 2. path1[i] is falsy, path2[i] is truthy -> ambiguous
+    // 3. path1[i] is falsy, path2[i] is falsy -> ambiguous
+  }
+
+  return true;
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -113,6 +113,7 @@ module.exports = {
     'ibm-etag-header': ibmRules.etagHeaderExists,
     'ibm-major-version-in-path': ibmRules.majorVersionInPath,
     'ibm-no-accept-header': ibmRules.acceptHeader,
+    'ibm-no-ambiguous-paths': ibmRules.noAmbiguousPaths,
     'ibm-no-array-of-arrays': ibmRules.arrayOfArrays,
     'ibm-no-array-responses': ibmRules.arrayResponses,
     'ibm-no-authorization-header': ibmRules.authorizationHeader,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -34,6 +34,7 @@ module.exports = {
   mergePatchProperties: require('./merge-patch-properties'),
   operationIdCasingConvention: require('./operationid-casing-convention'),
   operationIdNamingConvention: require('./operationid-naming-convention'),
+  noAmbiguousPaths: require('./no-ambiguous-paths'),
   noNullableProperties: require('./no-nullable-properties'),
   noOperationRequestBody: require('./no-operation-requestbody'),
   operationSummaryExists: require('./operation-summary-exists'),

--- a/packages/ruleset/src/rules/no-ambiguous-paths.js
+++ b/packages/ruleset/src/rules/no-ambiguous-paths.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { oas3 } = require('@stoplight/spectral-formats');
+const { noAmbiguousPaths } = require('../functions');
+
+module.exports = {
+  description: 'Avoid ambiguous path strings within an OpenAPI document',
+  message: '{{error}}',
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  given: ['$.paths'],
+  then: {
+    function: noAmbiguousPaths,
+  },
+};

--- a/packages/ruleset/test/binary-schemas.test.js
+++ b/packages/ruleset/test/binary-schemas.test.js
@@ -26,7 +26,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Array of binary, non-JSON content', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/menu'].put.requestBody = {
+      testDocument.paths['/v1/drink_menu'].put.requestBody = {
         content: {
           'application/octet-stream': {
             schema: {
@@ -47,7 +47,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Nested array of binary, non-JSON content', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/menu'].get.responses = {
+      testDocument.paths['/v1/drink_menu'].get.responses = {
         200: {
           content: {
             'application/octet-stream': {
@@ -73,7 +73,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Binary schema in non-JSON parameters.content', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/menu'].put.parameters[1].content = {
+      testDocument.paths['/v1/drink_menu'].put.parameters[1].content = {
         'application/octet-stream': {
           schema: {
             type: 'string',
@@ -91,7 +91,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('Binary parameter.schema', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/menu'].put.parameters[0].schema = {
+      testDocument.paths['/v1/drink_menu'].put.parameters[0].schema = {
         type: 'array',
         items: {
           type: 'string',
@@ -105,14 +105,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].message).toBe(expectedMsgParam);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/drinks/menu.put.parameters.0.schema'
+        'paths./v1/drink_menu.put.parameters.0.schema'
       );
     });
 
     it('Binary parameter.content.*.schema', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/menu'].put.parameters[1].content[
+      testDocument.paths['/v1/drink_menu'].put.parameters[1].content[
         'application/json'
       ].schema = {
         type: 'array',
@@ -128,14 +128,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].message).toBe(expectedMsgParam);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/drinks/menu.put.parameters.1.content.application/json.schema'
+        'paths./v1/drink_menu.put.parameters.1.content.application/json.schema'
       );
     });
 
     it('Binary requestBody schema, JSON content', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/menu'].put.requestBody = {
+      testDocument.paths['/v1/drink_menu'].put.requestBody = {
         content: {
           'application/json; charset=utf-8': {
             schema: {
@@ -152,14 +152,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].message).toBe(expectedMsgReqBody);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/drinks/menu.put.requestBody.content.application/json; charset=utf-8.schema'
+        'paths./v1/drink_menu.put.requestBody.content.application/json; charset=utf-8.schema'
       );
     });
 
     it('Binary response schema, JSON content', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/menu'].get.responses = {
+      testDocument.paths['/v1/drink_menu'].get.responses = {
         200: {
           content: {
             'application/json': {
@@ -178,7 +178,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results[0].message).toBe(expectedMsgResponse);
       expect(results[0].severity).toBe(expectedSeverity);
       expect(results[0].path.join('.')).toBe(
-        'paths./v1/drinks/menu.get.responses.200.content.application/json.schema'
+        'paths./v1/drink_menu.get.responses.200.content.application/json.schema'
       );
     });
   });

--- a/packages/ruleset/test/no-ambiguous-paths.test.js
+++ b/packages/ruleset/test/no-ambiguous-paths.test.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+const { noAmbiguousPaths } = require('../src/rules');
+
+const rule = noAmbiguousPaths;
+const ruleId = 'ibm-no-ambiguous-paths';
+const expectedSeverity = severityCodes.warning;
+const expectedMsgRE = /^Paths are ambiguous:/;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('/foos/{foo_id} vs /foos/{id}/bar', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/foos/{foo_id}'] = {};
+      testDocument.paths['/foos/{id}/bar'] = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+  describe('Should yield errors', () => {
+    it('/v1/drinks/{drink_id} vs /v1/drinks/foo', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/foo'] = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = ['paths./v1/drinks/{drink_id}'];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(expectedMsgRE);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('/{version}/drinks vs /v1/drinks', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/{version}/drinks'] = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = ['paths./v1/drinks'];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(expectedMsgRE);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('/{foo}/bar vs /foo/{bar}', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/{foo}/bar'] = {};
+      testDocument.paths['/foo/{bar}'] = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = ['paths./{foo}/bar'];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(expectedMsgRE);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('/v1/movies/{movie_id} vs /v1/movies/{film_id}', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies/{film_id}'] = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = ['paths./v1/movies/{movie_id}'];
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(expectedMsgRE);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -168,7 +168,7 @@ module.exports = {
         },
       },
     },
-    '/v1/drinks/menu': {
+    '/v1/drink_menu': {
       get: {
         operationId: 'download_menu',
         summary: 'Download Drinks Menu',


### PR DESCRIPTION
## PR summary
This commit introduces the new spectral-style rule 'ibm-no-ambiguous-paths' which will check to make sure there are not ambiguous paths defined in the OpenAPI document.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
