### PR TITLE
fix(ibm-accept-and-return-models): exempt non-object schemas

### DIFF
--- a/packages/ruleset/test/accept-and-return-models.test.js
+++ b/packages/ruleset/test/accept-and-return-models.test.js
@@ -10,7 +10,7 @@ const rule = acceptAndReturnModels;
 const ruleId = 'ibm-accept-and-return-models';
 const expectedSeverity = severityCodes.error;
 const expectedMessage =
-  'Request and response bodies must include fields defined in `properties`';
+  'Request and response bodies must be models - their schemas must define `properties`';
 
 // To enable debug logging in the rule function, copy this statement to an it() block:
 //    LoggerFactory.getInstance().addLoggerSetting(ruleId, 'debug');
@@ -24,7 +24,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
-    // non-JSON content, captured in root doc but might as well be explicit !!!
+    // Non-JSON content is captured in the root doc but adding this test to be explicit.
     it('Content is non-JSON', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -33,6 +33,23 @@ describe(`Spectral rule: ${ruleId}`, () => {
           schema: {
             type: 'string',
           },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('Content is not an object', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/movies'].post.requestBody.content[
+        'application/json'
+      ].schema = {
+        type: 'array',
+        description: 'should be an object but that is caught elsewhere',
+        items: {
+          type: 'string',
         },
       };
 

--- a/packages/validator/test/cli-validator/tests/expected-output.test.js
+++ b/packages/validator/test/cli-validator/tests/expected-output.test.js
@@ -86,26 +86,24 @@ describe('Expected output tests', function () {
         expect(capturedText[errorStart + 5].match(/\S+/g)[2]).toEqual('52');
         expect(capturedText[errorStart + 10].match(/\S+/g)[2]).toEqual('96');
         expect(capturedText[errorStart + 15].match(/\S+/g)[2]).toEqual('103');
-        expect(capturedText[errorStart + 20].match(/\S+/g)[2]).toEqual('103');
-        // Note: final number in this list captured below.
 
         // Specifically verify that the no-$ref-siblings error occurred.
         // We do this because this rule is inherited from Spectral's oas ruleset,
         // but we modify the rule definition in ibmoas.js so that it is run
         // against both OpenAPI 3.0 and 3.1 documents.
-        expect(capturedText[errorStart + 22].split(':')[1].trim()).toEqual(
+        expect(capturedText[errorStart + 17].split(':')[1].trim()).toEqual(
           '$ref must not be placed next to any other properties'
         );
-        expect(capturedText[errorStart + 23].split(':')[1].trim()).toEqual(
+        expect(capturedText[errorStart + 18].split(':')[1].trim()).toEqual(
           'no-$ref-siblings'
         );
-        expect(capturedText[errorStart + 24].split(':')[1].trim()).toEqual(
+        expect(capturedText[errorStart + 19].split(':')[1].trim()).toEqual(
           'components.schemas.Pet.properties.category.description'
         );
-        expect(capturedText[errorStart + 25].match(/\S+/g)[2]).toEqual('176');
+        expect(capturedText[errorStart + 20].match(/\S+/g)[2]).toEqual('176');
 
         // warnings
-        const warningStart = 30;
+        const warningStart = 25;
         expect(capturedText[warningStart + 5].match(/\S+/g)[2]).toEqual('22');
         expect(capturedText[warningStart + 10].match(/\S+/g)[2]).toEqual('24');
         expect(capturedText[warningStart + 15].match(/\S+/g)[2]).toEqual('40');

--- a/packages/validator/test/cli-validator/tests/option-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/option-handling.test.js
@@ -114,25 +114,19 @@ describe('cli tool - test option handling', function () {
       expect(sumSection).toBe(3);
 
       // totals
-      expect(capturedText[sumSection + 2].match(/\S+/g)[5]).toEqual('5');
+      expect(capturedText[sumSection + 2].match(/\S+/g)[5]).toEqual('4');
       expect(capturedText[sumSection + 3].match(/\S+/g)[5]).toEqual('29');
 
       // errors
       const errorSection = 8;
       expect(capturedText[errorSection + 1].match(/\S+/g)[0]).toEqual('1');
-      expect(capturedText[errorSection + 1].match(/\S+/g)[1]).toEqual('(20%)');
+      expect(capturedText[errorSection + 1].match(/\S+/g)[1]).toEqual('(25%)');
 
       expect(capturedText[errorSection + 2].match(/\S+/g)[0]).toEqual('2');
-      expect(capturedText[errorSection + 2].match(/\S+/g)[1]).toEqual('(40%)');
-
-      expect(capturedText[errorSection + 3].match(/\S+/g)[0]).toEqual('1');
-      expect(capturedText[errorSection + 3].match(/\S+/g)[1]).toEqual('(20%)');
-
-      expect(capturedText[errorSection + 4].match(/\S+/g)[0]).toEqual('1');
-      expect(capturedText[errorSection + 4].match(/\S+/g)[1]).toEqual('(20%)');
+      expect(capturedText[errorSection + 2].match(/\S+/g)[1]).toEqual('(50%)');
 
       // warnings
-      const warningSection = 14;
+      const warningSection = 13;
       expect(capturedText[warningSection + 1].match(/\S+/g)[0]).toEqual('2');
       expect(capturedText[warningSection + 1].match(/\S+/g)[1]).toEqual('(7%)');
 


### PR DESCRIPTION
When checking that request/response bodies are defined as models, we don't need to check schemas that aren't objects. These schemas should be objects, but there are other rules that will catch that and it's confusing for the validator to tell users they need the "properties" field on a non-object schema.