### PR TITLE
fix(ibm-schema-naming-convention): allow canonical schema for create/replace

### DIFF
--- a/packages/ruleset/src/functions/schema-naming-convention.js
+++ b/packages/ruleset/src/functions/schema-naming-convention.js
@@ -212,7 +212,10 @@ function checkSchemaNames(apidef, nodes) {
 
       if (
         postRequestSchemaName &&
-        postRequestSchemaName !== `${canonicalSchemaName}Prototype`
+        postRequestSchemaName !== `${canonicalSchemaName}Prototype` &&
+        // The API Handbook makes an exception for cases where the canonical
+        // schema itself should be used for creation
+        postRequestSchemaName !== canonicalSchemaName
       ) {
         logger.debug(`${ruleId}: reporting error! post prototype is wrong`);
         errors.push({
@@ -244,7 +247,10 @@ function checkSchemaNames(apidef, nodes) {
 
       if (
         putRequestSchemaName &&
-        putRequestSchemaName !== `${canonicalSchemaName}Prototype`
+        putRequestSchemaName !== `${canonicalSchemaName}Prototype` &&
+        // The API Handbook makes an exception for cases where the canonical
+        // schema itself should be used for creation
+        putRequestSchemaName !== canonicalSchemaName
       ) {
         logger.debug(`${ruleId}: reporting error! put prototype is wrong`);
         errors.push({

--- a/packages/ruleset/test/schema-naming-convention.test.js
+++ b/packages/ruleset/test/schema-naming-convention.test.js
@@ -254,6 +254,44 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
+    it('Prototype schema in POST request body uses canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Mess = {};
+      testDocument.components.schemas.MessPrototype = {};
+      testDocument.paths['/v1/messes'] = {
+        post: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Mess',
+                },
+              },
+            },
+          },
+        },
+      };
+      testDocument.paths['/v1/messes/{id}'] = {
+        get: {
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Mess',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
     it('Prototype schema in PUT request body is correctly named', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -280,6 +318,43 @@ describe(`Spectral rule: ${ruleId}`, () => {
               'application/json': {
                 schema: {
                   $ref: '#/components/schemas/MessPrototype',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Prototype schema in PUT request body uses canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Mess = {};
+      testDocument.components.schemas.MessPrototype = {};
+      testDocument.paths['/v1/messes'] = {};
+      testDocument.paths['/v1/messes/{id}'] = {
+        get: {
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Mess',
+                  },
+                },
+              },
+            },
+          },
+        },
+        put: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Mess',
                 },
               },
             },


### PR DESCRIPTION
The Handbook states:

"There is an important exception to this guidance if the nature of an API is to provide clients with full control over entire resources, with no system-defined or immutable aspects. For such APIs, the canonical schema itself SHOULD be used in requests to create or replace a resource."

This commit allows for the name of the canonical schema to be used for resource-oriented POSTs and PUTs.