### PR TITLE
feat(new-rule): ibm-well-defined-dictionaries

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -106,6 +106,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-unevaluated-properties](#ibm-unevaluated-properties)
   * [ibm-unique-parameter-request-property-names](#ibm-unique-parameter-request-property-names)
   * [ibm-valid-path-segments](#ibm-valid-path-segments)
+  * [ibm-well-defined-dictionaries](#ibm-well-defined-dictionaries)
 
 <!-- tocstop -->
 
@@ -608,6 +609,12 @@ specific "allow-listed" keywords.</td>
 <td><a href="#ibm-valid-path-segments">ibm-valid-path-segments</a></td>
 <td>error</td>
 <td>Checks each path string in the API to make sure path parameter references are valid within path segments.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-well-defined-dictionaries">ibm-well-defined-dictionaries</a></td>
+<td>warning</td>
+<td>Dictionaries must be well defined and all values must share a single type.</td>
 <td>oas3</td>
 </tr>
 </table>
@@ -6586,6 +6593,71 @@ paths:
   get:
     operationId: get_foo
     ...
+</pre>
+</td>
+</tr>
+</table>
+
+### ibm-well-defined-dictionaries
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-well-defined-dictionaries</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>
+  This rule validates that any dictionary schemas are well defined and that all values share a single type.
+  Dictionaries are defined as object type schemas that have variable key names. They are distinct from model types,
+  which are objects with pre-defined properties. A schema must not define both concrete properties and variable key names.
+  Practically, this means a schema must explicitly define a `properties` object or an `additionalProperties` schema, but not both.
+  If used, the `additionalProperties` schema must define a concrete type. See the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types">IBM Cloud API Handbook documentation on types</a> for more info.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warning</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    AmbiguousDictionary:
+      type: object
+      additionalProperties: true # No type description of the values in the dictionary
+    ProblematicHybird:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties: # If the schema is a model, all property names/types should be explicit
+        type: integer
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+  components:
+    schemas:
+      DefinedDictionary:
+        type: object
+        additionalProperties:
+          type: string # Map of string to type string
+          minLength: 1
+          maxLength: 42
+      DefinedModel:
+        type: object
+        properties:
+          name:
+            type: string
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -68,4 +68,5 @@ module.exports = {
   uniqueParameterRequestPropertyNames: require('./unique-parameter-request-property-names'),
   unusedTags: require('./unused-tags'),
   validatePathSegments: require('./valid-path-segments'),
+  wellDefinedDictionaries: require('./well-defined-dictionaries'),
 };

--- a/packages/ruleset/src/functions/well-defined-dictionaries.js
+++ b/packages/ruleset/src/functions/well-defined-dictionaries.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  isObject,
+  isObjectSchema,
+  schemaHasConstraint,
+  validateNestedSchemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+
+  return validateNestedSchemas(schema, context.path, wellDefinedDictionaries);
+};
+
+function wellDefinedDictionaries(schema, path) {
+  // We only care about object schemas.
+  if (!isObject(schema) || !isObjectSchema(schema)) {
+    return [];
+  }
+
+  logger.debug(
+    `${ruleId}: checking object schema at location: ${path.join('.')}`
+  );
+
+  // Dictionaries should have additionalProperties defined on them.
+  // If the schema doesn't, make sure it has properties and then
+  // abandon the check.
+  if (!schemaDefinesField(schema, 'additionalProperties')) {
+    if (!schemaDefinesField(schema, 'properties')) {
+      return [
+        {
+          message:
+            'Object schemas must define either properties, or additionalProperties with a concrete type',
+          path,
+        },
+      ];
+    }
+
+    logger.debug(
+      `${ruleId}: object schema at location ${path.join(
+        '.'
+      )} is a model, no need to check`
+    );
+
+    return [];
+  }
+
+  const errors = [];
+
+  // An object cannot try to be a model and a dictionary at the same time.
+  // It can't have both properties and additionalProperties.
+  if (schemaDefinesField(schema, 'properties')) {
+    errors.push({
+      message:
+        'Object schemas must be either a model or a dictionary - they cannot be both',
+      path,
+    });
+  }
+
+  // Make sure the dictionary has a defined type. We may want to make this check
+  // more strict in the future but this meets our current purposes.
+  if (schemaHasConstraint(schema, isAmbiguousDictionary)) {
+    errors.push({
+      message:
+        'Dictionary schemas must have a single, well-defined value type in `additionalProperties`',
+      path,
+    });
+  }
+
+  return errors;
+}
+
+function schemaDefinesField(schema, field) {
+  return schemaHasConstraint(schema, s => !!s[field]);
+}
+
+function isAmbiguousDictionary(schema) {
+  if (!schema.additionalProperties) {
+    return false;
+  }
+
+  return (
+    !isObject(schema.additionalProperties) || !schema.additionalProperties.type
+  );
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -184,5 +184,6 @@ module.exports = {
     'ibm-unique-parameter-request-property-names':
       ibmRules.uniqueParameterRequestPropertyNames,
     'ibm-valid-path-segments': ibmRules.validPathSegments,
+    'ibm-well-defined-dictionaries': ibmRules.wellDefinedDictionaries,
   },
 };

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -82,4 +82,5 @@ module.exports = {
   unusedTags: require('./unused-tags'),
   uniqueParameterRequestPropertyNames: require('./unique-parameter-request-property-names'),
   validPathSegments: require('./valid-path-segments'),
+  wellDefinedDictionaries: require('./well-defined-dictionaries'),
 };

--- a/packages/ruleset/src/rules/well-defined-dictionaries.js
+++ b/packages/ruleset/src/rules/well-defined-dictionaries.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+const { oas3 } = require('@stoplight/spectral-formats');
+const { wellDefinedDictionaries } = require('../functions');
+
+module.exports = {
+  description:
+    'Dictionaries must be well defined and all values must share a single type.',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  then: {
+    function: wellDefinedDictionaries,
+  },
+};

--- a/packages/ruleset/test/well-defined-dictionaries.test.js
+++ b/packages/ruleset/test/well-defined-dictionaries.test.js
@@ -1,0 +1,246 @@
+/**
+ * Copyright 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { wellDefinedDictionaries } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = wellDefinedDictionaries;
+const ruleId = 'ibm-valid-path-segments';
+const expectedSeverity = severityCodes.warning;
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    // The spec includes scalar values and models,
+    // neither of which should trigger warnings with this rule.
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Includes a well-defined dictionary with scalar values', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        description: 'a dictionary mapping keys to string values',
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Includes a dictionary that nests a well-defined dictionary with scalar values', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        description: 'a dictionary mapping keys to string values',
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          additionalProperties: {
+            type: 'string',
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Includes a well-defined composed dictionary schema with scalar values', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        oneOf: [
+          {
+            description: 'a dictionary mapping keys to string values',
+            type: 'object',
+            additionalProperties: {
+              type: 'string',
+              maxLength: 24,
+            },
+          },
+          {
+            description: 'a dictionary mapping keys to string values',
+            type: 'object',
+            additionalProperties: {
+              type: 'string',
+              maxLength: 42,
+            },
+          },
+        ],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    const expectedPaths = [
+      'paths./v1/movies.post.responses.201.content.application/json.schema.properties.metadata',
+      'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.properties.metadata',
+      'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.properties.metadata',
+      'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.properties.metadata',
+    ];
+
+    it('Includes an object with nothing defined', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        description: 'an object with no definition',
+        type: 'object',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(
+          'Object schemas must define either properties, or additionalProperties with a concrete type'
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('Includes a model/dictionary hybrid, which is not allowed', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        description: 'a dictionary with no definition',
+        type: 'object',
+        properties: {
+          rating: {
+            type: 'integer',
+          },
+        },
+        additionalProperties: {
+          type: 'string',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(
+          'Object schemas must be either a model or a dictionary - they cannot be both'
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('Includes a dictionary with additionalProperties set to "true"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        description: 'a dictionary with no definition',
+        type: 'object',
+        additionalProperties: true,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(
+          'Dictionary schemas must have a single, well-defined value type in `additionalProperties`'
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('Includes a dictionary with additionalProperties set to an empty object', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        description: 'a dictionary with no definition',
+        type: 'object',
+        additionalProperties: {},
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(
+          'Dictionary schemas must have a single, well-defined value type in `additionalProperties`'
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('Includes a nested dictionary with additionalProperties set to "true"', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        description: 'a dictionary with no definition',
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      const expectedRulePaths = [
+        'paths./v1/movies.post.responses.201.content.application/json.schema.properties.metadata.additionalProperties',
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.properties.metadata.additionalProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.properties.metadata.additionalProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.properties.metadata.additionalProperties',
+      ];
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(
+          'Dictionary schemas must have a single, well-defined value type in `additionalProperties`'
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedRulePaths[i]);
+      }
+    });
+
+    it('Includes a composed dictionary schema with additionalProperties set to true', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.metadata = {
+        allOf: [
+          {
+            type: 'object',
+            additionalProperties: true,
+          },
+          {
+            description: 'a dictionary with no definition',
+          },
+        ],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toMatch(
+          'Dictionary schemas must have a single, well-defined value type in `additionalProperties`'
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

Adds a rule to ensure that dictionary types are well defined, meaning:
- All values in the dictionary must conform to a single type
- Schemas are not hybrid model-dictionaries (defining both properties and additional properties)

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
