### PR TITLE
fix(*-attributes): fill gaps in (array|property|string)-attributes rules

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-05-20T16:10:39Z",
+  "generated_at": "2024-06-21T19:45:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -106,7 +106,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.56.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -939,7 +939,7 @@ paths:
 </tr>
 <tr>
 <td valign=top><b>Description:</b></td>
-<td>Array schemas must define the <code>items</code> field, and should define the <code>minItems</code> and <code>maxItems</code> fields.
+<td>Array schemas must define the <code>items</code> field, and should define the <code>minItems</code> and <code>maxItems</code> fields. Non-arrays must not define array keywords.
 [<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#array">1</a>].</td>
 </tr>
 <tr>
@@ -4911,6 +4911,9 @@ paths:
 <li><code>minimum</code> must not be greater than <code>maximum</code>.</li>
 <li><code>minimum</code> must not be defined for a schema type other than <code>integer</code> or <code>number</code>.</li>
 <li><code>maximum</code> must not be defined for a schema type other than <code>integer</code> or <code>number</code>.</li>
+<li><code>multipleOf</code> must not be defined for a schema type other than <code>integer</code> or <code>number</code>.</li>
+<li><code>exclusiveMaximum</code> must not be defined for a schema type other than <code>integer</code> or <code>number</code>.</li>
+<li><code>exclusiveMinimum</code> must not be defined for a schema type other than <code>integer</code> or <code>number</code>.</li>
 </ul>
 </dd>
 <dt>Object schemas (type=object):</dt>
@@ -4919,6 +4922,9 @@ paths:
 <li><code>minProperties</code> must not be greater than <code>maxProperties</code>.</li>
 <li><code>minProperties</code> must not be defined for a schema type other than <code>object</code>.</li>
 <li><code>maxProperties</code> must not be defined for a schema type other than <code>object</code>.</li>
+<li><code>additionalProperties</code> must not be defined for a schema type other than <code>object</code>.</li>
+<li><code>properties</code> must not be defined for a schema type other than <code>object</code>.</li>
+<li><code>required</code> must not be defined for a schema type other than <code>object</code>.</li>
 </ul>
 </dd>
 </dl>

--- a/packages/ruleset/src/functions/array-attributes.js
+++ b/packages/ruleset/src/functions/array-attributes.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -64,6 +64,16 @@ function arrayAttributeErrors(schema, path) {
       });
     }
 
+    // Is enum defined? Shouldn't be
+    const enm = getCompositeSchemaAttribute(schema, 'enum');
+    if (isDefined(enm)) {
+      logger.debug('enum field is present!');
+      errors.push({
+        message: `Array schemas should not define an 'enum' field`,
+        path: [...path, 'enum'],
+      });
+    }
+
     // Is items defined?
     const items = getCompositeSchemaAttribute(schema, 'items');
     if (!isDefined(items) || !isPlainObject(items)) {
@@ -76,7 +86,7 @@ function arrayAttributeErrors(schema, path) {
       ];
     }
   } else {
-    // minItems/maxItems should not be defined for a non-array schema
+    // minItems/maxItems/items should not be defined for a non-array schema
     if (schema.minItems) {
       errors.push({
         message: `'minItems' should not be defined for a non-array schema`,
@@ -87,6 +97,12 @@ function arrayAttributeErrors(schema, path) {
       errors.push({
         message: `'maxItems' should not be defined for a non-array schema`,
         path: [...path, 'maxItems'],
+      });
+    }
+    if (schema.items) {
+      errors.push({
+        message: `'items' should not be defined for a non-array schema`,
+        path: [...path, 'items'],
       });
     }
   }

--- a/packages/ruleset/src/rules/string-attributes.js
+++ b/packages/ruleset/src/rules/string-attributes.js
@@ -1,8 +1,11 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
 const { oas3 } = require('@stoplight/spectral-formats');
 const { stringAttributes } = require('../functions');
 
@@ -12,13 +15,7 @@ module.exports = {
   severity: 'warn',
   formats: [oas3],
   resolved: true,
-  given: [
-    '$.paths[*][parameters][*].schema',
-    '$.paths[*][parameters][*].content[*].schema',
-    '$.paths[*][*][parameters][*].schema',
-    '$.paths[*][*][parameters][*].content[*].schema',
-    '$.paths[*][*].requestBody.content[*].schema',
-  ],
+  given: schemas,
   then: {
     function: stringAttributes,
   },

--- a/packages/ruleset/test/property-attributes.test.js
+++ b/packages/ruleset/test/property-attributes.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -17,7 +17,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
-    describe('Numeric schema tests', () => {
+    // !!! add other expected fields to existing represented schemas
+
+    describe('Numeric schemas', () => {
       it('minimum defined by itself', async () => {
         const testDocument = makeCopy(rootDocument);
 
@@ -54,7 +56,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       });
     });
 
-    describe('Object schema tests', () => {
+    describe('Object schemas', () => {
       it('minProperties defined by itself', async () => {
         const testDocument = makeCopy(rootDocument);
 
@@ -90,17 +92,19 @@ describe(`Spectral rule: ${ruleId}`, () => {
         expect(results).toHaveLength(0);
       });
     });
+
+    // !!! maybe add new tests for other schema types to verify proper behavior
   });
 
   describe('Should yield errors', () => {
-    describe('Numeric schema tests', () => {
+    describe('Numeric schemas', () => {
       it('minimum > maximum', async () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'integer',
           minimum: 4,
-          maximum: 3,
+          maximum: 0,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -119,6 +123,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
           expect(results[i].path.join('.')).toBe(expectedPaths[i]);
         }
       });
+    });
+
+    describe('Non-numeric schemas', () => {
       it('minimum defined for non-numeric schema', async () => {
         const testDocument = makeCopy(rootDocument);
 
@@ -167,16 +174,88 @@ describe(`Spectral rule: ${ruleId}`, () => {
           expect(results[i].path.join('.')).toBe(expectedPaths[i]);
         }
       });
+      it('multipleOf defined for non-numeric schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['wheel_count'] = {
+          type: 'object',
+          multipleOf: 4,
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.multipleOf',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.multipleOf',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.multipleOf',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'multipleOf' should not be defined for non-numeric schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
+      it('exclusiveMaximum defined for non-numeric schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['wheel_count'] = {
+          type: 'object',
+          exclusiveMaximum: 4,
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.exclusiveMaximum',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.exclusiveMaximum',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.exclusiveMaximum',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'exclusiveMaximum' should not be defined for non-numeric schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
+      it('exclusiveMinimum defined for non-numeric schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['wheel_count'] = {
+          type: 'object',
+          exclusiveMinimum: 0,
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.exclusiveMinimum',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.exclusiveMinimum',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.exclusiveMinimum',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'exclusiveMinimum' should not be defined for non-numeric schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
     });
 
-    describe('Object schema tests', () => {
+    describe('Object schemas', () => {
       it('minProperties > maxProperties', async () => {
         const testDocument = makeCopy(rootDocument);
 
         testDocument.components.schemas.Car.properties['wheel_count'] = {
           type: 'object',
           minProperties: 5,
-          maxProperties: 4,
+          maxProperties: 0,
         };
 
         const results = await testRule(ruleId, rule, testDocument);
@@ -195,6 +274,35 @@ describe(`Spectral rule: ${ruleId}`, () => {
           expect(results[i].path.join('.')).toBe(expectedPaths[i]);
         }
       });
+      it('enum defined for object schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['wheel_count'] = {
+          type: 'object',
+          minProperties: 1,
+          maxProperties: 3,
+          enum: [{ foo: 'bar' }, { foo: 'bar', baz: 'bat' }],
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.enum',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.enum',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.enum',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'enum' should not be defined for object schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
+    });
+
+    describe('Non-object schemas', () => {
       it('minProperties defined for non-object schema', async () => {
         const testDocument = makeCopy(rootDocument);
 
@@ -239,6 +347,108 @@ describe(`Spectral rule: ${ruleId}`, () => {
           expect(results[i].code).toBe(ruleId);
           expect(results[i].message).toBe(
             `'maxProperties' should not be defined for non-object schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
+      it('additionalProperties defined for non-object schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['wheel_count'] = {
+          type: 'number',
+          format: 'double',
+          additionalProperties: false,
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.additionalProperties',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.additionalProperties',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.additionalProperties',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'additionalProperties' should not be defined for non-object schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
+      it('properties defined for non-object schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['wheel_count'] = {
+          type: 'number',
+          format: 'double',
+          properties: {},
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.properties',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.properties',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.properties',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'properties' should not be defined for non-object schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
+      it('required defined for non-object schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['wheel_count'] = {
+          type: 'number',
+          format: 'double',
+          required: true,
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.wheel_count.required',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.wheel_count.required',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.wheel_count.required',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'required' should not be defined for non-object schemas`
+          );
+          expect(results[i].severity).toBe(expectedSeverity);
+          expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+        }
+      });
+    });
+
+    describe('Object schemas', () => {
+      it('enum defined for boolean schema', async () => {
+        const testDocument = makeCopy(rootDocument);
+
+        testDocument.components.schemas.Car.properties['has_wheels'] = {
+          type: 'boolean',
+          enum: [true, false],
+        };
+
+        const results = await testRule(ruleId, rule, testDocument);
+        expect(results).toHaveLength(3);
+        const expectedPaths = [
+          'paths./v1/cars.post.responses.201.content.application/json.schema.properties.has_wheels.enum',
+          'paths./v1/cars/{car_id}.get.responses.200.content.application/json.schema.properties.has_wheels.enum',
+          'paths./v1/cars/{car_id}.patch.responses.200.content.application/json.schema.properties.has_wheels.enum',
+        ];
+        for (let i = 0; i < results.length; i++) {
+          expect(results[i].code).toBe(ruleId);
+          expect(results[i].message).toBe(
+            `'enum' should not be defined for boolean schemas`
           );
           expect(results[i].severity).toBe(expectedSeverity);
           expect(results[i].path.join('.')).toBe(expectedPaths[i]);


### PR DESCRIPTION
Issues fixed:
- Not all of the keywords were considered invalid for non-scoped schemas
- min/max comparison didn't take 0 as a falsy value into account
- Only input schemas were considered for keyword checks on non-strings

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
N/A
