### PR TITLE
fix(build): build binaries after npm package has been published

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -10,7 +10,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "npm run pkg"
+        "publishCmd": "npm run pkg"
       }
     ],
     [

--- a/packages/ruleset/src/functions/check-major-version.js
+++ b/packages/ruleset/src/functions/check-major-version.js
@@ -22,6 +22,7 @@ module.exports = function (apiDef, _opts, context) {
 // - Each path has a path segment of the form v followed by a number, and the number is
 //   the same for all paths
 function checkMajorVersion(apiDef) {
+  logger.debug(`${ruleId}: entered function checkMajorVersion().`);
   if (apiDef === null || typeof apiDef !== 'object') {
     return [];
   }

--- a/packages/validator/.releaserc
+++ b/packages/validator/.releaserc
@@ -8,7 +8,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "npm run pkg"
+        "publishCmd": "npm run pkg"
       }
     ],
     [


### PR DESCRIPTION
This commit modifies the semantic-release configuration (.releaserc) slightly to make sure we build the executables after we have published the validator package.
The intent is to make sure that the executables are built with the correct version of the ruleset and ruleset-utilities packages.

Edit: I made a small change to the ibm-major-version-in-path rule's function to add a debug message simply to have an easy way to verify that the latest version of the ruleset is being packaged with the executable that is produced.   I can remove this change while working on the next validator issue.