### PR TITLE
chore: update spectral dependencies, addresses CVE-2024-21534

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,10 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-4.3.1.tgz",
-      "integrity": "sha512-EfexhJu/lwF8OdQDm28NKLJHFkx0Gb6O+rcezhZYLPIoNYKXJMh2J1vFGpwmfAcTTh+ffK44Oc2Hs1Q4sLBp+A==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.8.0.tgz",
+      "integrity": "sha512-1i6xs8+IOh6U5T7yH+bCMGQBF+m7kP/NpwyAlt++XaDQutoGCgACf24mQBgcDVqDWWoY81evQv+9ABvw0BviVg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -1028,6 +1029,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
       "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -1039,6 +1041,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
       "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -1050,6 +1053,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.4.tgz",
       "integrity": "sha512-ck5wiqIbqdMX6WRQztBL7ASDty9YLgJ3sSAK5ZpBzXeySvFGCzIvM6UiAI4hTZ22fEcYQVV/zhUbNscggW+Ukg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -2054,9 +2058,10 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.1.tgz",
-      "integrity": "sha512-YiWhXdjyjn4vCl3102ywzwCEJzncxapFcj4dxcj1YP/bZ62DFeGJ8cEaMP164vSw2kI3rX7EMMzI/c8XOUnTfQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.2.tgz",
+      "integrity": "sha512-Yx1j7d0VGEbsOCimPgl+L8w7ZuuOaxqGvXSUXgm9weoGR5idLQjPaTuHLdfdziR1gjqQdVTCEk/dN0cFfUKhow==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "~3.21.0",
@@ -2071,17 +2076,17 @@
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "es-aggregate-error": "^1.0.7",
-        "jsonpath-plus": "7.1.0",
+        "jsonpath-plus": "10.1.0",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
         "minimatch": "3.1.2",
-        "nimma": "0.2.2",
+        "nimma": "0.2.3",
         "pony-cause": "^1.0.0",
-        "simple-eval": "1.0.0",
+        "simple-eval": "1.0.1",
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/@stoplight/better-ajv-errors": {
@@ -2135,17 +2140,18 @@
       }
     },
     "node_modules/@stoplight/spectral-formats": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.7.0.tgz",
-      "integrity": "sha512-vJ1vIkA2s96fdJp0d3AJBGuPAW3sj8yMamyzR+dquEFO6ZAoYBo/BVsKKQskYzZi/nwljlRqUmGVmcf2PncIaA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.1.tgz",
+      "integrity": "sha512-y9TP/EbJVMDde99pmifgjeGdA5mOb1dMxQjpFjq5ABF6Iz5q7ERoN6DWaQdRpuAO26CIAKZmSmh4jctaGPDRCQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.8.0",
+        "@stoplight/spectral-core": "^1.19.2",
         "@types/json-schema": "^7.0.7",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-formatters": {
@@ -2172,13 +2178,14 @@
       }
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.0.tgz",
-      "integrity": "sha512-T+xl93ji8bpus4wUsTq8Qr2DSu2X9PO727rbxW61tTCG0s17CbsXOLYI+Ezjg5P6aaQlgXszGX8khtc57xk8Yw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.1.tgz",
+      "integrity": "sha512-MYp5d0GdWrf7fysevqoRWA6opgYziuxHz0ZAbFB6JWAS+k/P/3Snyqb5wRliivWEBxhuaBrswlg0MGnrlHuA6A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.1",
-        "@stoplight/spectral-core": "^1.7.0",
+        "@stoplight/spectral-core": "^1.19.2",
         "@stoplight/spectral-formats": "^1.7.0",
         "@stoplight/spectral-runtime": "^1.1.0",
         "ajv": "^8.17.1",
@@ -2189,7 +2196,7 @@
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-functions/node_modules/@stoplight/better-ajv-errors": {
@@ -2369,14 +2376,15 @@
       }
     },
     "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.20.2.tgz",
-      "integrity": "sha512-7Y8orZuNyGyeHr9n50rMfysgUJ+/zzIEHMptt66jiy82GUWl+0nr865DkMuXdC5GryfDYhtjoRTUCVsXu80Nkg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.21.1.tgz",
+      "integrity": "sha512-c6TSOSoejZ8NpAfvNdfYdYUn5vyReHyRca+RdkrMM2uABZt9emy/raEPihpq0WjA2ZQutc9sCZDD3lHAiqTnOQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/specs": "^4.1.0",
+        "@asyncapi/specs": "^6.8.0",
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.8.1",
+        "@stoplight/spectral-core": "^1.19.2",
         "@stoplight/spectral-formats": "^1.7.0",
         "@stoplight/spectral-functions": "^1.5.1",
         "@stoplight/spectral-runtime": "^1.1.1",
@@ -2390,7 +2398,7 @@
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-rulesets/node_modules/@stoplight/better-ajv-errors": {
@@ -6666,6 +6674,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -6766,6 +6775,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
       "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "license": "MIT",
       "dependencies": {
         "@jsep-plugin/assignment": "^1.2.1",
         "@jsep-plugin/regex": "^1.0.3",
@@ -6958,7 +6968,8 @@
     "node_modules/lodash.topath": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
-      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg=="
+      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==",
+      "license": "MIT"
     },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
@@ -7518,9 +7529,10 @@
       "dev": true
     },
     "node_modules/nimma": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
-      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
+      "integrity": "sha512-1ZOI8J+1PKKGceo/5CT5GfQOG6H8I2BencSK06YarZ2wXwH37BSSUWldqJmMJYA5JfqDqffxDXynt6f11AyKcA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@jsep-plugin/regex": "^1.0.1",
         "@jsep-plugin/ternary": "^1.0.2",
@@ -7531,7 +7543,7 @@
         "node": "^12.20 || >=14.13"
       },
       "optionalDependencies": {
-        "jsonpath-plus": "^6.0.1",
+        "jsonpath-plus": "^6.0.1 || ^10.1.0",
         "lodash.topath": "^4.5.2"
       }
     },
@@ -12760,11 +12772,12 @@
       ]
     },
     "node_modules/simple-eval": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.0.tgz",
-      "integrity": "sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.1.tgz",
+      "integrity": "sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==",
+      "license": "MIT",
       "dependencies": {
-        "jsep": "^1.1.2"
+        "jsep": "^1.3.6"
       },
       "engines": {
         "node": ">=12"
@@ -13987,13 +14000,13 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.4.0",
-        "@stoplight/spectral-formats": "^1.7.0",
-        "@stoplight/spectral-functions": "^1.9.0",
-        "@stoplight/spectral-rulesets": "^1.20.2",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-rulesets": "^1.21.1",
         "chalk": "^4.1.2",
         "lodash": "^4.17.21",
         "loglevel": "^1.9.2",
@@ -14002,7 +14015,7 @@
         "validator": "^13.11.0"
       },
       "devDependencies": {
-        "@stoplight/spectral-core": "^1.19.1",
+        "@stoplight/spectral-core": "^1.19.2",
         "jest": "^27.4.5"
       },
       "engines": {
@@ -14036,7 +14049,7 @@
       "version": "1.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@stoplight/spectral-core": "^1.19.1",
+        "@stoplight/spectral-core": "^1.19.2",
         "jest": "^27.4.5"
       },
       "engines": {
@@ -14045,13 +14058,13 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.24.0",
+        "@ibm-cloud/openapi-ruleset": "1.25.0",
         "@ibm-cloud/openapi-ruleset-utilities": "1.4.0",
         "@stoplight/spectral-cli": "^6.13.1",
-        "@stoplight/spectral-core": "^1.19.1",
+        "@stoplight/spectral-core": "^1.19.2",
         "@stoplight/spectral-parsers": "^1.0.4",
         "@stoplight/spectral-ref-resolver": "^1.0.4",
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "overrides": {
     "proxy-agent": "^6.3.0",
     "micromatch": "^4.0.8",
-    "rollup": "2.79.2",
-    "jsonpath-plus": "^10.1.0"
+    "rollup": "2.79.2"
   }
 }

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@ibm-cloud/openapi-ruleset-utilities": "1.4.0",
-    "@stoplight/spectral-formats": "^1.7.0",
-    "@stoplight/spectral-functions": "^1.9.0",
-    "@stoplight/spectral-rulesets": "^1.20.2",
+    "@stoplight/spectral-formats": "^1.8.1",
+    "@stoplight/spectral-functions": "^1.9.1",
+    "@stoplight/spectral-rulesets": "^1.21.1",
     "chalk": "^4.1.2",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.2",
@@ -33,7 +33,7 @@
     "validator": "^13.11.0"
   },
   "devDependencies": {
-    "@stoplight/spectral-core": "^1.19.1",
+    "@stoplight/spectral-core": "^1.19.2",
     "jest": "^27.4.5"
   },
   "engines": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -20,7 +20,7 @@
     "pkg": "echo no executables to build in this package"
   },
   "devDependencies": {
-    "@stoplight/spectral-core": "^1.19.1",
+    "@stoplight/spectral-core": "^1.19.2",
     "jest": "^27.4.5"
   },
   "engines": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -26,7 +26,7 @@
     "@ibm-cloud/openapi-ruleset": "1.25.0",
     "@ibm-cloud/openapi-ruleset-utilities": "1.4.0",
     "@stoplight/spectral-cli": "^6.13.1",
-    "@stoplight/spectral-core": "^1.19.1",
+    "@stoplight/spectral-core": "^1.19.2",
     "@stoplight/spectral-parsers": "^1.0.4",
     "@stoplight/spectral-ref-resolver": "^1.0.4",
     "ajv": "^8.17.1",


### PR DESCRIPTION
## PR summary

Updates the spectral dependencies to address CVE-2024-21534.

<s>There was a single test failure, it seems spectral returns a bit more information around where the error happens, have updated the test to reflect that.</s>


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [ ] .secrets.baseline updated as needed?

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
