### PR TITLE
Modify tests to work with Node v20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: node_js
 node_js:
 - 16
 - 18
+- 20
 
 cache:
   npm: false
@@ -22,5 +23,5 @@ deploy:
   skip_cleanup: true
   script: npx -p @qiwi/semrel-toolkit multi-semrel --deps.release inherit
   on:
-    node: 18
+    node: 20
     branch: main

--- a/packages/validator/test/cli-validator/tests/configuration-manager.test.js
+++ b/packages/validator/test/cli-validator/tests/configuration-manager.test.js
@@ -134,7 +134,7 @@ describe('Configuration Manager tests', function () {
       // originalError(`Captured text: ${JSON.stringify(capturedText, null, 2)}`);
       expect(capturedText).toHaveLength(2);
       expect(capturedText[0]).toMatch(
-        /Unable to load config file.*SyntaxError: Unexpected token/
+        /\[ERROR\] Unable to load config file.*SyntaxError:/
       );
       expect(capturedText[1]).toMatch(
         /The validator will use a default config/

--- a/packages/validator/test/cli-validator/tests/error-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/error-handling.test.js
@@ -107,8 +107,8 @@ describe('cli tool - test error handling', function () {
     expect(capturedText[3].trim()).toEqual(
       '[ERROR] Invalid input file: ./test/cli-validator/mock-files/bad-json.json. See below for details.'
     );
-    expect(capturedText[4].trim()).toEqual(
-      '[ERROR] SyntaxError: Unexpected token ; in JSON at position 14'
+    expect(capturedText[4].trim()).toMatch(
+      /^\[ERROR\] SyntaxError:.*in JSON at position 14$/
     );
   });
 
@@ -174,8 +174,8 @@ describe('cli tool - test error handling', function () {
     expect(capturedText.length).toEqual(5);
 
     expect(capturedText[3].trim()).toContain('[ERROR] Invalid input file');
-    expect(capturedText[4].trim()).toEqual(
-      '[ERROR] SyntaxError: Unexpected token ] in JSON at position 634'
+    expect(capturedText[4].trim()).toContain(
+      '[ERROR] SyntaxError: Unexpected token'
     );
   });
 


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

Version 20 of Node changes the behavior of error messages. Where the
tests relied on equality with specific error messages, they have been
updated to match against slightly more generic regular expressions to
support running the tests.

Also, v20 is added to the Travis builds as it is the current LTS version.

Resolves #662 