### PR TITLE
fix: ingore violations from invalid locations of an api definition

### DIFF
--- a/packages/validator/src/spectral/index.js
+++ b/packages/validator/src/spectral/index.js
@@ -71,6 +71,12 @@ function convertResults(spectralResults, { config, logger }) {
       continue;
     }
 
+    // Ingore any rule violations that occur in sections of the spec that are
+    // not valid locations for API validation.
+    if (invalidLocation(r.path)) {
+      continue;
+    }
+
     const severity = convertSpectralSeverity(r.severity);
     // only collect errors when "errors only" is true
     if (errorsOnly && r.severity > 0) {
@@ -223,4 +229,11 @@ function convertSpectralSeverity(s) {
   // we have already guaranteed s to be a number, 0-3
   const mapping = { 0: 'error', 1: 'warning', 2: 'info', 3: 'hint' };
   return mapping[s];
+}
+
+function invalidLocation(pathArray) {
+  // The 'x-sdk-apiref' extension is an IBM internal section for providing
+  // SDK-related metadata. It is not appropriate for the validator to consider.
+  const invalidLocations = ['x-sdk-apiref'];
+  return invalidLocations.some(l => pathArray.includes(l));
 }

--- a/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/err-and-warn.yaml
@@ -210,3 +210,10 @@ components:
     UnusedString:
       description: string
       type: string
+
+x-sdk-apiref:
+  type: int64
+  enum:
+    - this would trigger spectrals 'typed-enum' rule
+    - without our custom filter for invalid openapi locations
+    - this just tests that no warning is emitted for the 'x-sdk-apiref' location


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Some extensions in an API definition, like those providing SDK-related metadata, are not valid places to check for rule violations.

Since some built-in, Spectral rules use broad JSON paths for their rules, it is possible for them to report false positives within extension objects, even when the extension objects contain information that is completely unrelated to the rule (like the typed-enum rule).

To avoid this in a generic way, this change filters out any rule violations that occur within our internal, SDK-related metadata extension and provides for any potential locations that may be added in the future.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run generate-utilities-docs` has been run if any files in `packages/utilities/src` have been updated