### PR TITLE
fix: adjust header parameter casing convention check

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -4047,8 +4047,8 @@ n/a
 <tr>
 <td valign=top><b>Description:</b></td>
 <td>This rule verifies that each parameter name complies with the casing convention associated with that parameter's type.
-For example, the default casing convention for query parameters is snake-case (e.g. `my-query-param`), the default for path parameters
-is snake-case (e.g. `my_path_param`), and the default casing convention for header params is kebab-separated pascal-case with provision for capitalized abbreviations (e.g. `IBM-CustomHeader-Name`).
+For example, the default casing convention for query parameters is snake-case (e.g. <code>my_query_param</code>), the default for path parameters
+is snake-case (e.g. <code>my_path_param</code>), and the default casing convention for header params is kebab-separated pascal-case with provision for capitalized abbreviations (e.g. <code>IBM-CustomHeader-Name</code>).
 These default casing conventions constitute the default configuration for the rule, although the rule's configuration can be modified to
 fit your needs (see below).
 </td>

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -4048,7 +4048,7 @@ n/a
 <td valign=top><b>Description:</b></td>
 <td>This rule verifies that each parameter name complies with the casing convention associated with that parameter's type.
 For example, the default casing convention for query parameters is snake-case (e.g. `my-query-param`), the default for path parameters
-is snake-case (e.g. `my_path_param`), and the default casing convention for header params is pascal-case (e.g. `X-My-Custom-Header`).
+is snake-case (e.g. `my_path_param`), and the default casing convention for header params is kebab-separated pascal-case with provision for capitalized abbreviations (e.g. `IBM-CustomHeader-Name`).
 These default casing conventions constitute the default configuration for the rule, although the rule's configuration can be modified to
 fit your needs (see below).
 </td>
@@ -4067,9 +4067,11 @@ fit your needs (see below).
 To configure the rule, set the <code>functionOptions</code> field within the rule definition to be an object
 with keys that represent the different parameter types to be checked for proper case conventions
 ('query', 'path', and 'header').  The value associated with each entry should be an object that is the
-appropriate configuration to be used by Spectral's <code>casing()</code> function
+appropriate configuration to be used by either Spectral's <code>casing()</code> function
 [<a href="https://meta.stoplight.io/docs/spectral/ZG9jOjExNg-core-functions#casing">1</a>]
-to enforce the desired case convention for that parameter type.
+or <code>pattern()</code> function [<a href="https://meta.stoplight.io/docs/spectral/ZG9jOjExNg-core-functions#pattern">2</a>]
+(for greater control over the case convention check) to enforce the desired case convention for that parameter type.
+Additionally, you can define custom messages in the form "{parameter-type}Message".
 <p>The default configuration object provided in the rule definition is:
 <pre>
 {
@@ -4082,12 +4084,12 @@ to enforce the desired case convention for that parameter type.
   path: {
     type: 'snake'
   },
+  // Spectral casing convention types aren't robust enough to handle
+  // the complexity of headers, so we define our own kebab/pascal case regex.
   header: {
-    type: 'pascal',
-    separator: {
-      char: '-'
-    }
-  }
+    match: '/^[A-Z]+[a-z0-9]*-*([A-Z]+[a-z0-9]*-*)*$/',
+  },
+  headerMessage: 'Header parameter names must be kebab-separated pascal case',
 }
 </pre>
 This enforces:

--- a/packages/ruleset/src/rules/parameter-casing-convention.js
+++ b/packages/ruleset/src/rules/parameter-casing-convention.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -22,9 +22,9 @@ module.exports = {
     // The configuration of this rule should be an object
     // with keys that represent the different parameter types
     // to be checked for property casing conventions: 'query', 'path', and 'header'.
-    // The value of each key should be an object that is the appropriate
-    // configuration needed by Spectral's casing() function to enforce the desired
-    // case convention for parameters of that type.
+    // The value of each key should be an object that is either the appropriate
+    // configuration needed by Spectral's casing() function OR pattern() function
+    // to enforce the desired case convention for parameters of that type.
     // To disable case convention checks for a particular parameter type,
     // simply remove that entry from the config object.
     functionOptions: {
@@ -42,13 +42,16 @@ module.exports = {
         type: 'snake',
       },
 
-      // Allow header parameter names to be in canonical header name form (e.g. X-My-Header).
+      // Spectral casing convention types aren't robust enough to handle
+      // the complexity of headers, so we define our own kebab/pascal case regex.
       header: {
-        type: 'pascal',
-        separator: {
-          char: '-',
-        },
+        match: '/^[A-Z]+[a-z0-9]*-*([A-Z]+[a-z0-9]*-*)*$/',
       },
+
+      // Define an alternate message for the header pattern validation
+      // to avoid using the default Spectral message.
+      headerMessage:
+        'Header parameter names must be kebab-separated pascal case',
     },
   },
 };

--- a/packages/utilities/src/collections/index.js
+++ b/packages/utilities/src/collections/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -17,8 +17,8 @@ const requestBodySchemas = [`${operations[0]}[requestBody].content[*].schema`];
 
 // A collection of locations where a JSON Schema object can be *used*.
 // Note that this does not include "components.schemas" to avoid duplication.
-// this collection should be used in a rule that has "resolved" set to "true".
-// we separately validate that all schemas in "components" need to be used.
+// This collection should be used in a rule that has "resolved" set to "true".
+// We separately validate that all schemas in "components" need to be used.
 const schemas = [
   `$.paths[*][parameters][*].schema`,
   `$.paths[*][parameters][*].content[*].schema`,


### PR DESCRIPTION
This allows us to support standard header patterns that would previously be flagged by the validator. The `casing` function options provided by Spectral are not sophsiticated enough to support the complexity of header parameter conventions (which use kebab-separated pascal case with capitalized abbreviations).

The new regular expression is a little more relaxed than the old convention but it also more accurate.

I made this change in a configuration-compatible way by expanding the config support to accept function arguments for either the casing or pattern built-in Spectral functions. This is slightly hacky but gives both us and users more control without changing any existing behavior. We might want to make this change for our other casing convention checks but for now, this is sufficient to solve our issues. The way we support configuration of Spectral functions is complicated, especially when we decide we don't want to use those functions 🙂 

I'm also happy to make this a "hidden feature" and take it out of the document and just use it as a convenience pattern for us to control casing through regular expressions without changing our configuration API.