### PR TITLE
feat(ibm-no-superfluous-allof): add new rule and documentation

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -357,6 +357,12 @@ should probably be required instead of optional.</td>
 <td>oas3</td>
 </tr>
 <tr>
+<td><a href="#ibm-no-superfluous-allof">ibm-no-superfluous-allof</a></td>
+<td>warn</td>
+<td>Warns about schemas that contain only a single-element <code>allOf</code>, which are unnecessary./td>
+<td>oas3</td>
+</tr>
+<tr>
 <td><a href="#ibm-no-unsupported-keywords">ibm-no-unsupported-keywords</a></td>
 <td>error</td>
 <td>Checks for the use of unsupported keywords within an OpenAPI 3.1.x document.</td>
@@ -3590,6 +3596,54 @@ paths:
                   thing_type: type1
       responses:
         ...
+</pre>
+</td>
+</tr>
+</table>
+
+
+### ibm-no-superfluous-allof
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-no-superfluous-allof</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>If a schema contains only a single-element <code>allOf</code>, the <code>allOf</code> can be considered superfluous and can be removed. This rule checks for these unnecessary <code>allOf</code> attributes.</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warn</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      properties:
+        foo_ref:
+          allOf:
+            - $ref: '#/components/schemas/Foo'
+<</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Thing:
+      properties:
+        foo_ref:
+          $ref: '#/components/schemas/Foo'
 </pre>
 </td>
 </tr>

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -27,6 +27,7 @@ module.exports = {
   noAmbiguousPaths: require('./no-ambiguous-paths'),
   noNullableProperties: require('./no-nullable-properties'),
   noOperationRequestBody: require('./no-operation-requestbody'),
+  noSuperfluousAllOf: require('./no-superfluous-allof'),
   noUnsupportedKeywords: require('./no-unsupported-keywords'),
   operationIdCasingConvention: require('./operationid-casing-convention'),
   operationIdNamingConvention: require('./operationid-naming-convention'),

--- a/packages/ruleset/src/functions/no-superfluous-allof.js
+++ b/packages/ruleset/src/functions/no-superfluous-allof.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 - 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { validateSubschemas } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+
+  return validateSubschemas(schema, context.path, checkForSuperfluousAllOf);
+};
+
+function checkForSuperfluousAllOf(schema, path) {
+  // We're interested only in schemas that contain ONLY a single-element allOf list.
+  if (
+    Array.isArray(schema.allOf) &&
+    schema.allOf.length === 1 &&
+    Object.keys(schema).length === 1
+  ) {
+    return [
+      {
+        // Use rule description for error message.
+        message: '',
+        path,
+      },
+    ];
+  }
+
+  return [];
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -140,6 +140,7 @@ module.exports = {
     'ibm-no-operation-requestbody': ibmRules.noOperationRequestBody,
     'ibm-no-optional-properties-in-required-body': ibmRules.optionalRequestBody,
     'ibm-no-space-in-example-name': ibmRules.examplesNameContainsSpace,
+    'ibm-no-superfluous-allof': ibmRules.noSuperfluousAllOf,
     'ibm-no-unsupported-keywords': ibmRules.noUnsupportedKeywords,
     'ibm-openapi-tags-used': ibmRules.unusedTags,
     'ibm-operation-responses': ibmRules.operationResponses,

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -35,6 +35,7 @@ module.exports = {
   noAmbiguousPaths: require('./no-ambiguous-paths'),
   noNullableProperties: require('./no-nullable-properties'),
   noOperationRequestBody: require('./no-operation-requestbody'),
+  noSuperfluousAllOf: require('./no-superfluous-allof'),
   noUnsupportedKeywords: require('./no-unsupported-keywords'),
   operationIdCasingConvention: require('./operationid-casing-convention'),
   operationIdNamingConvention: require('./operationid-naming-convention'),

--- a/packages/ruleset/src/rules/no-superfluous-allof.js
+++ b/packages/ruleset/src/rules/no-superfluous-allof.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2017 - 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+const { oas3 } = require('@stoplight/spectral-formats');
+const { noSuperfluousAllOf } = require('../functions');
+
+module.exports = {
+  description: 'Avoid schemas containing only a single-element allOf',
+  given: schemas,
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  then: {
+    function: noSuperfluousAllOf,
+  },
+};

--- a/packages/ruleset/test/no-superfluous-allof.test.js
+++ b/packages/ruleset/test/no-superfluous-allof.test.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2017 - 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { noSuperfluousAllOf } = require('../src/rules');
+const { makeCopy, rootDocument, testRule, severityCodes } = require('./utils');
+
+const rule = noSuperfluousAllOf;
+const ruleId = 'ibm-no-superfluous-allof';
+const expectedSeverity = severityCodes.warning;
+const expectedMsg = 'Avoid schemas containing only a single-element allOf';
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('allOf along with other attributes', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Drink = {
+        description: 'description',
+        allOf: [
+          {
+            $ref: '#/components/schemas/Juice',
+          },
+        ],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+    it('allOf with 2 or more elements', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Drink = {
+        description: 'description',
+        allOf: [
+          {
+            $ref: '#/components/schemas/Juice',
+          },
+          {
+            $ref: '#/components/schemas/Soda',
+          },
+        ],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    it('Single-element allOf with no other attributes', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Drink = {
+        allOf: [
+          {
+            $ref: '#/components/schemas/Juice',
+          },
+        ],
+      };
+
+      const expectedPaths = [
+        'paths./v1/drinks.post.responses.201.content.application/json.schema',
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks.items',
+        'paths./v1/drinks/{drink_id}.get.responses.200.content.application/json.schema',
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+
+      expect(results).toHaveLength(3);
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('Superfluous allOf in nested oneOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Juice = {
+        oneOf: [
+          {
+            allOf: [
+              {
+                $ref: '#/components/schemas/NormalString',
+              },
+            ],
+          },
+        ],
+      };
+
+      const expectedPaths = [
+        'paths./v1/drinks.post.requestBody.content.application/json.schema.oneOf.0.oneOf.0',
+        'paths./v1/drinks.post.responses.201.content.application/json.schema.oneOf.0.oneOf.0',
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.properties.drinks.items.oneOf.0.oneOf.0',
+        'paths./v1/drinks/{drink_id}.get.responses.200.content.application/json.schema.oneOf.0.oneOf.0',
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
This commit adds the new "ibm-no-superfluous-allof" rule which warns about the use of a superfluous allOf, which is a schema that contains only a single-element allOf.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
