### PR TITLE
fix(ibm-use-date-based-format): tighten heuristic for flagging date-time values

### DIFF
--- a/packages/ruleset/test/utils/date-based-utils.test.js
+++ b/packages/ruleset/test/utils/date-based-utils.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 IBM Corporation.
+ * Copyright 2024-2025 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -26,7 +26,11 @@ describe('Date-based utility functions', () => {
       expect(isDateBasedValue('This certificate is good until June 2032')).toBe(
         false
       );
+      expect(
+        isDateBasedValue('0000-0000-0000-0000/abc/2022/2/22/12345678_data.json')
+      ).toBe(false);
       expect(isDateBasedValue('Octopus')).toBe(false);
+      expect(isDateBasedValue('Januaryuary 31')).toBe(false);
       expect(isDateBasedValue('12345678')).toBe(false);
       expect(isDateBasedValue('0001-01-2000')).toBe(false);
       expect(isDateBasedValue('10.1.24.1')).toBe(false);


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
The regular expressions used to determine if a value should be considered a date-time value are too loose and allow false positives to sneak in. It's a tricky problem, but this commit makes an attempt to tighten them by dismissing the possibility of a date-time value if any letters are found that are not relevant to a date-time value.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run generate-utilities-docs` has been run if any files in `packages/utilities/src` have been updated