### PR TITLE
feat(ibm-schema-keywords): add new validation rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -90,6 +90,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-resource-response-consistency](#ibm-resource-response-consistency)
   * [ibm-response-status-codes](#ibm-response-status-codes)
   * [ibm-schema-description](#ibm-schema-description)
+  * [ibm-schema-keywords](#ibm-schema-keywords)
   * [ibm-schema-type](#ibm-schema-type)
   * [ibm-schema-type-format](#ibm-schema-type-format)
   * [ibm-sdk-operations](#ibm-sdk-operations)
@@ -508,6 +509,13 @@ has non-form content.</td>
 <td>warn</td>
 <td>Schemas should have a non-empty description.</td>
 <td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-schema-keywords">ibm-schema-keywords</a></td>
+<td>error</td>
+<td>Verifies that schemas and schema properties in an OpenAPI 3.1 document are defined using only
+specific "allow-listed" keywords.</td>
+<td>oas3_1</td>
 </tr>
 <tr>
 <td><a href="#ibm-schema-type">ibm-schema-type</a></td>
@@ -5330,6 +5338,155 @@ components:
       type: object
       properties:
         ...
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-schema-keywords
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-schema-keywords</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>
+This rule verifies that only certain keywords (fields) are used when defining schemas and schema properties
+in an OpenAPI 3.1.x document. The allowable keywords are configurable (see the <code>Configuration</code> section below).
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>error</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3_1</td>
+</tr>
+<tr>
+<td valign=top><b>Configuration:</b></td>
+<td>This rule supports a configuration object that specifies the set of keywords that are allowed within a schema
+or schema property.
+<p>The default configuration object provided with the rule is:
+<pre>
+{
+  keywordAllowList: [
+    '$ref',
+    'additionalProperties',
+    'allOf',
+    'anyOf',
+    'default',
+    'description',
+    'discriminator',
+    'enum',
+    'example',
+    'exclusiveMaximum',
+    'exclusiveMinimum',
+    'format',
+    'items',
+    'maximum',
+    'maxItems',
+    'maxLength',
+    'maxProperties',
+    'minimum',
+    'minItems',
+    'minLength',
+    'minProperties',
+    'multipleOf',
+    'not',
+    'oneOf',
+    'pattern',
+    'patternProperties',
+    'properties',
+    'readOnly',
+    'required',
+    'title',
+    'type',
+    'uniqueItems',
+    'unevaluatedProperties',
+    'writeOnly',
+  ]
+}
+</pre>
+<p>To configure the rule with a different set of allowable keywords, you'll need to
+<a href="#replace-a-rule-from-ibm-cloudopenapi-ruleset">replace this rule with a new rule within your
+custom ruleset</a> and modify the configuration such that the value of the <code>keywordAllowList</code> field 
+contains the desired set of keywords to be checked.
+For example, to configure the rule so that <code>uniqueItems</code> and <code>unevaluatedProperties</code> are disallowed, 
+modify the configuration to remove these keywords from the <code>keywordAllowList</code>
+configuration field, like this:
+<pre>
+{
+  keywordAllowList: [
+    '$ref',
+    'additionalProperties',
+    'allOf',
+    'anyOf',
+    'default',
+    'description',
+    'discriminator',
+    'enum',
+    'example',
+    'exclusiveMaximum',
+    'exclusiveMinimum',
+    'format',
+    'items',
+    'maximum',
+    'maxItems',
+    'maxLength',
+    'maxProperties',
+    'minimum',
+    'minItems',
+    'minLength',
+    'minProperties',
+    'multipleOf',
+    'not',
+    'oneOf',
+    'pattern',
+    'patternProperties',
+    'properties',
+    'readOnly',
+    'required',
+    'title',
+    'type',
+    'writeOnly',
+  ]
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Things:
+      type: object
+      properties:
+        thing_id:
+          type: string
+          $comment: A comment about this property definition
+          nullable: true
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Things:
+      type: object
+      properties:
+        thing_id:
+          description: A comment about this property definition
+          type:
+            - string
+            - null
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/allowed-keywords.js
+++ b/packages/ruleset/src/functions/allowed-keywords.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { validateSubschemas } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (obj, options, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+  return validateSubschemas(
+    obj,
+    context.path,
+    (schema, path) => allowedKeywords(schema, path, options),
+    true,
+    true
+  );
+};
+
+/**
+ * This function will check to make sure that 'obj' is an object that contains only fields (keys)
+ * that are contained in the configured allow-list or extensions ('x-*').
+ * @param {*} obj the object within the OpenAPI document to check for allowed keywords
+ * @param {*} path the location of 'obj' within the OpenAPI document
+ * @param {*} options this is the value of the 'functionOptions' field within this rule's definition.
+ * This should be an object with the following fields:
+ *   - 'keywordAllowList': an array of strings which are the allowed keywords
+ *
+ * @returns an array containing zero or more error objects
+ */
+function allowedKeywords(obj, path, options) {
+  logger.debug(
+    `${ruleId}: checking for allowed keywords in object located at: ${path.join(
+      '.'
+    )}`
+  );
+
+  // Find the fields of 'obj' that are not an extension or an allowed keyword.
+  const disallowedKeywords = Object.keys(obj).filter(
+    k => !(k.startsWith('x-') || options.keywordAllowList.includes(k))
+  );
+
+  // Return an error for each disallowed keyword that we found.
+  if (disallowedKeywords.length) {
+    logger.debug(
+      `${ruleId}: found these disallowed keywords: ${JSON.stringify(
+        disallowedKeywords
+      )}`
+    );
+
+    return disallowedKeywords.map(k => {
+      return {
+        message: `Found disallowed keyword: ${k}`,
+        path: [...path, k],
+      };
+    });
+  }
+
+  logger.debug(`PASSED!`);
+  return [];
+}

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -4,6 +4,7 @@
  */
 
 module.exports = {
+  allowedKeywords: require('./allowed-keywords'),
   arrayAttributes: require('./array-attributes'),
   arrayOfArrays: require('./array-of-arrays'),
   arrayResponses: require('./array-responses'),

--- a/packages/ruleset/src/functions/no-operation-requestbody.js
+++ b/packages/ruleset/src/functions/no-operation-requestbody.js
@@ -20,7 +20,7 @@ module.exports = function (operation, options, context) {
  * This function will check to make sure that certain operations do not have a requestBody.
  * @param {*} operation the operation object to check
  * @param {*} path the location of 'operation' within the OpenAPI document
- * @param {*} config this is the value of the 'functionOptions' field
+ * @param {*} options this is the value of the 'functionOptions' field
  * within this rule's definition (see src/rules/operation-requestbody.js).
  * This should be an object with the following fields:
  *   - 'httpMethods': an array of strings which are the http methods that should be checked

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -160,6 +160,7 @@ module.exports = {
     'ibm-resource-response-consistency': ibmRules.resourceResponseConsistency,
     'ibm-response-status-codes': ibmRules.responseStatusCodes,
     'ibm-schema-description': ibmRules.schemaDescriptionExists,
+    'ibm-schema-keywords': ibmRules.schemaKeywords,
     'ibm-schema-type': ibmRules.schemaTypeExists,
     'ibm-schema-type-format': ibmRules.schemaTypeFormat,
     'ibm-sdk-operations': ibmRules.ibmSdkOperations,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -67,6 +67,7 @@ module.exports = {
   responseExampleExists: require('./response-example-exists'),
   responseStatusCodes: require('./response-status-codes'),
   schemaDescriptionExists: require('./schema-description-exists'),
+  schemaKeywords: require('./schema-keywords'),
   schemaTypeExists: require('./schema-type-exists'),
   schemaTypeFormat: require('./schema-type-format'),
   securitySchemes: require('./securityschemes'),

--- a/packages/ruleset/src/rules/schema-keywords.js
+++ b/packages/ruleset/src/rules/schema-keywords.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+const { oas3_1 } = require('@stoplight/spectral-formats');
+const { allowedKeywords } = require('../functions');
+
+module.exports = {
+  description:
+    'Verifies that schema objects include only allowed-listed keywords',
+  message: '{{error}}',
+  severity: 'error',
+  formats: [oas3_1],
+  resolved: true,
+  given: schemas,
+  then: {
+    function: allowedKeywords,
+    functionOptions: {
+      keywordAllowList: [
+        '$ref',
+        'additionalProperties',
+        'allOf',
+        'anyOf',
+        'default',
+        'description',
+        'discriminator',
+        'enum',
+        'example',
+        'exclusiveMaximum',
+        'exclusiveMinimum',
+        'format',
+        'items',
+        'maximum',
+        'maxItems',
+        'maxLength',
+        'maxProperties',
+        'minimum',
+        'minItems',
+        'minLength',
+        'minProperties',
+        'multipleOf',
+        'not',
+        'oneOf',
+        'pattern',
+        'patternProperties',
+        'properties',
+        'readOnly',
+        'required',
+        'title',
+        'type',
+        'uniqueItems',
+        'unevaluatedProperties',
+        'writeOnly',
+      ],
+    },
+  },
+};

--- a/packages/ruleset/test/no-nullable-properties.test.js
+++ b/packages/ruleset/test/no-nullable-properties.test.js
@@ -15,7 +15,9 @@ const expectedMsg =
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
-      // rootDocument contains a nullable property in the CarPatch schema.
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.CarPatch.properties.make.nullable = true;
+
       const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
     });

--- a/packages/ruleset/test/schema-keywords.test.js
+++ b/packages/ruleset/test/schema-keywords.test.js
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { schemaKeywords } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = schemaKeywords;
+const ruleId = 'ibm-schema-keywords';
+const expectedSeverity = severityCodes.error;
+const expectedMsgPrefix = `Found disallowed keyword:`;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  beforeAll(() => {
+    rootDocument.openapi = '3.1.0';
+  });
+
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('schema with uncommon supported keywords', async () => {
+      // This is just a positive test using valid, uncommonly-used keywords.
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Car.properties.optionsPackage = {
+        type: 'string',
+        exclusiveMinimum: true,
+        exclusiveMaximum: false,
+        minimum: 2,
+        maximum: 4,
+        minItems: 1,
+        maxItems: 10,
+        minLength: 1,
+        maxLength: 10,
+        minProperties: 2,
+        maxProperties: 25,
+        multipleOf: 13,
+        readOnly: true,
+        writeOnly: false,
+        patternProperties: {
+          '.*': {},
+        },
+        title: 'options_package',
+        uniqueItems: 33,
+        unevaluatedProperties: false,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('response schema contains "nullable"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.nullable = true;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.nullable',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`${expectedMsgPrefix} nullable`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('requestBody schema contains "$anchor"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.CarPatch['$anchor'] = 'urn:foo-anchor';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.$anchor',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`${expectedMsgPrefix} $anchor`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('schema property contains "$comment"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.CarPatch.properties.make['$comment'] =
+        'This is a comment';
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/cars/{car_id}.patch.requestBody.content.application/merge-patch+json; charset=utf-8.schema.properties.make.$comment',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`${expectedMsgPrefix} $comment`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('allOf element schema contains "examples"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkCollection.allOf[1].examples = {};
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.examples',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`${expectedMsgPrefix} examples`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('"not" schema contains "additionalItems"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Drink.not = {
+        type: 'string',
+        additionalItems: 'foo',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      const expectedPaths = [
+        'paths./v1/drinks.post.requestBody.content.application/json.schema.not.additionalItems',
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.not.additionalItems',
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks.items.not.additionalItems',
+        'paths./v1/drinks/{drink_id}.get.responses.200.content.application/json.schema.not.additionalItems',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`${expectedMsgPrefix} additionalItems`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('oneOf element schema contains "if"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Drink.oneOf[2] = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            description: 'A foo property within a new oneOf element',
+          },
+        },
+        if: {
+          type: 'string',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      const expectedPaths = [
+        'paths./v1/drinks.post.requestBody.content.application/json.schema.oneOf.2.if',
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.oneOf.2.if',
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks.items.oneOf.2.if',
+        'paths./v1/drinks/{drink_id}.get.responses.200.content.application/json.schema.oneOf.2.if',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`${expectedMsgPrefix} if`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('additionalProperties schema contains "then"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.MovieCollection.additionalProperties = {
+        type: 'string',
+        then: {
+          type: 'object',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const expectedPaths = [
+        'paths./v1/movies.get.responses.200.content.application/json.schema.additionalProperties.then',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(`${expectedMsgPrefix} then`);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -882,7 +882,6 @@ module.exports = {
             minLength: 1,
             maxLength: 32,
             pattern: '.*',
-            nullable: true,
           },
           model: {
             $ref: '#/components/schemas/CarModelType',

--- a/packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
@@ -149,8 +149,6 @@ components:
         name:
           type: string
           description: string
-      xml:
-        name: Category
     Tag:
       type: object
       description: string
@@ -162,8 +160,6 @@ components:
         name:
           type: string
           description: string
-      xml:
-        name: Tag
     Pet:
       type: object
       description: string
@@ -186,9 +182,6 @@ components:
           description: string
           minItems: 0
           maxItems: 20
-          xml:
-            name: photoUrl
-            wrapped: true
           items:
             type: string
         tags:
@@ -196,9 +189,6 @@ components:
           description: string
           minItems: 0
           maxItems: 20
-          xml:
-            name: tag
-            wrapped: true
           items:
             $ref: "#/components/schemas/Tag"
         status:
@@ -208,8 +198,6 @@ components:
             - available
             - pending
             - sold
-      xml:
-        name: Pet
     UnusedString:
       description: string
       type: string

--- a/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
@@ -149,8 +149,6 @@ components:
         name:
           type: string
           description: string
-      xml:
-        name: Category
     Tag:
       type: object
       description: string
@@ -162,8 +160,6 @@ components:
         name:
           type: string
           description: string
-      xml:
-        name: Tag
     Pet:
       type: object
       description: string
@@ -186,9 +182,6 @@ components:
           description: string
           minItems: 0
           maxItems: 20
-          xml:
-            name: photoUrl
-            wrapped: true
           items:
             type: string
         tags:
@@ -196,9 +189,6 @@ components:
           description: string
           minItems: 0
           maxItems: 20
-          xml:
-            name: tag
-            wrapped: true
           items:
             $ref: "#/components/schemas/Tag"
         status:
@@ -208,8 +198,6 @@ components:
             - available
             - pending
             - sold
-      xml:
-        name: Pet
     UnusedString:
       description: string
       type: string

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -101,7 +101,7 @@ describe('Expected output tests', function () {
         expect(capturedText[warningStart + 50].match(/\S+/g)[2]).toEqual('96');
         // Skip a few, then verify the last one.
         expect(capturedText[warningStart + 145].match(/\S+/g)[2]).toEqual(
-          '213'
+          '201'
         );
       }
     );


### PR DESCRIPTION
## PR summary
This commit introduces the new 'ibm-schema-keywords' validation rule which will verify that each schema and schema property are defined with only "allowed" keywords (fields), whwere the set of allowable keywords are defined in a configurable allow list.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
