### PR TITLE
fix(ibm-resource-response-consistency): expand support to bulk operations

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -5233,7 +5233,7 @@ paths:
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>
-<td>Synchronous responses for create-style POST or update (PUT/PATCH) operations on a given resource should return the canonical schema for the resource. As in, the same schema as the "GET" request for the same resource.</td>
+<td>Synchronous responses for create-style POST or update (PUT/PATCH) operations on a given resource instance should return the canonical schema for the resource, which is the schema returned in the GET operation on the single-instance path (e.g. `/resources/{id}`). Synchronous responses for bulk replace (PUT) operations should return the collection schema, which is the schema returned in the GET operation on the collection path (e.g. `/resources`).</td>
 </tr>
 <tr>
 <td><b>Severity:</b></td>


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

This commit adds support for recognizing bulk operations and recommending the collection schema be returned instead of the canonical schema. It also:
- Updates the message to be more clear
- Updates the path to be more aligned with the operation
- Adds an "info" log pointing to the specific operation in case it is unclear

Previously, the rule would flag a bulk operation that didn't return the collection schema but it did so unintentionally (and with a bad heuristic) and the message would indicate that the canonical schema should be returned, which was false (often, the canonical schema *was* being returned).

Also, the warning would be tied to a specific schema and it was difficult to parse the debug logs to determine which operation was responsible for the warning.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] .secrets.baseline updated as needed?
