### PR TITLE
fix: edit code to process composed schemas in context

### DIFF
--- a/packages/ruleset/src/functions/required-array-properties-in-response.js
+++ b/packages/ruleset/src/functions/required-array-properties-in-response.js
@@ -41,6 +41,25 @@ function checkForOptionalArrays(schema, path) {
       `${ruleId}: examining object schema at location: ${path.join('.')}`
     );
 
+    // If "schema" is an allOf element, then we need to make an educated
+    // guess as to whether or not we should complain about an optional array property.
+    // This will be our heuristic:
+    // If "schema" is an allOf element AND...
+    // 1. DOES NOT INCLUDE the "required" field, then we'll assume that the allOf element
+    //    IS NOT fully-defined and we'll avoid returning errors for any optional array properties
+    //    within "schema".
+    // 2. DOES INCLUDE the "required" field, then we'll assume that the allOf element is
+    //    fully-defined and go ahead and return an error for any optional array properties.
+    // This isn't perfect, but should allow us to make a good guess (famous last words, perhaps).
+    if (path[path.length - 2] === 'allOf' && !('required' in schema)) {
+      logger.debug(
+        `${ruleId}: allOf element w/o 'required' field... skipping at location: ${path.join(
+          '.'
+        )}`
+      );
+      return [];
+    }
+
     const errors = [];
 
     const requiredProps = schema.required || [];

--- a/packages/ruleset/test/required-array-properties-in-response.test.js
+++ b/packages/ruleset/test/required-array-properties-in-response.test.js
@@ -33,6 +33,32 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+    it('Optional array property in allOf w/no required field', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Add a new allOf element to DrinkCollection which itself is a composed schema
+      // with an allOf that defines an optional array.
+      testDocument.components.schemas['DrinkCollection'].allOf[2] = {
+        type: 'object',
+        allOf: [
+          {
+            // allOf element has no required field: errors are bypassed
+            type: 'object',
+            properties: {
+              optional_details: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {
@@ -135,7 +161,8 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       // Add a new allOf element to DrinkCollection which itself is a composed schema
-      // with an allOf that defines an optional array.
+      // with an allOf that defines an optional array.  Note that for an error to be
+      // returned, the allOf element must include the 'required' field.
       testDocument.components.schemas['DrinkCollection'].allOf[2] = {
         type: 'object',
         allOf: [
@@ -148,7 +175,11 @@ describe(`Spectral rule: ${ruleId}`, () => {
                   type: 'string',
                 },
               },
+              foo: {
+                type: 'string',
+              },
             },
+            required: ['foo'],
           },
         ],
       };

--- a/packages/ruleset/test/required-array-properties-in-response.test.js
+++ b/packages/ruleset/test/required-array-properties-in-response.test.js
@@ -33,32 +33,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
-    it('Optional array property in allOf w/no required field', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      // Add a new allOf element to DrinkCollection which itself is a composed schema
-      // with an allOf that defines an optional array.
-      testDocument.components.schemas['DrinkCollection'].allOf[2] = {
-        type: 'object',
-        allOf: [
-          {
-            // allOf element has no required field: errors are bypassed
-            type: 'object',
-            properties: {
-              optional_details: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-            },
-          },
-        ],
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(0);
-    });
   });
 
   describe('Should yield errors', () => {
@@ -180,6 +154,43 @@ describe(`Spectral rule: ${ruleId}`, () => {
               },
             },
             required: ['foo'],
+          },
+        ],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+
+      const expectedPaths = [
+        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.2.allOf.0.properties.optional_details',
+      ];
+
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(expectedMsg);
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
+      }
+    });
+    it('Optional array property in response (nested allOf without required)', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      // Add a new allOf element to DrinkCollection which itself is a composed schema
+      // with an allOf that defines an optional array.
+      testDocument.components.schemas['DrinkCollection'].allOf[2] = {
+        type: 'object',
+        allOf: [
+          {
+            // allOf element has no required field: errors are bypassed
+            type: 'object',
+            properties: {
+              optional_details: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
           },
         ],
       };


### PR DESCRIPTION
This is the result of my experiment to try and get composed schemas, like `allOf`, to be processed within the context of their top-level required field.

The code could potentially be cleaned up but it seems to work alright (all of the tests pass). Let me know what you think or if this gives you any ideas!