### PR TITLE
fix(ibm-schema-keywords): include 'examples' in allowlist

### DIFF
--- a/packages/ruleset/src/rules/schema-keywords.js
+++ b/packages/ruleset/src/rules/schema-keywords.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 IBM Corporation.
+ * Copyright 2023-2025 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -30,6 +30,7 @@ module.exports = {
         'discriminator',
         'enum',
         'example',
+        'examples',
         'exclusiveMaximum',
         'exclusiveMinimum',
         'format',

--- a/packages/ruleset/test/rules/schema-keywords.test.js
+++ b/packages/ruleset/test/rules/schema-keywords.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 - 2024 IBM Corporation.
+ * Copyright 2023 - 2025 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -52,6 +52,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
         title: 'options_package',
         uniqueItems: 33,
         unevaluatedProperties: false,
+        examples: [],
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -108,23 +109,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
       for (let i = 0; i < results.length; i++) {
         expect(results[i].code).toBe(ruleId);
         expect(results[i].message).toBe(`${expectedMsgPrefix} $comment`);
-        expect(results[i].severity).toBe(expectedSeverity);
-        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
-      }
-    });
-    it('allOf element schema contains "examples"', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.components.schemas.DrinkCollection.allOf[1].examples = {};
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-      const expectedPaths = [
-        'paths./v1/drinks.get.responses.200.content.application/json.schema.allOf.1.examples',
-      ];
-      for (let i = 0; i < results.length; i++) {
-        expect(results[i].code).toBe(ruleId);
-        expect(results[i].message).toBe(`${expectedMsgPrefix} examples`);
         expect(results[i].severity).toBe(expectedSeverity);
         expect(results[i].path.join('.')).toBe(expectedPaths[i]);
       }


### PR DESCRIPTION
The OpenAPI 3.1 specification states:

> The example property has been deprecated in favor of the JSON Schema examples
> keyword. Use of example is discouraged, and later versions of this
> specification may remove it.

We had previously excluded the use of 'examples' but as the specification is moving away from 'example' completely, we need to support it to allow proper authorship of OpenAPI 3.1.x documents.

This PR is currently in draft mode until internal support for `examples` is delivered.

Resolves #714 