### PR TITLE
build: separate docker deployment into tagged release build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,7 @@ jobs:
 
   build:
     needs: detect-secrets
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    name: Build & Test (Node v${{ matrix.node-version }})
+    name: Build/Test (Node v${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,14 +71,11 @@ jobs:
           npm run lint
           npm run test-docker
 
-  create_release:
+  publish-release:
     needs: build
-    # Only run this job on the main branch and only for our max version of Go.
+    name: Semantic-Release
     if: "github.ref_name == 'main' && github.event_name != 'pull_request'"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ['20']
 
     steps:
       - name: Checkout repository
@@ -90,15 +86,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
 
-      - name: Install Deployment Tools
+      - name: Install Publishing Tools
         run: |
           npm install
 
-      - name: Create & Tag Release
+      - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
         run: npx -p @qiwi/semrel-toolkit multi-semrel --deps.release inherit

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,33 @@
+# This workflow is responsible for deploying a Docker image for a given
+# release to Docker Hub. It is triggered when a new release is created. This
+# job is separated from the publishing job, as it may fail independently and
+# we need to be able to retry it without re-running the publish step.
+
+name: Docker Deploy
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    # Allow this workflow to be triggered manually
+
+jobs:
+  deploy-docker-image:
+    name: Deploy image
+    runs-on: ubuntu-latest
+ 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Node is used in the deployment script to extract the numeric version
+      # from packages/validator/package.json.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Build and deploy Docker image
+        env:
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+        run: ./scripts/deploy-container-image.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://github.com/IBM/openapi-validator/actions/workflows/build.yaml/badge.svg)](https://github.com/IBM/openapi-validator/actions/workflows/build.yaml)
 [![npm-version](https://img.shields.io/npm/v/ibm-openapi-validator.svg)](https://www.npmjs.com/package/ibm-openapi-validator)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Gitter](https://badges.gitter.im/openapi-validator/community.svg)](https://gitter.im/openapi-validator/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.com/IBM/openapi-validator.svg?branch=main)](https://travis-ci.com/IBM/openapi-validator)
 [![npm-version](https://img.shields.io/npm/v/ibm-openapi-validator.svg)](https://www.npmjs.com/package/ibm-openapi-validator)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Gitter](https://badges.gitter.im/openapi-validator/community.svg)](https://gitter.im/openapi-validator/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/packages/validator/.releaserc
+++ b/packages/validator/.releaserc
@@ -20,12 +20,6 @@
           "bin/*"
         ]
       }
-    ],
-    [
-      "@semantic-release/exec",
-      {
-        "successCmd": "cd ../.. && ./scripts/deploy-container-image.sh ${nextRelease.version}"
-      }
     ]
   ]
 }

--- a/scripts/deploy-container-image.sh
+++ b/scripts/deploy-container-image.sh
@@ -3,9 +3,8 @@
 set -e
 
 deploy() {
-    local new_version=$1
     login "$DOCKER_HUB_TOKEN"
-    deploy_docker "$new_version"
+    deploy_docker
 }
 
 login() {
@@ -18,7 +17,7 @@ login() {
 }
 
 deploy_docker() {
-    local new_version=$1
+    local new_version=`node -p "require('./packages/validator/package.json').version"`
 
     # Ensure version is present and has semver format
     [[ "$new_version" =~ [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]


### PR DESCRIPTION
This offers greater control to retry the Docker deployment step in the event that it fails, independently of the release being published. We've observed the network request being fragile during builds, so it is important to be able to retry this step without re-running the release publishing step.

This commit also removes the Travis badge from the README and aligns the naming and formatting in the build workflow with our other projects.