### PR TITLE
fix: adjust path location regular expressions to handle edge cases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Please make sure that your PR fulfills the following requirements:
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] Dependencies have been updated as needed
 - [ ] `.secrets.baseline` has been updated as needed
-- [ ] `npm run generate-utilities-docs` has been run if needed
+- [ ] `npm run generate-utilities-docs` has been run if any files in `packages/utilities/src` have been updated
 
 #### Checklist for adding a new validation rule:
 - [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-27T14:56:49Z",
+  "generated_at": "2024-12-16T19:27:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/packages/ruleset/src/functions/binary-schemas.js
+++ b/packages/ruleset/src/functions/binary-schemas.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -7,7 +7,10 @@ const { isBinarySchema } = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const {
   isJsonMimeType,
-  pathMatchesRegexp,
+  isParamSchema,
+  isParamContentSchema,
+  isRequestBodySchema,
+  isResponseSchema,
   LoggerFactory,
 } = require('../utils');
 
@@ -49,20 +52,10 @@ function binarySchemaCheck(schema, path) {
 
   // 1. Is it the schema for a parameter within a path item or operation?
   // a. ...parameters[n].schema
-  const isParamSchema = pathMatchesRegexp(
-    path,
-    /^paths,.*,parameters,\d+,schema$/
-  );
-
   // b. ...parameters[n].content.*.schema
-  const isParamContentSchema = pathMatchesRegexp(
-    path,
-    /^paths,.*,parameters,\d+,content,.*schema$/
-  );
-
   if (
-    isParamSchema ||
-    (isParamContentSchema && isJsonMimeType(path[path.length - 2]))
+    isParamSchema(path) ||
+    (isParamContentSchema(path) && isJsonMimeType(path[path.length - 2]))
   ) {
     logger.debug(`${ruleId}: it's a parameter schema!`);
     return [
@@ -75,11 +68,7 @@ function binarySchemaCheck(schema, path) {
   }
 
   // 2. Is it the schema for a JSON requestBody?
-  const isRequestBodySchema = pathMatchesRegexp(
-    path,
-    /^paths,.*,requestBody,content,.*,schema$/
-  );
-  if (isRequestBodySchema && isJsonMimeType(path[path.length - 2])) {
+  if (isRequestBodySchema(path) && isJsonMimeType(path[path.length - 2])) {
     logger.debug(`${ruleId}: it's a requestBody schema!`);
     return [
       {
@@ -91,11 +80,7 @@ function binarySchemaCheck(schema, path) {
   }
 
   // 3. Is it the schema for a JSON response?
-  const isResponseSchema = pathMatchesRegexp(
-    path,
-    /^paths,.*,responses,[^,]*,content,.*,schema$/
-  );
-  if (isResponseSchema && isJsonMimeType(path[path.length - 2])) {
+  if (isResponseSchema(path) && isJsonMimeType(path[path.length - 2])) {
     logger.debug(`${ruleId}: it's a response schema!`);
     return [
       {

--- a/packages/ruleset/src/functions/property-description-exists.js
+++ b/packages/ruleset/src/functions/property-description-exists.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -7,7 +7,7 @@ const {
   schemaHasConstraint,
   validateSubschemas,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
-const { LoggerFactory, pathMatchesRegexp } = require('../utils');
+const { LoggerFactory, isSchemaProperty } = require('../utils');
 
 let ruleId;
 let logger;
@@ -23,20 +23,20 @@ module.exports = function (schema, _opts, context) {
 
 function propertyDescriptionExists(schema, path) {
   // If "schema" is a schema property, then check for a description.
-  const isSchemaProperty = pathMatchesRegexp(path, /^.*,properties,[^,]*$/);
-  if (isSchemaProperty) {
+  if (isSchemaProperty(path)) {
     logger.debug(
       `${ruleId}: checking schema property at location: ${path.join('.')}`
     );
-  }
-  if (isSchemaProperty && !schemaHasDescription(schema)) {
-    logger.debug(`${ruleId}: no description found!`);
-    return [
-      {
-        message: 'Schema properties should have a non-empty description',
-        path,
-      },
-    ];
+
+    if (!schemaHasDescription(schema)) {
+      logger.debug(`${ruleId}: no description found!`);
+      return [
+        {
+          message: 'Schema properties should have a non-empty description',
+          path,
+        },
+      ];
+    }
   }
 
   return [];

--- a/packages/ruleset/src/functions/schema-description-exists.js
+++ b/packages/ruleset/src/functions/schema-description-exists.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -7,7 +7,7 @@ const {
   validateSubschemas,
   schemaHasConstraint,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
-const { LoggerFactory, pathMatchesRegexp } = require('../utils');
+const { LoggerFactory, isPrimarySchema } = require('../utils');
 
 let ruleId;
 let logger;
@@ -22,23 +22,9 @@ module.exports = function (schema, _opts, context) {
 };
 
 function schemaDescriptionExists(schema, path) {
-  //
   // Check to see if "path" represents a primary schema (i.e. not a schema property).
-  // Note: the regexp used below uses a "lookbehind assertion"
-  // (i.e. the "(?<!,parameters,\d+)" part) to match paths that end with the "schema" part,
-  // but not paths where "schema" is preceded by "parameters" and "<digits>".
-  // So a primary schema is one with a path like:
-  // ["paths", "/v1/drinks", "requestBody", "content", "application/json", "schema"]
-  // but not one with a path like these:
-  // ["paths", "/v1/drinks", "parameters", "0", "schema"]
-  // ["paths", "/v1/drinks", "requestBody", "content", "application/json", "schema", "properties", "prop1"]
-  //
-  const isPrimarySchema = pathMatchesRegexp(
-    path,
-    /^.*(?<!,parameters,\d+),schema$/
-  );
   // If "schema" is a primary schema, then check for a description.
-  if (isPrimarySchema) {
+  if (isPrimarySchema(path)) {
     logger.debug(`${ruleId}: checking schema at location: ${path.join('.')}`);
 
     if (!schemaHasDescription(schema)) {

--- a/packages/ruleset/src/utils/index.js
+++ b/packages/ruleset/src/utils/index.js
@@ -23,5 +23,6 @@ module.exports = {
   pathMatchesRegexp: require('./path-matches-regexp'),
   ...require('./mimetype-utils'),
   ...require('./pagination-utils'),
+  ...require('./path-location-utils'),
   ...require('./schema-finding-utils'),
 };

--- a/packages/ruleset/src/utils/path-location-utils.js
+++ b/packages/ruleset/src/utils/path-location-utils.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const pathMatchesRegexp = require('./path-matches-regexp');
+
+/**
+ * Returns true if the path points to a schema object within
+ * a media type object defined on a parameter's content field.
+ *
+ * @param {array} path the path to the openapi artifact
+ * @returns true if path is to a parameter content schema object
+ */
+function isParamContentSchema(path) {
+  // ...parameters[n].content.*.schema
+  return pathMatchesRegexp(
+    path,
+    /^paths,.+,parameters,\d+,content,[^,]+,schema$/
+  );
+}
+
+/**
+ * Returns true if the path points to a schema object defined
+ * directly on a parameter.
+ *
+ * @param {array} path the path to the openapi artifact
+ * @returns true if path is to a parameter schema object
+ */
+function isParamSchema(path) {
+  // Schema for a parameter within a path item or operation:
+  // ...parameters[n].schema
+  return pathMatchesRegexp(path, /^paths,.+,parameters,\d+,schema$/);
+}
+
+/**
+ * Returns true if the path points to a schema object that
+ * is a "primary" schema, meaning it is not the schema of a
+ * parameter or a property of another schema. This ultimately
+ * translates to "content" schemas (for request bodies,
+ * response bodies, and parameters).
+ *
+ * So a primary schema is one with a path like:
+ * - ["paths", "/v1/drinks", "requestBody", "content", "application/json", "schema"]
+ *
+ * but not one with a path like these:
+ * - ["paths", "/v1/drinks", "parameters", "0", "schema"]
+ * - ["paths", "/v1/drinks", "requestBody", "content", "application/json", "schema", "properties", "prop1"]
+ *
+ * @param {array} path the path to the openapi artifact
+ * @returns true if path is to a primary, non-property schema
+ */
+function isPrimarySchema(path) {
+  // Note: the regexp used below uses a "lookbehind assertion"
+  // (i.e. the "(?<!properties)" part) to ensure we don't match any
+  // schemas in "properties" that may have names like "content" or "schema".
+  return pathMatchesRegexp(path, /^.*(?<!properties),content,[^,]+,schema$/);
+}
+
+/**
+ * Returns true if the path points to a schema object within
+ * a media type object defined on a request body.
+ *
+ * @param {array} path the path to the openapi artifact
+ * @returns true if path is to a request body content schema object
+ */
+function isRequestBodySchema(path) {
+  return pathMatchesRegexp(path, /^paths,.+,requestBody,content,[^,]+,schema$/);
+}
+
+/**
+ * Returns true if the path points to a schema object within
+ * a media type object defined on a response body.
+ *
+ * @param {array} path the path to the openapi artifact
+ * @returns true if path is to a response body content schema object
+ */
+function isResponseSchema(path) {
+  return pathMatchesRegexp(
+    path,
+    /^paths,([^,]+,){2}responses,[^,]+,content,[^,]+,schema$/
+  );
+}
+
+/**
+ * Returns true if the path points to a schema object that is
+ * explictly defined as a property of another object schema.
+ *
+ * @param {array} path the path to the openapi artifact
+ * @returns true if path is to a schema property schema object
+ */
+function isSchemaProperty(path) {
+  const matches = pathMatchesRegexp(path, /^.+,properties,[^,]+$/);
+
+  // Handle the rare edge case where a property is named "properties"
+  // and we end up in its properties field, which should return false.
+  // This scenario is rather difficult to handle with a regular expression.
+  if (matches && path.at(-1) === 'properties') {
+    // Count the amount of times the segment 'properties' occurs at the end
+    // of the path. Look for an even number.
+    const count = path
+      .slice()
+      .reverse()
+      .findIndex(p => p !== 'properties');
+
+    return count % 2 === 0;
+  }
+
+  return matches;
+}
+
+module.exports = {
+  isParamContentSchema,
+  isParamSchema,
+  isPrimarySchema,
+  isRequestBodySchema,
+  isResponseSchema,
+  isSchemaProperty,
+};

--- a/packages/ruleset/test/utils/path-location-utils.test.js
+++ b/packages/ruleset/test/utils/path-location-utils.test.js
@@ -1,0 +1,661 @@
+/**
+ * Copyright 2024 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  isParamContentSchema,
+  isParamSchema,
+  isPrimarySchema,
+  isRequestBodySchema,
+  isResponseSchema,
+  isSchemaProperty,
+} = require('../../src/utils');
+
+describe('Path Location utility functions', () => {
+  describe('isParamContentSchema()', () => {
+    it('should throw for non-array path', () => {
+      const expectedMessage = 'argument "path" must be an array!';
+
+      expect(() => {
+        isParamContentSchema(undefined);
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isParamContentSchema('string');
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isParamContentSchema({});
+      }).toThrowError(expectedMessage);
+    });
+
+    it('should return `true` for path parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamContentSchema(path)).toBe(true);
+    });
+
+    it('should return `true` for operation parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'parameters',
+        '1',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamContentSchema(path)).toBe(true);
+    });
+
+    it('should return `false` for path parameter schema', () => {
+      const path = ['paths', '/resources', 'parameters', '2', 'schema'];
+      expect(isParamContentSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter schema', () => {
+      const path = ['paths', '/resources', 'get', 'parameters', '1', 'schema'];
+      expect(isParamContentSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for request body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamContentSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for response body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamContentSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for schema property named schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'schema',
+      ];
+      expect(isParamContentSchema(path)).toBe(false);
+    });
+  });
+
+  describe('isParamSchema()', () => {
+    it('should throw for non-array path', () => {
+      const expectedMessage = 'argument "path" must be an array!';
+
+      expect(() => {
+        isParamSchema(undefined);
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isParamSchema('string');
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isParamSchema({});
+      }).toThrowError(expectedMessage);
+    });
+
+    it('should return `true` for path parameter schema', () => {
+      const path = ['paths', '/resources', 'parameters', '2', 'schema'];
+      expect(isParamSchema(path)).toBe(true);
+    });
+
+    it('should return `true` for operation parameter schema', () => {
+      const path = ['paths', '/resources', 'get', 'parameters', '1', 'schema'];
+      expect(isParamSchema(path)).toBe(true);
+    });
+
+    it('should return `false` for path parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'parameters',
+        '1',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for request body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for response body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isParamSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for schema property named schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'schema',
+        'properties',
+        'parameters',
+        'properties',
+        'schema',
+      ];
+      expect(isParamSchema(path)).toBe(false);
+    });
+  });
+
+  describe('isPrimarySchema()', () => {
+    it('should throw for non-array path', () => {
+      const expectedMessage = 'argument "path" must be an array!';
+
+      expect(() => {
+        isPrimarySchema(undefined);
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isPrimarySchema('string');
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isPrimarySchema({});
+      }).toThrowError(expectedMessage);
+    });
+
+    it('should return `true` for top level request body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isPrimarySchema(path)).toBe(true);
+    });
+
+    it('should return `true` for top level response body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isPrimarySchema(path)).toBe(true);
+    });
+
+    it('should return `true` for path parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isPrimarySchema(path)).toBe(true);
+    });
+
+    it('should return `true` for operation parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'parameters',
+        '1',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isPrimarySchema(path)).toBe(true);
+    });
+
+    it('should return `false` for path parameter schema', () => {
+      const path = ['paths', '/resources', 'parameters', '2', 'schema'];
+      expect(isPrimarySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter schema', () => {
+      const path = ['paths', '/resources', 'get', 'parameters', '1', 'schema'];
+      expect(isPrimarySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for schema property named schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'schema',
+      ];
+      expect(isPrimarySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for schema property named schema in a schema named content', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'content',
+        'properties',
+        'schema',
+      ];
+      expect(isPrimarySchema(path)).toBe(false);
+    });
+  });
+
+  describe('isRequestBodySchema()', () => {
+    it('should throw for non-array path', () => {
+      const expectedMessage = 'argument "path" must be an array!';
+
+      expect(() => {
+        isRequestBodySchema(undefined);
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isRequestBodySchema('string');
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isRequestBodySchema({});
+      }).toThrowError(expectedMessage);
+    });
+
+    it('should return `true` for top level request body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isRequestBodySchema(path)).toBe(true);
+    });
+
+    it('should return `false` for top level response body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isRequestBodySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for path parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isRequestBodySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'parameters',
+        '1',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isRequestBodySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for path parameter schema', () => {
+      const path = ['paths', '/resources', 'parameters', '2', 'schema'];
+      expect(isRequestBodySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter schema', () => {
+      const path = ['paths', '/resources', 'get', 'parameters', '1', 'schema'];
+      expect(isRequestBodySchema(path)).toBe(false);
+    });
+
+    it('should return `false` for schema property named schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'requestBody',
+        'properties',
+        'content',
+        'properties',
+        'schema',
+      ];
+      expect(isRequestBodySchema(path)).toBe(false);
+    });
+  });
+
+  describe('isResponseSchema()', () => {
+    it('should throw for non-array path', () => {
+      const expectedMessage = 'argument "path" must be an array!';
+
+      expect(() => {
+        isResponseSchema(undefined);
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isResponseSchema('string');
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isResponseSchema({});
+      }).toThrowError(expectedMessage);
+    });
+
+    it('should return `true` for top level response body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isResponseSchema(path)).toBe(true);
+    });
+
+    it('should return `false` for top level request body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isResponseSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for path parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isResponseSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'parameters',
+        '1',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isResponseSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for path parameter schema', () => {
+      const path = ['paths', '/resources', 'parameters', '2', 'schema'];
+      expect(isResponseSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter schema', () => {
+      const path = ['paths', '/resources', 'get', 'parameters', '1', 'schema'];
+      expect(isResponseSchema(path)).toBe(false);
+    });
+
+    it('should return `false` for schema property named schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'responses',
+        'properties',
+        'content',
+        'properties',
+        'schema',
+      ];
+      expect(isResponseSchema(path)).toBe(false);
+    });
+  });
+
+  describe('isSchemaProperty()', () => {
+    it('should throw for non-array path', () => {
+      const expectedMessage = 'argument "path" must be an array!';
+
+      expect(() => {
+        isSchemaProperty(undefined);
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isSchemaProperty('string');
+      }).toThrowError(expectedMessage);
+      expect(() => {
+        isSchemaProperty({});
+      }).toThrowError(expectedMessage);
+    });
+
+    it('should return `true` for a schema property', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'something',
+      ];
+      expect(isSchemaProperty(path)).toBe(true);
+    });
+
+    it('should return `true` for schema property named schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'schema',
+      ];
+      expect(isSchemaProperty(path)).toBe(true);
+    });
+
+    it('should return `true` for schema property of property named properties', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'properties',
+      ];
+      expect(isSchemaProperty(path)).toBe(true);
+    });
+
+    it('should return `false` for top level response body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isSchemaProperty(path)).toBe(false);
+    });
+
+    it('should return `false` for top level request body schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isSchemaProperty(path)).toBe(false);
+    });
+
+    it('should return `false` for path parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'parameters',
+        '2',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isSchemaProperty(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter content schema', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'parameters',
+        '1',
+        'content',
+        'application/json',
+        'schema',
+      ];
+      expect(isSchemaProperty(path)).toBe(false);
+    });
+
+    it('should return `false` for path parameter schema', () => {
+      const path = ['paths', '/resources', 'parameters', '2', 'schema'];
+      expect(isSchemaProperty(path)).toBe(false);
+    });
+
+    it('should return `false` for operation parameter schema', () => {
+      const path = ['paths', '/resources', 'get', 'parameters', '1', 'schema'];
+      expect(isSchemaProperty(path)).toBe(false);
+    });
+
+    it('should return `false` for properties field of schema property named properties', () => {
+      const path = [
+        'paths',
+        '/resources',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+        'properties',
+        'properties',
+        'properties',
+      ];
+      expect(isSchemaProperty(path)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

A couple of the regular expressions we use for determining the location of a given OpenAPI artifact based on the path had minor bugs that would prevent expected operations for edge cases. These are now resolved. Also, they are now packaged into utilities for easy sharing between rules and increased readability within the rule function code itself.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] `.secrets.baseline` has been updated as needed
- [x] `npm run generate-utilities-docs` has been run if needed
