### PR TITLE
fix(ibm-well-defined-dictionaries): include patternProperties in validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-19T16:14:03Z",
+  "generated_at": "2025-01-09T19:49:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -7328,8 +7328,8 @@ paths:
   This rule validates that any dictionary schemas are well defined and that all values share a single type.
   Dictionaries are defined as object type schemas that have variable key names. They are distinct from model types,
   which are objects with pre-defined properties. A schema must not define both concrete properties and variable key names.
-  Practically, this means a schema must explicitly define a `properties` object or an `additionalProperties` schema, but not both.
-  If used, the `additionalProperties` schema must define a concrete type. The concrete type of the values must not be a dictionary itself. See the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types">IBM Cloud API Handbook documentation on types</a> for more info.
+  Practically, this means a schema must explicitly define a `properties` object or an `(additional|pattern)Properties` schema, but not both.
+  If used, the `(additional|pattern)Properties` schema must define a concrete type. The concrete type of the values must not be a dictionary itself. See the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-types">IBM Cloud API Handbook documentation on types</a> for more info.
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Currently, the rule only considers dictionaries defined with `additionalProperties`. OpenAPI 3.1.x supports defining dictionaries with `patternProperties`, so this commit adds consideration for this field in its validation, in addition to `additionalProperties`.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [x] `.secrets.baseline` has been updated as needed
- [x] `npm run generate-utilities-docs` has been run if any files in `packages/utilities/src` have been updated