### PR TITLE
docs: update all package readmes with latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,11 +674,15 @@ module.exports = {
 <td width=25%><b>Default</b></td>
 </tr>
 <tr>
-<td>The <code>produceImpactScore</code> configuration property corresponds to the <code>-q</code>/<code>--impact-score</code> command-line option.
-If set to true, the validator will, in addition to reporting individual rule violations, use the rule violation data to produce
-API impact scores based on the categories of usability, security, robustness, and cost of evolution. By default, the data demonstrating
-how the scores are calculated from each rule is displayed. If this option is combined with the "summary only" configuration option,
-only the categorized impact scores are displayed.
+<td>The <code>produceImpactScore</code> configuration property corresponds to the
+<code>-q</code>/<code>--impact-score</code> command-line option. If set to true,
+the validator will, in addition to reporting individual rule violations, use the
+rule violation data to produce API impact scores based on the categories of usability,
+security, robustness, and cost of evolution. By default, the data demonstrating how
+the scores are calculated from each rule is displayed. If this option is combined with
+the "summary only" configuration option, only the categorized impact scores are displayed.
+These scores are useful for "Automated Quality Screening". See [this documentation](docs/automated-quality-screening.md)
+for more information about the purpose of these scores and how they are computed.
 </td>
 <td><code>false</code></td>
 </tr>

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -5,6 +5,7 @@ This package contains a number of JS functions that may be useful in developing 
 
 `npm install @ibm-cloud/openapi-ruleset-utilities`
 
-## Usage
+## Documentation
 
-Documentation coming soon.
+See [this page for comprehensive documentation](../../docs/openapi-ruleset-utilities.md)
+on all functionality available in this package.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -25,10 +25,17 @@ Options:
   -n, --no-colors                disable colorizing of the output (default is false)
   -r, --ruleset <file>           use Spectral ruleset contained in `<file>` ("default" forces use of default IBM Cloud Validation Ruleset)
   -s, --summary-only             include only the summary information and skip individual errors and warnings (default is false)
+  -q, --impact-score             compute scores representing the API impact of rule violations and include with the results (default is false)
+  -m, --markdown-report          generate a Markdown file with a report on all validator results (default is false)
   -w, --warnings-limit <number>  set warnings limit to <number> (default is -1)
   --version                      output the version number
   -h, --help                     display help for command
 ```
 where `[file...]` is a space-separated list containing the filenames of one or more OpenAPI 3.x documents to be validated.
 
-Detailed usage information for the validator can be found [here](../../README.md).
+## Further Reading
+Again, this page displays abbreviated information. The following links may be helpful:
+
+- [Detailed information about the configuration options](../../README.md#configuration)
+- [Detailed information about the default ruleset](../../docs/ibm-cloud-rules.md)
+- [Detailed information about the `--impact-score` feature](../../docs/automated-quality-screening.md)


### PR DESCRIPTION
Things like the newest CLI options, the new utility package docs, and the AQS docs were not included or linked to from the relevant readme files. This commit catches them up to date.