### PR TITLE
fix(resource-response-consistency): avoid destructuring property of undefined values

### DIFF
--- a/packages/ruleset/src/functions/resource-response-consistency.js
+++ b/packages/ruleset/src/functions/resource-response-consistency.js
@@ -222,7 +222,7 @@ function getCanonicalSchema(path, apidef, pathToReferencesMap) {
     logger.debug(
       `${ruleId}: resource-specific path "${resourceSpecificPath}" does not exist`
     );
-    return;
+    return {};
   }
 
   return getSchemaInfo(resourceSpecificPath, apidef, pathToReferencesMap);

--- a/packages/validator/src/cli-validator/utils/get-copyright-string.js
+++ b/packages/validator/src/cli-validator/utils/get-copyright-string.js
@@ -6,5 +6,5 @@
 const getVersionString = require('./get-version-string');
 
 module.exports = function () {
-  return `IBM OpenAPI Validator (${getVersionString()}), @Copyright IBM Corporation 2017, 2023.`;
+  return `IBM OpenAPI Validator (${getVersionString()}), @Copyright IBM Corporation 2017, 2024.`;
 };


### PR DESCRIPTION
Addresses a bug reported in which a property is attempted to be deconstructed from an object type. When the `getCanonicalSchema` function was converted to return an object, a return statement was left unconverted and was still returning undefined. This caused the bug upon attempted deconstruction of the return value.

Also, I updated the project copyright string for the new year.