### PR TITLE
fix(ibm-major-version-in-path): remove extraneous debug message

### DIFF
--- a/packages/ruleset/src/functions/check-major-version.js
+++ b/packages/ruleset/src/functions/check-major-version.js
@@ -22,7 +22,6 @@ module.exports = function (apiDef, _opts, context) {
 // - Each path has a path segment of the form v followed by a number, and the number is
 //   the same for all paths
 function checkMajorVersion(apiDef) {
-  logger.debug(`${ruleId}: entered function checkMajorVersion().`);
   if (apiDef === null || typeof apiDef !== 'object') {
     return [];
   }


### PR DESCRIPTION
This PR removes a debug message that was recently added to the check-major-version.js file in order to verify that the executables are being built correctly.
Removing this debug message will trigger a new version of the ruleset dependency and will allow us to verify that things are working correctly with the new fix that we have in place for the "pkg" problem.