### PR TITLE
refactor: expose cli tool utilities under a single export

### DIFF
--- a/packages/validator/src/cli-validator/utils/check-ruleset-version.js
+++ b/packages/validator/src/cli-validator/utils/check-ruleset-version.js
@@ -4,7 +4,7 @@
  */
 
 const semver = require('semver');
-const getDefaultRulesetVersion = require('./get-default-ruleset-version.js');
+const getDefaultRulesetVersion = require('./get-default-ruleset-version');
 
 module.exports = checkRulesetVersion;
 

--- a/packages/validator/src/cli-validator/utils/configuration-manager.js
+++ b/packages/validator/src/cli-validator/utils/configuration-manager.js
@@ -9,9 +9,9 @@ const {
   supportedFileExtension,
 } = require('./file-extension-validator');
 const { LoggerFactory } = require('@ibm-cloud/openapi-ruleset/src/utils');
-const { validate } = require('./schema-validator');
+const validateSchema = require('./validate-schema');
 const createCLIOptions = require('./cli-options');
-const { readYaml } = require('./read-yaml');
+const readYaml = require('./read-yaml');
 
 // Lazy initializer for the logger.
 let logger;
@@ -98,7 +98,7 @@ async function loadConfig(filename) {
     // against our schema.
     if (userConfig) {
       const schema = await getConfigFileSchema();
-      const results = validate(userConfig, schema);
+      const results = validateSchema(userConfig, schema);
       if (results.length) {
         let msg = `Invalid configuration file '${configFile}' detected:`;
         results.forEach(result => {

--- a/packages/validator/src/cli-validator/utils/file-extension-validator.js
+++ b/packages/validator/src/cli-validator/utils/file-extension-validator.js
@@ -18,5 +18,7 @@ const validateExtension = (filename, supportedFileTypes) => {
   return goodExtension;
 };
 
-module.exports.supportedFileExtension = validateExtension;
-module.exports.getFileExtension = getExtension;
+module.exports = {
+  supportedFileExtension: validateExtension,
+  getFileExtension: getExtension,
+};

--- a/packages/validator/src/cli-validator/utils/index.js
+++ b/packages/validator/src/cli-validator/utils/index.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+module.exports = {
+  checkRulesetVersion: require('./check-ruleset-version'),
+  createCLIOptions: require('./cli-options'),
+  getCopyrightString: require('./get-copyright-string'),
+  getDefaultRulesetVersion: require('./get-default-ruleset-version'),
+  getLocalRulesetVersion: require('./get-local-ruleset-version'),
+  getVersionString: require('./get-version-string'),
+  preprocessFile: require('./preprocess-file'),
+  printJson: require('./print-json'),
+  printResults: require('./print-results'),
+  printVersions: require('./print-versions'),
+  readYaml: require('./read-yaml'),
+  validateSchema: require('./validate-schema'),
+  ...require('./configuration-manager'),
+  ...require('./file-extension-validator'),
+};

--- a/packages/validator/src/cli-validator/utils/print-json.js
+++ b/packages/validator/src/cli-validator/utils/print-json.js
@@ -7,4 +7,4 @@ function printJson(context, results) {
   console.log(JSON.stringify(results, null, 2));
 }
 
-module.exports.printJson = printJson;
+module.exports = printJson;

--- a/packages/validator/src/cli-validator/utils/read-yaml.js
+++ b/packages/validator/src/cli-validator/utils/read-yaml.js
@@ -14,4 +14,4 @@ async function readYaml(path) {
   return jsYaml.safeLoad(fileContents);
 }
 
-module.exports.readYaml = readYaml;
+module.exports = readYaml;

--- a/packages/validator/src/cli-validator/utils/validate-schema.js
+++ b/packages/validator/src/cli-validator/utils/validate-schema.js
@@ -12,7 +12,7 @@ const Ajv = require('ajv');
  * @returns [] if no validation errors were detected, or an array strings
  * containing the error messages.
  */
-function validate(data, schema) {
+function validateSchema(data, schema) {
   const ajv = new Ajv({ allErrors: false });
 
   const validate = ajv.compile(schema);
@@ -30,6 +30,4 @@ function validate(data, schema) {
   return messages;
 }
 
-module.exports = {
-  validate,
-};
+module.exports = validateSchema;

--- a/packages/validator/src/spectral/spectral-validator.js
+++ b/packages/validator/src/spectral/spectral-validator.js
@@ -9,11 +9,13 @@ const {
   getRuleset,
 } = require('@stoplight/spectral-cli/dist/services/linter/utils/getRuleset');
 const ibmRuleset = require('@ibm-cloud/openapi-ruleset');
+
 const {
+  checkRulesetVersion,
   getFileExtension,
-} = require('../cli-validator/utils/file-extension-validator');
-const getLocalRulesetVersion = require('../cli-validator/utils/get-local-ruleset-version');
-const checkRulesetVersion = require('../cli-validator/utils/check-ruleset-version');
+  getLocalRulesetVersion,
+} = require('../cli-validator/utils');
+
 const { findSpectralRuleset } = require('./utils');
 
 /**

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -3,17 +3,18 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const { stripAnsi } = require('../../test-utils');
 const {
   getCapturedText,
   getCapturedTextWithColor,
+  stripAnsi,
   testValidator,
 } = require('../../test-utils');
+
 const {
-  validate,
-} = require('../../../src/cli-validator/utils/schema-validator');
-const { readYaml } = require('../../../src/cli-validator/utils/read-yaml');
-const getCopyrightString = require('../../../src/cli-validator/utils/get-copyright-string');
+  getCopyrightString,
+  readYaml,
+  validateSchema,
+} = require('../../../src/cli-validator/utils');
 
 describe('cli tool - test option handling', function () {
   let consoleSpy;
@@ -197,7 +198,7 @@ describe('cli tool - test option handling', function () {
       const outputSchemaPath =
         __dirname + '/../../../src/schemas/results-object.yaml';
       const outputSchema = await readYaml(outputSchemaPath);
-      const results = validate(outputObject, outputSchema);
+      const results = validateSchema(outputObject, outputSchema);
       expect(results).toHaveLength(0);
     }
   );

--- a/packages/validator/test/cli-validator/tests/utils/read-yaml.test.js
+++ b/packages/validator/test/cli-validator/tests/utils/read-yaml.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const { readYaml } = require('../../../../src/cli-validator/utils/read-yaml');
+const { readYaml } = require('../../../../src/cli-validator/utils');
 
 describe('Read YAML tests', function () {
   it('should read a yaml file and return an object representing the contents', async () => {

--- a/packages/validator/test/cli-validator/tests/utils/schema-validator.test.js
+++ b/packages/validator/test/cli-validator/tests/utils/schema-validator.test.js
@@ -4,11 +4,9 @@
  */
 
 const {
-  validate,
-} = require('../../../../src/cli-validator/utils/schema-validator');
-const {
   getConfigFileSchema,
-} = require('../../../../src/cli-validator/utils/configuration-manager');
+  validateSchema,
+} = require('../../../../src/cli-validator/utils');
 
 describe('Schema validator tests', function () {
   let configFileSchema;
@@ -30,14 +28,14 @@ describe('Schema validator tests', function () {
       foo: 'bar',
     };
 
-    const results = validate(fooObj, schema);
+    const results = validateSchema(fooObj, schema);
     expect(results).toHaveLength(0);
   });
 
   it('empty config object should validate clean', function () {
     const configObj = {};
 
-    const results = validate(configObj, configFileSchema);
+    const results = validateSchema(configObj, configFileSchema);
     expect(results).toHaveLength(0);
   });
 
@@ -52,7 +50,7 @@ describe('Schema validator tests', function () {
       ignoreFiles: ['file1'],
     };
 
-    const results = validate(configObj, configFileSchema);
+    const results = validateSchema(configObj, configFileSchema);
     expect(results).toHaveLength(0);
   });
 
@@ -70,7 +68,7 @@ describe('Schema validator tests', function () {
       foo: 38,
     };
 
-    const results = validate(fooObj, schema);
+    const results = validateSchema(fooObj, schema);
     expect(results).toHaveLength(1);
   });
 
@@ -85,7 +83,7 @@ describe('Schema validator tests', function () {
       ignoreFiles: ['file1'],
     };
 
-    const results = validate(configObj, configFileSchema);
+    const results = validateSchema(configObj, configFileSchema);
     expect(results).toHaveLength(1);
     expect(results[0]).toBe(
       `schema validation error: must NOT have additional properties`


### PR DESCRIPTION
This is a small, mostly superficial change I've been wanting to make for a while, so I took some time to do it while things are slow 🙂 

To better organize the private utility functions for the CLI validator, this commit wraps their exposure within a single object exported from an index.js file. This simplifies the import syntax in our other files.