### PR TITLE
fix(ibm-string-attributes): expand rule to apply to response schemas

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -6522,7 +6522,6 @@ fields in order to clearly define the set of valid values for the property.
 [<a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types#string">1</a>].
 <p>Note that these checks are bypassed for the following scenarios:
 <ul>
-<li>All checks are bypassed for string schemas that are used only within an operation response.
 <li>All checks are bypassed for string schemas that contain an <code>enum</code> field.</li>
 <li>The check for the <code>pattern</code> field is bypassed if <code>format</code> is set to 
 <code>binary</code>, <code>byte</code>, <code>date</code>, <code>date-time</code>, or <code>url</code>.</li>

--- a/packages/ruleset/src/functions/string-attributes.js
+++ b/packages/ruleset/src/functions/string-attributes.js
@@ -9,11 +9,7 @@ const {
   validateNestedSchemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 
-const {
-  getCompositeSchemaAttribute,
-  LoggerFactory,
-  pathMatchesRegexp,
-} = require('../utils');
+const { getCompositeSchemaAttribute, LoggerFactory } = require('../utils');
 
 let ruleId;
 let logger;
@@ -55,7 +51,7 @@ function stringBoundaryErrors(schema, path) {
 
   // Only check for the presence of validation keywords on input schemas
   // (i.e. those used for parameters and request bodies).
-  if (isStringSchema(schema) && isInputSchema(path)) {
+  if (isStringSchema(schema)) {
     logger.debug('schema is a string schema');
 
     // Perform these checks only if enum is not defined.
@@ -95,10 +91,7 @@ function stringBoundaryErrors(schema, path) {
         });
       }
     }
-  }
-
-  // Make sure string attributes aren't used for non-strings.
-  if (!isStringSchema(schema)) {
+  } else {
     // Make sure that string-related fields are not present in a non-string schema.
     if (schemaContainsAttribute(schema, 'pattern')) {
       errors.push({
@@ -134,15 +127,4 @@ function schemaContainsAttribute(schema, attrName) {
     schema,
     s => attrName in s && isDefined(s[attrName])
   );
-}
-
-function isInputSchema(path) {
-  // Output schemas are much simpler to check for with regex.
-  // Use the inverse of that to determine input schemas.
-  const isOutputSchema = pathMatchesRegexp(
-    path,
-    /^paths,.*,responses,.+,(content|headers),.+,schema/
-  );
-
-  return !isOutputSchema;
 }

--- a/packages/ruleset/test/utils/root-document.js
+++ b/packages/ruleset/test/utils/root-document.js
@@ -248,6 +248,7 @@ module.exports = {
                   type: 'string',
                   minLength: 0,
                   maxLength: 512,
+                  pattern: '^[a-zA-Z0-9 ]+$',
                 },
               },
             },
@@ -1039,7 +1040,9 @@ module.exports = {
           trace: {
             description: 'The error trace information.',
             type: 'string',
-            format: 'uuid',
+            format: 'identifier',
+            pattern: '^[a-zA-Z0-9 ]+$',
+            maxLength: 30,
           },
         },
       },
@@ -1055,10 +1058,16 @@ module.exports = {
           message: {
             description: 'The error message.',
             type: 'string',
+            pattern: '^[a-zA-Z0-9 ]+$',
+            minLength: 1,
+            maxLength: 128,
           },
           more_info: {
             description: 'Additional info about the error.',
             type: 'string',
+            pattern: '^[a-zA-Z0-9 ]+$',
+            minLength: 1,
+            maxLength: 128,
           },
           target: {
             $ref: '#/components/schemas/ErrorTarget',
@@ -1078,6 +1087,9 @@ module.exports = {
             description:
               'The name of the field/header/query parameter associated with the error.',
             type: 'string',
+            pattern: '^[a-zA-Z0-9 ]+$',
+            minLength: 1,
+            maxLength: 30,
           },
         },
       },

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean-with-tabs.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean-with-tabs.yml
@@ -48,6 +48,9 @@ paths:
 							schema:
 								type: string
 								description: A link to the next page of responses
+								pattern: '^[a-zA-Z0-9]+$'
+								minLength: 1
+								maxLength: 128
 					content:
 						application/json:
 							schema:
@@ -159,6 +162,9 @@ components:
 				next_token:
 					type: string
 					description: next token
+					pattern: '^[a-zA-Z0-9_]+$'
+					minLength: 1
+					maxLength: 128
 				first:
 					allOf:
 						- $ref: '#/components/schemas/PageLink'
@@ -190,6 +196,9 @@ components:
 				href:
 					description: Request URL string
 					type: string
+					pattern: '^[a-zA-Z0-9]+$'
+					minLength: 1
+					maxLength: 128
 		Error:
 			type: object
 			description:

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
@@ -48,6 +48,9 @@ paths:
               schema:
                 type: string
                 description: A link to the next page of responses
+                pattern: '^[a-zA-Z0-9]+$'
+                minLength: 1
+                maxLength: 128
           content:
             application/json:
               schema:
@@ -159,6 +162,9 @@ components:
         next_token:
           type: string
           description: next token
+          pattern: '^[a-zA-Z0-9_]+$'
+          minLength: 1
+          maxLength: 128
         first:
           allOf:
             - $ref: '#/components/schemas/PageLink'
@@ -190,6 +196,9 @@ components:
         href:
           description: Request URL string
           type: string
+          pattern: '^[a-zA-Z0-9]+$'
+          minLength: 1
+          maxLength: 128
     Error:
       type: object
       description:

--- a/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
@@ -48,6 +48,9 @@ paths:
               schema:
                 type: string
                 description: A link to the next page of responses
+                pattern: '^[a-zA-Z0-9]+$'
+                minLength: 1
+                maxLength: 128
           content:
             application/json:
               schema:
@@ -159,6 +162,9 @@ components:
         next_token:
           type: string
           description: next token
+          pattern: '^[a-zA-Z0-9_]+$'
+          minLength: 1
+          maxLength: 128
         first:
           allOf:
             - $ref: '#/components/schemas/PageLink'
@@ -190,6 +196,9 @@ components:
         href:
           description: Request URL string
           type: string
+          pattern: '^[a-zA-Z0-9]+$'
+          minLength: 1
+          maxLength: 128
     Error:
       type: object
       description:


### PR DESCRIPTION
The rule only applied to "input" schemas, which are more important to check for the attributes, but the API Handbook recommends the attributes for repsonse schemas as well. This commit expands the rule to check for those scenarios.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
