### PR TITLE
feat(ibm-pattern-properties): enforce use of anchors for property patterns

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -4733,6 +4733,7 @@ within a schema:
 <ul>
 <li>The <code>patternProperties</code> field must be an object with exactly one entry.
 <li>The <code>patternProperties</code> and <code>additionalProperties</code> fields are mutually exclusive within a particular schema.
+<li>The <code>patternProperties</code> field must contain a regular expression anchored by <code>^</code> and <code>$</code>.
 </ul>
 </tr>
 <tr>

--- a/packages/ruleset/src/functions/pattern-properties.js
+++ b/packages/ruleset/src/functions/pattern-properties.js
@@ -32,6 +32,7 @@ module.exports = function (schema, _opts, context) {
  * 2. patternProperties must be an object
  * 3. patternProperties must not be empty
  * 4. patternProperties must have at most one entry
+ * 5. patternProperties must anchor its pattern
  *
  * @param {*} schema the schema to check
  * @param {*} path the array of path segments indicating the location of "schema" within the API definition
@@ -91,6 +92,20 @@ function patternPropertiesCheck(schema, path) {
       {
         message: 'patternProperties must be an object with at most one entry',
         path: [...path, 'patternProperties'],
+      },
+    ];
+  }
+
+  // At this point, we're guaranteed to have one pattern in the list.
+  // We need to make sure the regular expression is anchored.
+  if (!keys[0].startsWith('^') || !keys[0].endsWith('$')) {
+    logger.debug(
+      `${ruleId}: Error: patternProperties has a non-anchored pattern!`
+    );
+    return [
+      {
+        message: 'patternProperties patterns should be anchored with ^ and $',
+        path: [...path, 'patternProperties', 0],
       },
     ];
   }

--- a/packages/ruleset/test/pattern-properties.test.js
+++ b/packages/ruleset/test/pattern-properties.test.js
@@ -13,6 +13,7 @@ const expectedMessage1 = `patternProperties and additionalProperties are mutuall
 const expectedMessage2 = `patternProperties must be an object`;
 const expectedMessage3 = `patternProperties must be a non-empty object`;
 const expectedMessage4 = `patternProperties must be an object with at most one entry`;
+const expectedMessage5 = `patternProperties patterns should be anchored with ^ and $`;
 
 describe(`Spectral rule: ${ruleId}`, () => {
   beforeAll(() => {
@@ -140,6 +141,56 @@ describe(`Spectral rule: ${ruleId}`, () => {
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);
         expect(results[i].message).toBe(expectedMessage4);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties entry is missing beginning anchor', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        'str.*$': {
+          type: 'string',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      const expectedPaths = [
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage5);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+
+    it('patternProperties entry is missing ending anchor', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas['Movie'].patternProperties = {
+        '^str.*': {
+          type: 'string',
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      const expectedPaths = [
+        'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.patternProperties',
+        'paths./v1/movies.post.responses.201.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.patternProperties',
+        'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.patternProperties',
+      ];
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMessage5);
         expect(results[i].severity).toBe(expectedSeverity);
         expect(results[i].path.join('.')).toBe(expectedPaths[i]);
       }


### PR DESCRIPTION
This commit adds an additional check to the rule dealing with `pattern-properties`. It requires the use of starting and ending anchors (^ and $, respectively) for the regular expression it defines as its single element, much like we require for the `pattern` field of string schemas.