### PR TITLE
feat: add `collectFromComposedSchemas()` and `getExamplesForSchema()` to utilities

### DIFF
--- a/docs/openapi-ruleset-utilities.md
+++ b/docs/openapi-ruleset-utilities.md
@@ -59,12 +59,12 @@ to a specific language type or data structure in an SDK).
 ### `collectFromComposedSchemas(schema, collector, includeSelf, includeNot)`
 
 Returns an array of items collected by the provided `collector(schema) => item[]` function for a
-simple or composite schema, and deduplicate primitives in the result. The collector function is
+simple or composite schema, and deduplicates primitives in the result. The collector function is
 not run for `null` or `undefined` schemas.
 
 #### Parameters
 
-- **`schema`** `<object>`: simple or composite OpenAPI 3.0 schema object
+- **`schema`** `<object>`: simple or composite OpenAPI 3.x schema object
 - **`collector`** `<function>`: a `(schema) => item[]` function to collect items from each simple schema
 - **`includeSelf`** `<boolean>`: collect from the provided schema in addition to its composed schemas (defaults to `true`)
 - **`includeNot`** `<boolean>`: collect from schemas composed with `not` (defaults to `false`)
@@ -78,7 +78,7 @@ Returns an array of examples for a simple or composite schema. For each composed
 
 #### Parameters
 
-- **`schema`** `<object>`: simple or composite OpenAPI 3.0 schema object
+- **`schema`** `<object>`: simple or composite OpenAPI 3.x schema object
 
 #### Returns `Array`: examples
 
@@ -89,7 +89,7 @@ optionally filtered by a lambda function.
 
 #### Parameters
 
-- **`schema`** `<object>`: simple or composite OpenAPI 3.0 schema object
+- **`schema`** `<object>`: simple or composite OpenAPI 3.x schema object
 - **`propertyFilter`** `<function>`: a `(propertyName, propertySchema) => boolean` function to perform filtering
 
 #### Returns `Array`: property names

--- a/docs/openapi-ruleset-utilities.md
+++ b/docs/openapi-ruleset-utilities.md
@@ -56,6 +56,32 @@ to a specific language type or data structure in an SDK).
 
 ## Functions
 
+### `collectFromComposedSchemas(schema, collector, includeSelf, includeNot)`
+
+Returns an array of items collected by the provided `collector(schema) => item[]` function for a
+simple or composite schema, and deduplicate primitives in the result. The collector function is
+not run for `null` or `undefined` schemas.
+
+#### Parameters
+
+- **`schema`** `<object>`: simple or composite OpenAPI 3.0 schema object
+- **`collector`** `<function>`: a `(schema) => item[]` function to collect items from each simple schema
+- **`includeSelf`** `<boolean>`: collect from the provided schema in addition to its composed schemas (defaults to `true`)
+- **`includeNot`** `<boolean>`: collect from schemas composed with `not` (defaults to `false`)
+
+#### Returns `Array`: collected items
+
+### `getExamplesForSchema(schema)`
+
+Returns an array of examples for a simple or composite schema. For each composed schema, if
+`schema.examples` is present (and an array), `schema.example` is ignored.
+
+#### Parameters
+
+- **`schema`** `<object>`: simple or composite OpenAPI 3.0 schema object
+
+#### Returns `Array`: examples
+
 ### `getPropertyNamesForSchema(schema, propertyFilter)`
 
 Returns an array of property names for a simple or composite schema,
@@ -64,7 +90,7 @@ optionally filtered by a lambda function.
 #### Parameters
 
 - **`schema`** `<object>`: simple or composite OpenAPI 3.0 schema object
-- **`propertyFilter`** `<function>`: a `(schema) => boolean` function to perform filtering
+- **`propertyFilter`** `<function>`: a `(propertyName, propertySchema) => boolean` function to perform filtering
 
 #### Returns `Array`: property names
 

--- a/packages/utilities/src/utils/collect-from-composed-schemas.js
+++ b/packages/utilities/src/utils/collect-from-composed-schemas.js
@@ -1,13 +1,13 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
 /**
  * Returns an array of items collected by the provided `collector(schema) => item[]` function for a
- * simple or composite schema, and deduplicate primitives in the result. The collector function is
+ * simple or composite schema, and deduplicates primitives in the result. The collector function is
  * not run for `null` or `undefined` schemas.
- * @param {object} schema simple or composite OpenAPI 3.0 schema object
+ * @param {object} schema simple or composite OpenAPI 3.x schema object
  * @param {Function} collector a `(schema) => item[]` function to collect items from each simple schema
  * @param {boolean} includeSelf collect from the provided schema in addition to its composed schemas (defaults to `true`)
  * @param {boolean} includeNot collect from schemas composed with `not` (defaults to `false`)

--- a/packages/utilities/src/utils/collect-from-composed-schemas.js
+++ b/packages/utilities/src/utils/collect-from-composed-schemas.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+/**
+ * Returns an array of items collected by the provided `collector(schema) => item[]` function for a
+ * simple or composite schema, and deduplicate primitives in the result. The collector function is
+ * not run for `null` or `undefined` schemas.
+ * @param {object} schema simple or composite OpenAPI 3.0 schema object
+ * @param {Function} collector a `(schema) => item[]` function to collect items from each simple schema
+ * @param {boolean} includeSelf collect from the provided schema in addition to its composed schemas (defaults to `true`)
+ * @param {boolean} includeNot collect from schemas composed with `not` (defaults to `false`)
+ * @returns {Array} collected items
+ */
+function collectFromComposedSchemas(
+  schema,
+  collector,
+  includeSelf = true,
+  includeNot = false
+) {
+  const items = [];
+
+  if (schema === undefined || schema === null) {
+    return items;
+  }
+
+  if (includeSelf) {
+    items.push(...collector(schema));
+  }
+
+  if (includeNot) {
+    items.push(
+      ...collectFromComposedSchemas(schema.not, collector, true, true)
+    );
+  }
+
+  for (const applicatorType of ['allOf', 'oneOf', 'anyOf']) {
+    if (Array.isArray(schema[applicatorType])) {
+      for (const applicatorSchema of schema[applicatorType]) {
+        items.push(
+          ...collectFromComposedSchemas(
+            applicatorSchema,
+            collector,
+            true,
+            includeNot
+          )
+        );
+      }
+    }
+  }
+
+  return [...new Set(items)]; // de-duplicate
+}
+
+module.exports = collectFromComposedSchemas;

--- a/packages/utilities/src/utils/get-examples-for-schema.js
+++ b/packages/utilities/src/utils/get-examples-for-schema.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -11,7 +11,7 @@ const collectFromComposedSchemas = require('./collect-from-composed-schemas');
 /**
  * Returns an array of examples for a simple or composite schema. For each composed schema, if
  * `schema.examples` is present (and an array), `schema.example` is ignored.
- * @param {object} schema simple or composite OpenAPI 3.0 schema object
+ * @param {object} schema simple or composite OpenAPI 3.x schema object
  * @returns {Array} examples
  */
 function getExamplesForSchema(schema) {

--- a/packages/utilities/src/utils/get-examples-for-schema.js
+++ b/packages/utilities/src/utils/get-examples-for-schema.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+/**
+ * @private
+ */
+const collectFromComposedSchemas = require('./collect-from-composed-schemas');
+
+/**
+ * Returns an array of examples for a simple or composite schema. For each composed schema, if
+ * `schema.examples` is present (and an array), `schema.example` is ignored.
+ * @param {object} schema simple or composite OpenAPI 3.0 schema object
+ * @returns {Array} examples
+ */
+function getExamplesForSchema(schema) {
+  return collectFromComposedSchemas(schema, s => {
+    if (Array.isArray(s.examples)) {
+      return s.examples;
+    } else if (s.example !== undefined) {
+      return [s.example];
+    }
+
+    return [];
+  });
+}
+
+module.exports = getExamplesForSchema;

--- a/packages/utilities/src/utils/get-property-names-for-schema.js
+++ b/packages/utilities/src/utils/get-property-names-for-schema.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2017 - 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -15,7 +15,7 @@ const collectFromComposedSchemas = require('./collect-from-composed-schemas');
 /**
  * Returns an array of property names for a simple or composite schema,
  * optionally filtered by a lambda function.
- * @param {object} schema simple or composite OpenAPI 3.0 schema object
+ * @param {object} schema simple or composite OpenAPI 3.x schema object
  * @param {Function} propertyFilter a `(propertyName, propertySchema) => boolean` function to perform filtering
  * @returns {Array} property names
  */

--- a/packages/utilities/src/utils/index.js
+++ b/packages/utilities/src/utils/index.js
@@ -4,6 +4,8 @@
  */
 
 module.exports = {
+  collectFromComposedSchemas: require('./collect-from-composed-schemas'),
+  getExamplesForSchema: require('./get-examples-for-schema'),
   getPropertyNamesForSchema: require('./get-property-names-for-schema'),
   ...require('./get-schema-type'),
   isObject: require('./is-object'),

--- a/packages/utilities/test/collect-from-composed-schemas.test.js
+++ b/packages/utilities/test/collect-from-composed-schemas.test.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { collectFromComposedSchemas } = require('../src');
+
+describe('Utility function: collectFromComposedSchemas()', () => {
+  it('should return `[]` for `undefined` or `null`', async () => {
+    expect(collectFromComposedSchemas(undefined, () => ['foo'])).toEqual([]);
+    expect(collectFromComposedSchemas(null, () => ['foo'])).toEqual([]);
+  });
+
+  it('should not run collector for `undefined` or `null`', async () => {
+    expect(() =>
+      collectFromComposedSchemas(undefined, () => {
+        throw new Error();
+      })
+    ).not.toThrow();
+    expect(() =>
+      collectFromComposedSchemas(null, () => {
+        throw new Error();
+      })
+    ).not.toThrow();
+  });
+
+  it('should collect once from a simple schema', async () => {
+    const schemaFoo = { foo: Math.random() };
+    const collectedFrom = [];
+
+    collectFromComposedSchemas(schemaFoo, s => {
+      collectedFrom.push(s);
+
+      return [];
+    });
+
+    expect(collectedFrom.length).toEqual(1);
+    expect(collectedFrom[0]).toEqual(schemaFoo);
+  });
+
+  it('should collect from a composed schema', async () => {
+    const composedSchema = {
+      foo: Math.random(),
+      allOf: [
+        {
+          foo: Math.random(),
+        },
+      ],
+      oneOf: [
+        {
+          foo: Math.random(),
+        },
+      ],
+      anyOf: [
+        {
+          foo: Math.random(),
+        },
+      ],
+    };
+
+    expect(
+      collectFromComposedSchemas(composedSchema, s => [s.foo]).sort()
+    ).toEqual(
+      [
+        composedSchema.foo,
+        composedSchema.allOf[0].foo,
+        composedSchema.oneOf[0].foo,
+        composedSchema.anyOf[0].foo,
+      ].sort()
+    );
+  });
+
+  it('should collect from a deeply composed schema', async () => {
+    const deeplyComposedSchema = {
+      foo: Math.random(),
+      allOf: [
+        {
+          foo: Math.random(),
+          oneOf: [
+            {
+              foo: Math.random(),
+              anyOf: [
+                {
+                  foo: Math.random(),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      collectFromComposedSchemas(deeplyComposedSchema, s => [s.foo]).sort()
+    ).toEqual(
+      [
+        deeplyComposedSchema.foo,
+        deeplyComposedSchema.allOf[0].foo,
+        deeplyComposedSchema.allOf[0].oneOf[0].foo,
+        deeplyComposedSchema.allOf[0].oneOf[0].anyOf[0].foo,
+      ].sort()
+    );
+  });
+
+  it('should de-duplicate primitive items collected in a composed schema', async () => {
+    const value = Math.random();
+
+    expect(
+      collectFromComposedSchemas(
+        {
+          foo: value,
+          allOf: [
+            {
+              foo: value + 0,
+            },
+          ],
+        },
+        s => [s.foo]
+      )
+    ).toEqual([value]);
+  });
+
+  it('should not deduplicate non-primitive examples for composed schema', async () => {
+    expect(
+      collectFromComposedSchemas(
+        {
+          foo: {},
+          allOf: [
+            {
+              foo: {},
+            },
+          ],
+        },
+        s => [s.foo]
+      )
+    ).toEqual([{}, {}]);
+  });
+
+  it('should not collect from self if includeSelf = false', async () => {
+    const composedSchema = {
+      foo: Math.random(),
+      allOf: [
+        {
+          foo: Math.random(),
+        },
+      ],
+    };
+
+    expect(
+      collectFromComposedSchemas(composedSchema, s => [s.foo], false).sort()
+    ).toEqual([composedSchema.allOf[0].foo].sort());
+  });
+
+  it('should not collect from `not` if includeNot = false', async () => {
+    const composedSchema = {
+      foo: Math.random(),
+      not: {
+        foo: Math.random(),
+      },
+    };
+
+    expect(
+      collectFromComposedSchemas(
+        composedSchema,
+        s => [s.foo],
+        true,
+        false
+      ).sort()
+    ).toEqual([composedSchema.foo].sort());
+  });
+
+  it('should collect from `not` if includeNot = true', async () => {
+    const composedSchema = {
+      foo: Math.random(),
+      not: {
+        foo: Math.random(),
+      },
+    };
+
+    expect(
+      collectFromComposedSchemas(
+        composedSchema,
+        s => [s.foo],
+        true,
+        true
+      ).sort()
+    ).toEqual([composedSchema.foo, composedSchema.not.foo].sort());
+  });
+});

--- a/packages/utilities/test/collect-from-composed-schemas.test.js
+++ b/packages/utilities/test/collect-from-composed-schemas.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 

--- a/packages/utilities/test/get-examples-for-schema.test.js
+++ b/packages/utilities/test/get-examples-for-schema.test.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2017 - 2023 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { getExamplesForSchema } = require('../src');
+
+describe('Utility function: getExamplesForSchema()', () => {
+  it('should return `[]` for `undefined`', async () => {
+    expect(getExamplesForSchema(undefined)).toEqual([]);
+  });
+
+  it('should return `[]` for `null`', async () => {
+    expect(getExamplesForSchema(null)).toEqual([]);
+  });
+
+  it('should return `[]` for empty object', async () => {
+    expect(getExamplesForSchema({})).toEqual([]);
+  });
+
+  it('should return examples for simple schema', async () => {
+    expect(
+      getExamplesForSchema({
+        examples: ['three', 'two', 'one'],
+      }).sort()
+    ).toEqual(['three', 'two', 'one'].sort());
+  });
+
+  it('should return single example for simple schema', async () => {
+    expect(
+      getExamplesForSchema({
+        example: 'one',
+      }).sort()
+    ).toEqual(['one']);
+  });
+
+  it('should return examples for composed schema', async () => {
+    expect(
+      getExamplesForSchema({
+        examples: ['one'],
+        allOf: [
+          {
+            examples: ['two'],
+          },
+        ],
+        oneOf: [
+          {
+            examples: ['three'],
+          },
+        ],
+        anyOf: [
+          {
+            examples: ['four'],
+          },
+        ],
+      }).sort()
+    ).toEqual(['four', 'three', 'two', 'one'].sort());
+  });
+
+  it('should return examples for deeply composed schema', async () => {
+    expect(
+      getExamplesForSchema({
+        examples: ['one'],
+        allOf: [
+          {
+            examples: ['two'],
+            oneOf: [
+              {
+                examples: ['three'],
+                anyOf: [
+                  {
+                    examples: ['four'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }).sort()
+    ).toEqual(['four', 'three', 'two', 'one'].sort());
+  });
+
+  it('should return examples for deeply composed schema', async () => {
+    expect(
+      getExamplesForSchema({
+        examples: ['one'],
+        allOf: [
+          {
+            examples: ['two'],
+            oneOf: [
+              {
+                examples: ['three'],
+                anyOf: [
+                  {
+                    examples: ['four'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }).sort()
+    ).toEqual(['four', 'three', 'two', 'one'].sort());
+  });
+
+  it('should aggregate examples for any mixture of schemas with `example` and `examples`', async () => {
+    expect(
+      getExamplesForSchema({
+        examples: ['one'],
+        allOf: [
+          {
+            example: 'two',
+            oneOf: [
+              {
+                examples: ['three'],
+                anyOf: [
+                  {
+                    example: 'four',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }).sort()
+    ).toEqual(['four', 'three', 'two', 'one'].sort());
+  });
+
+  it('should de-duplicate primitive examples for composed schema', async () => {
+    expect(
+      getExamplesForSchema({
+        examples: ['one'],
+        allOf: [
+          {
+            examples: ['one'],
+          },
+        ],
+      })
+    ).toEqual(['one']);
+  });
+
+  it('should not deduplicate non-primitive examples for composed schema', async () => {
+    expect(
+      getExamplesForSchema({
+        examples: [{}],
+        allOf: [
+          {
+            examples: [{}],
+          },
+        ],
+      })
+    ).toEqual([{}, {}]);
+  });
+});

--- a/packages/utilities/test/get-examples-for-schema.test.js
+++ b/packages/utilities/test/get-examples-for-schema.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2023 IBM Corporation.
+ * Copyright 2024 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -30,7 +30,7 @@ describe('Utility function: getExamplesForSchema()', () => {
     expect(
       getExamplesForSchema({
         example: 'one',
-      }).sort()
+      })
     ).toEqual(['one']);
   });
 


### PR DESCRIPTION
## PR summary
Adds a generic `collectFromComposedSchemas()` function that can be used to build functions like the also-added `getExamplesForSchema()`, and refactors `getPropertyNamesForSchema()` to use `collectFromComposedSchemas()` as well.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] `.secrets.baseline` has been updated as needed
- [x] `npm run generate-utilities-docs` has been run if any files in `packages/utilities/src` have been updated
