### PR TITLE
feat: display actual ruleset version with --version option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4781,17 +4781,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/find-versions": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
@@ -6933,18 +6922,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/lodash": {
@@ -11080,6 +11057,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -11088,17 +11066,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-map": {
@@ -11184,6 +11151,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11239,6 +11207,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -14090,7 +14059,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -14100,10 +14068,10 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.6.1",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset-utilities": "1.2.0",
+        "@ibm-cloud/openapi-ruleset-utilities": "1.3.0",
         "@stoplight/spectral-formats": "^1.5.0",
         "@stoplight/spectral-functions": "^1.7.2",
         "@stoplight/spectral-rulesets": "^1.16.0",
@@ -14146,7 +14114,7 @@
     },
     "packages/utilities": {
       "name": "@ibm-cloud/openapi-ruleset-utilities",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@stoplight/spectral-core": "^1.18.0",
@@ -14158,17 +14126,17 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.6.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.6.0",
+        "@ibm-cloud/openapi-ruleset": "1.13.0",
         "@stoplight/spectral-cli": "^6.8.0",
         "@stoplight/spectral-core": "^1.18.0",
         "@stoplight/spectral-parsers": "^1.0.2",
         "ajv": "^8.12.0",
         "chalk": "^4.1.1",
         "commander": "^10.0.0",
-        "find-up": "^3.0.0",
+        "find-up": "5.0.0",
         "globby": "^11.0.4",
         "js-yaml": "^3.14.1",
         "json-dup-key-validator": "^1.0.3",
@@ -14189,46 +14157,69 @@
         "npm": ">=8.3.0"
       }
     },
-    "packages/validator/node_modules/@ibm-cloud/openapi-ruleset": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@ibm-cloud/openapi-ruleset/-/openapi-ruleset-1.6.0.tgz",
-      "integrity": "sha512-Hx29G2x0UHdVySM0U6Y9LGHsidlwm63GTncvmj73+t/Pv07pYLoAA2sc2P21lAInVwLf0Ae8gOeLYvrTaDrBDQ==",
+    "packages/validator/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset-utilities": "1.2.0",
-        "@stoplight/spectral-formats": "^1.5.0",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-rulesets": "^1.16.0",
-        "chalk": "^4.1.1",
-        "lodash": "^4.17.21",
-        "loglevel": "^1.8.1",
-        "loglevel-plugin-prefix": "0.8.4",
-        "minimatch": "^6.1.6",
-        "validator": "^13.7.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "packages/validator/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/validator/node_modules/minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/validator/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/validator/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/validator/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/validator/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
       }
     }
   },
@@ -14847,7 +14838,7 @@
     "@ibm-cloud/openapi-ruleset": {
       "version": "file:packages/ruleset",
       "requires": {
-        "@ibm-cloud/openapi-ruleset-utilities": "1.2.0",
+        "@ibm-cloud/openapi-ruleset-utilities": "1.3.0",
         "@stoplight/spectral-core": "^1.18.0",
         "@stoplight/spectral-formats": "^1.5.0",
         "@stoplight/spectral-functions": "^1.7.2",
@@ -17825,14 +17816,6 @@
         "repeat-string": "^1.5.2"
       }
     },
-    "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "requires": {
-        "locate-path": "^3.0.0"
-      }
-    },
     "find-versions": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
@@ -18257,7 +18240,7 @@
     "ibm-openapi-validator": {
       "version": "file:packages/validator",
       "requires": {
-        "@ibm-cloud/openapi-ruleset": "1.6.0",
+        "@ibm-cloud/openapi-ruleset": "1.13.0",
         "@stoplight/spectral-cli": "^6.8.0",
         "@stoplight/spectral-core": "^1.18.0",
         "@stoplight/spectral-parsers": "^1.0.2",
@@ -18265,7 +18248,7 @@
         "ansi-regex": "^5.0.1",
         "chalk": "^4.1.1",
         "commander": "^10.0.0",
-        "find-up": "^3.0.0",
+        "find-up": "5.0.0",
         "globby": "^11.0.4",
         "jest": "^27.4.5",
         "js-yaml": "^3.14.1",
@@ -18276,38 +18259,43 @@
         "semver": "^7.5.3"
       },
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@ibm-cloud/openapi-ruleset/-/openapi-ruleset-1.6.0.tgz",
-          "integrity": "sha512-Hx29G2x0UHdVySM0U6Y9LGHsidlwm63GTncvmj73+t/Pv07pYLoAA2sc2P21lAInVwLf0Ae8gOeLYvrTaDrBDQ==",
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "requires": {
-            "@ibm-cloud/openapi-ruleset-utilities": "1.2.0",
-            "@stoplight/spectral-formats": "^1.5.0",
-            "@stoplight/spectral-functions": "^1.7.2",
-            "@stoplight/spectral-rulesets": "^1.16.0",
-            "chalk": "^4.1.1",
-            "lodash": "^4.17.21",
-            "loglevel": "^1.8.1",
-            "loglevel-plugin-prefix": "0.8.4",
-            "minimatch": "^6.1.6",
-            "validator": "^13.7.0"
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
           }
         },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "requires": {
-            "balanced-match": "^1.0.0"
+            "p-locate": "^5.0.0"
           }
         },
-        "minimatch": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-          "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "requires": {
-            "brace-expansion": "^2.0.1"
+            "yocto-queue": "^0.1.0"
           }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         }
       }
     },
@@ -19466,15 +19454,6 @@
           "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true
         }
-      }
-    },
-    "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -22328,16 +22307,9 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "requires": {
-        "p-limit": "^2.0.0"
       }
     },
     "p-map": {
@@ -22391,7 +22363,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "pad": {
       "version": "2.3.0",
@@ -22431,7 +22404,8 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -24518,8 +24492,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.12.0",
     "chalk": "^4.1.1",
     "commander": "^10.0.0",
-    "find-up": "^3.0.0",
+    "find-up": "5.0.0",
     "globby": "^11.0.4",
     "js-yaml": "^3.14.1",
     "json-dup-key-validator": "^1.0.3",

--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -20,6 +20,7 @@ const print = require('./utils/print-results');
 const { printJson } = require('./utils/json-results');
 const { runSpectral } = require('../spectral/spectral-validator');
 const getCopyrightString = require('./utils/get-copyright-string');
+const printVersions = require('./utils/print-versions');
 
 let logger;
 
@@ -48,7 +49,18 @@ async function runValidator(cliArgs, parseOptions = {}) {
     // help was displayed, version string requested, unknown option, etc.)
     // and it should have an "exitCode" field.
     const exitCode = 'exitCode' in err ? err.exitCode : 2;
+    if (exitCode !== 0) {
+      console.error('Command parsing error: ', err.message);
+    }
     return exitCode === 0 ? Promise.resolve(0) : Promise.reject(2);
+  }
+
+  // If the version was requested, print that here. Note that we
+  // needed to wait until after the configuration was processed
+  // to try and compute/include the ruleset version.
+  if (command.opts().version) {
+    await printVersions(context);
+    return Promise.resolve(0);
   }
 
   logger = context.logger;
@@ -61,7 +73,7 @@ async function runValidator(cliArgs, parseOptions = {}) {
 
   // If no arguments are passed in, then display help text and exit.
   if (args.length === 0) {
-    logger.error(`${getCopyrightString()}\n${command.helpInformation()}`);
+    console.log(`${getCopyrightString()}\n${command.helpInformation()}`);
     return Promise.reject(2);
   }
 

--- a/packages/validator/src/cli-validator/utils/check-ruleset-version.js
+++ b/packages/validator/src/cli-validator/utils/check-ruleset-version.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const semver = require('semver');
+const getDefaultRulesetVersion = require('./get-default-ruleset-version.js');
+
+module.exports = checkRulesetVersion;
+
+/**
+ * Checks the locally installed version of the IBM Cloud OpenAPI
+ * Ruleset (if there is one) against what the default version
+ * would be for the current version of the validator tool.
+ *
+ * If the installed version is older than the default version that
+ * comes with the tool, this function returns a warning alerting
+ * the user to this fact. We do this because it is possible for a
+ * user to continue updating their validator tool version but never
+ * seeing the new behavior from later versions of the ruleset because
+ * they've fixed their ruleset version locally. This happens silently,
+ * so the user may end up in this scenario without being aware of it.
+ *
+ * @param string local - the semantic version of the locally installed ruleset
+ * @returns string|undefined - the warning message, if relevant
+ */
+function checkRulesetVersion(local) {
+  if (!local || typeof local !== 'string') {
+    return;
+  }
+
+  const defaultVersion = getDefaultRulesetVersion();
+  if (semver.lt(local, defaultVersion)) {
+    return `Note: local version of the IBM OpenAPI Ruleset is behind the default version, which is ${defaultVersion}.`;
+  }
+
+  return;
+}

--- a/packages/validator/src/cli-validator/utils/cli-options.js
+++ b/packages/validator/src/cli-validator/utils/cli-options.js
@@ -5,7 +5,6 @@
 
 const { Command } = require('commander');
 const getCopyrightString = require('./get-copyright-string');
-const getVersionString = require('./get-version-string');
 
 /**
  * This function is used to gather multi-valued arguments into an array.
@@ -81,7 +80,7 @@ function createCLIOptions() {
       'set warnings limit to <number> (default is -1)',
       parseWarningsLimit
     )
-    .version(getVersionString(), '--version')
+    .option('--version', 'output the version number')
     .showHelpAfterError()
     .addHelpText('beforeAll', getCopyrightString());
 

--- a/packages/validator/src/cli-validator/utils/get-default-ruleset-version.js
+++ b/packages/validator/src/cli-validator/utils/get-default-ruleset-version.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const packageConfig = require('../../../package.json');
+
+module.exports = getDefaultRulesetVersion;
+
+/**
+ * Looks at the validator tool's declared dependencies and
+ * returns the semantic version of the IBM Cloud OpenAPI
+ * Ruleset package that ships by default with the current
+ * version of the validator tool.
+ *
+ * @returns string - the default ruleset version
+ */
+function getDefaultRulesetVersion() {
+  return packageConfig.dependencies['@ibm-cloud/openapi-ruleset'];
+}

--- a/packages/validator/src/cli-validator/utils/get-local-ruleset-version.js
+++ b/packages/validator/src/cli-validator/utils/get-local-ruleset-version.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const findUp = require('find-up');
+const { dirname, join } = require('path');
+
+module.exports = getLocalRulesetVersion;
+
+/**
+ * Looks for a locally installed version of the IBM Cloud OpenAPI
+ * Ruleset package. It mimics the behavior of Spectral's local
+ * module lookup by seeking up the file system for a `node_modules/`
+ * directory that contains the package. If we find it, we try to
+ * extract the version from the `package.json` file and return it.
+ *
+ * @param string directory - the path to the user's local ruleset
+ * @param object logger - the root logger instance
+ * @returns string - the semantic version, if found. empty string, if not.
+ */
+async function getLocalRulesetVersion(localRuleset, logger) {
+  if (!localRuleset) {
+    return '';
+  }
+
+  // Compute the location of the local ruleset to use in looking for
+  // the locally installed instance of the ruleset.
+  const rulesetLocation = dirname(localRuleset);
+  logger.debug('Custom ruleset file found in:', rulesetLocation);
+
+  // Look for the locally installed ruleset package, which will have to
+  // be there if the user is extending their ruleset from the IBM
+  // ruleset. It follows Spectral's logic, seeking up from the location
+  // of the ruleset and looking for a `node_modules/` folder that contains
+  // the package name given in `extends`.
+  const packagePath = await lookForRulesetPackage(rulesetLocation);
+
+  if (packagePath) {
+    logger.debug('Found IBM ruleset package file at:', packagePath);
+    try {
+      // Read the JSON file using `require`.
+      const rulesetPackageFile = require(packagePath);
+
+      // Return the value of the `version` field in the `package.json`.
+      // Note: the "|| {}" just makes sure we don't get a type error from `hasOwn`.
+      if (Object.hasOwn(rulesetPackageFile || {}, 'version')) {
+        return rulesetPackageFile.version;
+      }
+    } catch (e) {
+      logger.debug('Could not read the IBM ruleset package file:', e.message);
+    }
+  } else {
+    logger.debug('IBM OpenAPI ruleset package not found');
+  }
+
+  // The IBM ruleset is not being used at all,
+  // so we don't provide a version.
+  return '';
+}
+
+/**
+ * This function mimics the logic used by Spectral to find the
+ * node module providing the ruleset package defined in the
+ * `extends` field of a user ruleset. If they aren't extending
+ * our package, thats okay - we either won't find it or we will
+ * report the version that they would be using if they extend it.
+ *
+ * The logic starts in the directory where their ruleset config
+ * file is found, then looks up in each directory until it finds
+ * it or reaches the root of the filesystem. Returns the path to
+ * the file it's looking for if found, undefined if it is not.
+ *
+ * @param string rulesetDir - the path to the users ruleset
+ * @returns string|undefined - filepath if found, undefined if not
+ */
+async function lookForRulesetPackage(rulesetDir) {
+  let pathToPackage;
+
+  // This partial provides a "matcher" callback for `findUp`. It
+  // will be called for each directory up a path and will check
+  // for the IBM ruleset package in each one. If it finds it, it
+  // will save the path and return the directory string (which
+  // will stop the search) and if not, it will return `undefined`,
+  // which continues the search.
+  async function matchIBMRulesetPackage(directory) {
+    const expectedPath = join(
+      directory,
+      'node_modules',
+      '@ibm-cloud',
+      'openapi-ruleset',
+      'package.json'
+    );
+
+    const ibmRulesetFound = await findUp.exists(expectedPath);
+
+    // The way to break the search is to return the directory
+    // currently being searched, but we want to save the path
+    // to the actual file as well.
+    if (ibmRulesetFound) {
+      pathToPackage = expectedPath;
+      return directory;
+    }
+
+    return;
+  }
+
+  // Run `findUp` to look for the package file.
+  const opts = { type: 'directory', cwd: rulesetDir };
+  await findUp(matchIBMRulesetPackage, opts);
+  return pathToPackage;
+}

--- a/packages/validator/src/cli-validator/utils/get-version-string.js
+++ b/packages/validator/src/cli-validator/utils/get-version-string.js
@@ -6,8 +6,5 @@
 const packageConfig = require('../../../package.json');
 
 module.exports = function () {
-  const validator = packageConfig.version;
-  const ruleset = packageConfig.dependencies['@ibm-cloud/openapi-ruleset'];
-
-  return `validator: ${validator}; ruleset: ${ruleset}`;
+  return `validator: ${packageConfig.version}`;
 };

--- a/packages/validator/src/cli-validator/utils/print-versions.js
+++ b/packages/validator/src/cli-validator/utils/print-versions.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const getDefaultRulesetVersion = require('./get-default-ruleset-version.js');
+const getLocalRulesetVersion = require('./get-local-ruleset-version');
+const getVersionString = require('./get-version-string');
+const checkRulesetVersion = require('./check-ruleset-version');
+const { findSpectralRuleset } = require('../../spectral/utils');
+
+module.exports = printVersions;
+
+/**
+ * Prints the "version" strings upon request. It always
+ * includes the semantic version of the validator tool
+ * itself and if relevant, it includes the semantic
+ * version of the IBM Cloud OpenAPI Ruleset that is being
+ * executed with the tool. That will either be the default
+ * version, which will be explicitly indicated, or it will
+ * be the user's locally installed version.
+ *
+ * @param context object - the local context object
+ * @returns void
+ */
+async function printVersions(context) {
+  const versionInfo = await collectVersionInfo(context);
+
+  let output = versionInfo.tool;
+
+  if (versionInfo.ruleset) {
+    output += `; ${versionInfo.ruleset}`;
+  }
+
+  if (versionInfo.note) {
+    output += `\n\n${versionInfo.note}`;
+  }
+
+  output += `\n`;
+
+  console.log(output);
+}
+
+/**
+ * Assembles the information about package versions to print for the user.
+ * It retrieves the version of the validator tool, computes the version of
+ * the IBM Cloud OpenAPI Ruleset (if being used), and notes any additional
+ * information that the user may find relevant to contextualize the version
+ * output. It also formats the version strings for printing.
+ *
+ * @param object - the local context object
+ * @returns object - information about local versions
+ *          .tool - the version string for the validator CLI tool
+ *          .ruleset - the version string for the IBM ruleset (optional)
+ *          .note - a message providing additional info for the user (optional)
+ */
+async function collectVersionInfo({ config, logger }) {
+  // Collect the version information in this object to return
+  // as the result of this function.
+  const versionInfo = {};
+
+  // Add the tool version, which is always guaranteed to be present.
+  versionInfo.tool = getVersionString();
+
+  // Add the IBM ruleset version, if it is being used. Include a note if not.
+  const localRuleset = await findSpectralRuleset(config, logger);
+
+  if (localRuleset) {
+    const rulesetVersion = await getLocalRulesetVersion(localRuleset, logger);
+    if (rulesetVersion) {
+      versionInfo.ruleset = `ruleset: ${rulesetVersion}`;
+
+      // Check to see if the ruleset is locally installed and if so, add a note
+      // if the local version is behind what the default version would be for
+      // the current version of the tool.
+      const versionWarning = checkRulesetVersion(rulesetVersion);
+      if (versionWarning) {
+        versionInfo.note = versionWarning;
+      }
+    }
+  } else {
+    // If the user isn't using a custom, local ruleset
+    // we will use our default ruleset.
+    versionInfo.ruleset = `ruleset: ${getDefaultRulesetVersion()} (default)`;
+  }
+
+  if (!versionInfo.ruleset) {
+    // Add a note explaining why a ruleset version is not included in the output.
+    versionInfo.note =
+      'Note: ruleset version not included because IBM OpenAPI Ruleset is not being used.';
+  }
+
+  return versionInfo;
+}

--- a/packages/validator/src/spectral/utils.js
+++ b/packages/validator/src/spectral/utils.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const findUp = require('find-up');
+
+module.exports = {
+  findSpectralRuleset,
+};
+
+/**
+ * Checks the user configuration and the file system for local
+ * Spectral config file (aka a local ruleset). If not found,
+ * our included default ruleset will be used.
+ *
+ * @param config - the user-defined config object
+ * @param logger - the root logger instance
+ * @returns string|null - the path to the local ruleset
+ */
+async function findSpectralRuleset(config, logger) {
+  // Spectral only supports reading a config file in the working directory,
+  // but we support looking up the file path for the nearest file (if one exists).
+  let rulesetFileOverride = config.ruleset;
+  if (!rulesetFileOverride) {
+    rulesetFileOverride = await lookForSpectralRuleset();
+    if (!rulesetFileOverride) {
+      logger.info(
+        `No Spectral ruleset file found, using the default IBM Cloud OpenAPI Ruleset.`
+      );
+    }
+  }
+
+  // If '--ruleset default' was specified on command-line, then force the use
+  // of our default ruleset.
+  if (rulesetFileOverride === 'default') {
+    rulesetFileOverride = null;
+    logger.info(`Using the default IBM Cloud OpenAPI Ruleset.`);
+  }
+
+  return rulesetFileOverride;
+}
+
+/**
+ * Looks for a local Spectral configuration file based on the
+ * names allowed by Spectral. However, unlike Spectral, we will
+ * look up the file system for it instead of only the current
+ * working directory.
+ *
+ * @returns string - the path to the local ruleset file
+ */
+async function lookForSpectralRuleset() {
+  // List of ruleset files to search for
+  const rulesetFilesToFind = [
+    '.spectral.yaml',
+    '.spectral.yml',
+    '.spectral.json',
+    '.spectral.js',
+  ];
+
+  let rulesetFile = null;
+
+  // search up the file system for the first ruleset file found
+  try {
+    for (const file of rulesetFilesToFind) {
+      if (!rulesetFile) {
+        rulesetFile = await findUp(file);
+      }
+    }
+  } catch {
+    // if there's any issue finding a custom ruleset, then return null
+    rulesetFile = null;
+  }
+
+  return rulesetFile;
+}

--- a/packages/validator/test/cli-validator/tests/configuration-manager.test.js
+++ b/packages/validator/test/cli-validator/tests/configuration-manager.test.js
@@ -432,19 +432,14 @@ describe('Configuration Manager tests', function () {
         }
       );
 
-      it('should throw error for --version option', async function () {
-        let caughtException;
-        try {
-          await configMgr.processArgs(['--version'], cliParseOptions);
-        } catch (err) {
-          caughtException = true;
-          expect(err.exitCode).toBe(0);
-        }
+      it('should not throw error for --version option', async function () {
+        const { command } = await configMgr.processArgs(
+          ['--version'],
+          cliParseOptions
+        );
+        expect(command.opts().version).toBe(true);
         const capturedText = getCapturedText(consoleSpy.mock.calls);
-        // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
-        expect(capturedText).toHaveLength(1);
-        expect(capturedText[0]).toMatch(/validator:.*ruleset:.*/);
-        expect(caughtException).toBe(true);
+        expect(capturedText).toHaveLength(0);
       });
 
       it('should throw error for --help option', async function () {
@@ -459,7 +454,7 @@ describe('Configuration Manager tests', function () {
         // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
         expect(capturedText).toHaveLength(2);
         expect(capturedText[0]).toMatch(
-          /IBM OpenAPI Validator.*validator:.*ruleset:.*Copyright.*/
+          /IBM OpenAPI Validator.*validator:.*Copyright.*/
         );
         expect(capturedText[1]).toMatch(/Usage:/);
         expect(caughtException).toBe(true);

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -238,6 +238,14 @@ describe('cli tool - test option handling', function () {
     expect(outputObject.warning.summary.total).toBeGreaterThan(0);
   });
 
+  it('should print out the version strings with the --version option', async function () {
+    await testValidator(['--version']);
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+    expect(capturedText).toHaveLength(1);
+    expect(capturedText[0]).toMatch(/validator:.*ruleset:.*(default)/);
+  });
+
   describe('test unknown option handling', function () {
     it('should return an error and help text when there is an unknown option', async function () {
       let caughtException = false;


### PR DESCRIPTION
Before this commit, the --version option would print the version of the validator tool and the version of the IBM Cloud OpenAPI Ruleset that is run by default if the user doesn't provide their own ruleset.

However, if the user did use their own, locally installed version of our ruleset, the version included in the output of the tool would not actually reflect the version being used. Additionally, users could install new versions of the validator tool but if they didn't update their locally installed instance of the ruleset, they would not get the updated behavior of the rules (which are often the reasons for bumping the version of the tool).

This commit adds logic to print the actually used (whether the default or locally installed) ruleset version and additionally will print a warning if the user has upgraded the version of their tool without upgrading the version of their locally installed ruleset.

This all required a little bit of re-organizing of some of the code.
