### PR TITLE
feat(no-$ref-siblings): modify rule to also run on OpenAPI 3.1.x documents

### DIFF
--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -6,6 +6,13 @@
 const { oas3 } = require('@stoplight/spectral-formats');
 const { oas } = require('@stoplight/spectral-rulesets');
 const ibmRules = require('./rules');
+
+// Spectral's "no-$ref-siblings" rule is configured to run on
+// OpenAPI 3.0.x documents (ref sibling attributes are allowed in OpenAPI 3.1.x).
+// However, we want to enable this rule also for OpenAPI 3.1.x documents,
+// so we'll just tweak Spectral's rule definition here.
+oas.rules['no-$ref-siblings'].formats = [oas3];
+
 module.exports = {
   extends: oas,
   documentationUrl:

--- a/packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/err-and-warn.yaml
@@ -173,6 +173,7 @@ components:
           description: string
         category:
           $ref: "#/components/schemas/Category"
+          description: 'This ref sibling should cause an error'
         name:
           type: string
           example: doggie

--- a/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
@@ -173,6 +173,7 @@ components:
           description: string
         category:
           $ref: "#/components/schemas/Category"
+          description: 'This ref sibling should cause an error'
         name:
           type: string
           example: doggie

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -87,8 +87,23 @@ describe('Expected output tests', function () {
         expect(capturedText[errorStart + 10].match(/\S+/g)[2]).toEqual('96');
         expect(capturedText[errorStart + 15].match(/\S+/g)[2]).toEqual('103');
 
+        // Specifically verify that the no-$ref-siblings error occurred.
+        // We do this because this rule is inherited from Spectral's oas ruleset,
+        // but we modify the rule definition in ibmoas.js so that it is run
+        // against both OpenAPI 3.0 and 3.1 documents.
+        expect(capturedText[errorStart + 17].split(':')[1].trim()).toEqual(
+          '$ref must not be placed next to any other properties'
+        );
+        expect(capturedText[errorStart + 18].split(':')[1].trim()).toEqual(
+          'no-$ref-siblings'
+        );
+        expect(capturedText[errorStart + 19].split(':')[1].trim()).toEqual(
+          'components.schemas.Pet.properties.category.description'
+        );
+        expect(capturedText[errorStart + 20].match(/\S+/g)[2]).toEqual('176');
+
         // warnings
-        const warningStart = 20;
+        const warningStart = 25;
         expect(capturedText[warningStart + 5].match(/\S+/g)[2]).toEqual('22');
         expect(capturedText[warningStart + 10].match(/\S+/g)[2]).toEqual('24');
         expect(capturedText[warningStart + 15].match(/\S+/g)[2]).toEqual('40');
@@ -101,7 +116,7 @@ describe('Expected output tests', function () {
         expect(capturedText[warningStart + 50].match(/\S+/g)[2]).toEqual('96');
         // Skip a few, then verify the last one.
         expect(capturedText[warningStart + 145].match(/\S+/g)[2]).toEqual(
-          '201'
+          '202'
         );
       }
     );

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -91,7 +91,7 @@ describe('cli tool - test option handling', function () {
       const capturedText = getCapturedText(consoleSpy.mock.calls);
       // This can be uncommented to display the output when adjustments to
       // the expect statements below are needed.
-      // let textOutput = "";
+      // let textOutput = '';
       // capturedText.forEach((elem, index) => {
       //   textOutput += `[${index}]: ${elem}\n`;
       // });
@@ -113,19 +113,19 @@ describe('cli tool - test option handling', function () {
       expect(sumSection).toBe(3);
 
       // totals
-      expect(capturedText[sumSection + 2].match(/\S+/g)[5]).toEqual('3');
+      expect(capturedText[sumSection + 2].match(/\S+/g)[5]).toEqual('4');
       expect(capturedText[sumSection + 3].match(/\S+/g)[5]).toEqual('29');
 
       // errors
       const errorSection = 8;
       expect(capturedText[errorSection + 1].match(/\S+/g)[0]).toEqual('1');
-      expect(capturedText[errorSection + 1].match(/\S+/g)[1]).toEqual('(33%)');
+      expect(capturedText[errorSection + 1].match(/\S+/g)[1]).toEqual('(25%)');
 
       expect(capturedText[errorSection + 2].match(/\S+/g)[0]).toEqual('2');
-      expect(capturedText[errorSection + 2].match(/\S+/g)[1]).toEqual('(67%)');
+      expect(capturedText[errorSection + 2].match(/\S+/g)[1]).toEqual('(50%)');
 
       // warnings
-      const warningSection = 12;
+      const warningSection = 13;
       expect(capturedText[warningSection + 1].match(/\S+/g)[0]).toEqual('2');
       expect(capturedText[warningSection + 1].match(/\S+/g)[1]).toEqual('(7%)');
 


### PR DESCRIPTION
## PR summary
This commit modifies the 'no-$ref-siblings' rule which is inherited from Spectral's oas ruleset.  Specifically, we modify the rule so that it is run on OpenAPI 3.1.x documents instead of only 3.0.x documents.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
