### PR TITLE
fix: allow property names to be $ref without crashing

### DIFF
--- a/packages/ruleset/src/functions/circular-refs.js
+++ b/packages/ruleset/src/functions/circular-refs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -56,6 +56,13 @@ const reportedRefValues = new Set();
  * @returns an array containing the violations found or [] if no violations
  */
 function checkForCircularRef($ref, path) {
+  // $ref *may* be the name of a property, etc. so this check makes sure we are
+  // validating a $ref property that points to a string value, which should
+  // nearly always be an actual reference value.
+  if (typeof $ref !== 'string') {
+    return [];
+  }
+
   logger.debug(
     `${ruleId}: found unresolved $ref '${$ref}' at location: ${path.join('.')}`
   );

--- a/packages/ruleset/src/functions/ref-pattern.js
+++ b/packages/ruleset/src/functions/ref-pattern.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -64,6 +64,13 @@ const validRefPrefixes = {
 };
 
 function checkRefPattern($ref, path) {
+  // $ref *may* be the name of a property, etc. so this check makes sure we are
+  // validating a $ref property that points to a string value, which should
+  // nearly always be an actual reference value.
+  if (typeof $ref !== 'string') {
+    return [];
+  }
+
   // We're interested only in local refs (e.g. #/components/schemas/MyModel).
   if (!$ref.startsWith('#')) {
     logger.debug(`${ruleId}: skipping check for external $ref: ${$ref}`);

--- a/packages/ruleset/test/circular-refs.test.js
+++ b/packages/ruleset/test/circular-refs.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -22,6 +22,17 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Property named $ref should not cause problems', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.Car.properties.$ref = {
+        type: 'string',
+        description: 'this property is actually called $ref',
+      };
+
       const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
     });

--- a/packages/ruleset/test/ref-pattern.test.js
+++ b/packages/ruleset/test/ref-pattern.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -28,6 +28,17 @@ const expectedMsgs = {
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
     it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Property named $ref should not cause problems', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.Car.properties.$ref = {
+        type: 'string',
+        description: 'this property is actually called $ref',
+      };
+
       const results = await testRule(ruleId, rule, rootDocument);
       expect(results).toHaveLength(0);
     });


### PR DESCRIPTION
The rules checking for valid ref patterns and for circular references both assumed that any $ref values found in the entire document would be reference values, and therefore strings.

However, it's valid to define the field with the literal name "$ref" in other places - e.g. as a property name. The ref-related rules would crash if it encountered these cases because of the assumption that the values would be strings. This commit adds a simple check to enforce that the rules are, in fact, dealing with a string value.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)