### PR TITLE
fix(ibm-response-status-codes): allow PUT w/204 if a GET w/204 exists

### DIFF
--- a/packages/ruleset/src/functions/request-and-response-content.js
+++ b/packages/ruleset/src/functions/request-and-response-content.js
@@ -75,7 +75,7 @@ function checkForContent(operation, path, apidef) {
       if (
         path.at(-1) === 'put' &&
         statusCode === '201' &&
-        pathHasMinimallyRepresentedResource(path.at(-2), apidef, logger, ruleId)
+        pathHasMinimallyRepresentedResource(path.at(-2), apidef)
       ) {
         continue;
       }

--- a/packages/ruleset/src/functions/response-status-codes.js
+++ b/packages/ruleset/src/functions/response-status-codes.js
@@ -125,10 +125,18 @@ function responseStatusCodes(operation, path, apidef) {
       }
     }
 
-    // 7. A "PUT" operation must return either a 200, 201, or 202
+    // 7. A "PUT" operation must return either a 200, 201, or 202.
+    // Exception: we'll also allow a 204 status code if there's a corresponding GET
+    // operation that also returns a 204.
     // Note: we've already checked for lack of any success codes - no need to double-report that.
     if (isOperationOfType('put', path) && successCodes.length) {
-      if (!['200', '201', '202'].find(code => successCodes.includes(code))) {
+      if (
+        !['200', '201', '202'].find(code => successCodes.includes(code)) &&
+        !(
+          successCodes.includes('204') &&
+          pathHasMinimallyRepresentedResource(path.at(-2), apidef)
+        )
+      ) {
         errors.push({
           message: `PUT operations should return a 200, 201, or 202 status code`,
           path: [...path, 'responses'],
@@ -185,10 +193,5 @@ function hasBodyRepresentation(path, apidef) {
     return;
   }
 
-  return !pathHasMinimallyRepresentedResource(
-    resourceSpecificPath,
-    apidef,
-    logger,
-    ruleId
-  );
+  return !pathHasMinimallyRepresentedResource(resourceSpecificPath, apidef);
 }


### PR DESCRIPTION
## PR summary
This commit modifies the ibm-response-status-codes rule so that a PUT that returns a 204 status code will be allowed if there is a corresponding GET operation on the same path that also returns a 204.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
