### PR TITLE
feat(ibm-valid-schema-example): introduce new validation rule

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -116,6 +116,7 @@ which is delivered in the `@ibm-cloud/openapi-ruleset` NPM package.
   * [ibm-unique-parameter-request-property-names](#ibm-unique-parameter-request-property-names)
   * [ibm-use-date-based-format](#ibm-use-date-based-format)
   * [ibm-valid-path-segments](#ibm-valid-path-segments)
+  * [ibm-valid-schema-example](#ibm-valid-schema-example)
   * [ibm-well-defined-dictionaries](#ibm-well-defined-dictionaries)
 
 <!-- tocstop -->
@@ -685,6 +686,12 @@ specific "allow-listed" keywords.</td>
 <td><a href="#ibm-valid-path-segments">ibm-valid-path-segments</a></td>
 <td>error</td>
 <td>Checks each path string in the API to make sure path parameter references are valid within path segments.</td>
+<td>oas3</td>
+</tr>
+<tr>
+<td><a href="#ibm-valid-schema-example">ibm-valid-schema-example</a></td>
+<td>warning</td>
+<td>Checks each individual schema example to ensure compliance with the schema.</td>
 <td>oas3</td>
 </tr>
 <tr>
@@ -7315,6 +7322,54 @@ paths:
 </td>
 </tr>
 </table>
+
+
+### ibm-valid-schema-example
+<table>
+<tr>
+<td><b>Rule id:</b></td>
+<td><b>ibm-valid-schema-example</b></td>
+</tr>
+<tr>
+<td valign=top><b>Description:</b></td>
+<td>This rule validates each unique schema and ensures that any example(s) defined
+is a valid instance of that schema.
+</td>
+</tr>
+<tr>
+<td><b>Severity:</b></td>
+<td>warning</td>
+</tr>
+<tr>
+<td><b>OAS Versions:</b></td>
+<td>oas3</td>
+</tr>
+<tr>
+<td valign=top><b>Non-compliant example:<b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Foo:
+      type: string
+      example: 42
+</pre>
+</td>
+</tr>
+<tr>
+<td valign=top><b>Compliant example:</b></td>
+<td>
+<pre>
+components:
+  schemas:
+    Foo:
+      type: string
+      example: 'value'
+</pre>
+</td>
+</tr>
+</table>
+
 
 ### ibm-well-defined-dictionaries
 <table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6921,6 +6921,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -14233,14 +14242,15 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.25.1",
+      "version": "1.28.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset-utilities": "1.5.0",
+        "@ibm-cloud/openapi-ruleset-utilities": "1.7.0",
         "@stoplight/spectral-formats": "^1.8.1",
         "@stoplight/spectral-functions": "^1.9.1",
         "@stoplight/spectral-rulesets": "^1.21.1",
         "chalk": "^4.1.2",
+        "jsonschema": "^1.5.0",
         "lodash": "^4.17.21",
         "loglevel": "^1.9.2",
         "loglevel-plugin-prefix": "0.8.4",
@@ -14279,7 +14289,7 @@
     },
     "packages/utilities": {
       "name": "@ibm-cloud/openapi-ruleset-utilities",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@stoplight/spectral-core": "^1.19.2",
@@ -14291,11 +14301,11 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.29.0",
+      "version": "1.32.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.25.1",
-        "@ibm-cloud/openapi-ruleset-utilities": "1.5.0",
+        "@ibm-cloud/openapi-ruleset": "1.28.4",
+        "@ibm-cloud/openapi-ruleset-utilities": "1.7.0",
         "@stoplight/spectral-cli": "^6.13.1",
         "@stoplight/spectral-core": "^1.19.2",
         "@stoplight/spectral-parsers": "^1.0.4",

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -26,6 +26,7 @@
     "@stoplight/spectral-functions": "^1.9.1",
     "@stoplight/spectral-rulesets": "^1.21.1",
     "chalk": "^4.1.2",
+    "jsonschema": "^1.5.0",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.2",
     "loglevel-plugin-prefix": "0.8.4",

--- a/packages/ruleset/src/functions/index.js
+++ b/packages/ruleset/src/functions/index.js
@@ -80,5 +80,6 @@ module.exports = {
   unusedTags: require('./unused-tags'),
   useDateBasedFormat: require('./use-date-based-format'),
   validatePathSegments: require('./valid-path-segments'),
+  validSchemaExample: require('./valid-schema-example'),
   wellDefinedDictionaries: require('./well-defined-dictionaries'),
 };

--- a/packages/ruleset/src/functions/use-date-based-format.js
+++ b/packages/ruleset/src/functions/use-date-based-format.js
@@ -147,7 +147,10 @@ function checkForDateBasedFormat(s, p, apidef) {
     // order the schemas are checked in (the logic may look at more examples
     // for one instance of a property than another, arbitrarily) and we don't
     // make a guarantee that order will be stable in `validateNestedSchemas`.
-    examples[logicalPath.join('.')] = [...schemaExamples, ...parentalExamples];
+    examples[logicalPath.join('.')] = [
+      ...schemaExamples,
+      ...parentalExamples,
+    ].filter(e => e !== null); // Null values are technically allowed - don't keep them.
 
     // Perform the validation using the first value example value found for the
     // schema at this logical path.

--- a/packages/ruleset/src/functions/valid-schema-example.js
+++ b/packages/ruleset/src/functions/valid-schema-example.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2025 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { validate } = require('jsonschema');
+const { validateSubschemas } = require('@ibm-cloud/openapi-ruleset-utilities');
+const { LoggerFactory } = require('../utils');
+
+let ruleId;
+let logger;
+
+module.exports = function (schema, _opts, context) {
+  if (!logger) {
+    ruleId = context.rule.name;
+    logger = LoggerFactory.getInstance().getLogger(ruleId);
+  }
+
+  return validateSubschemas(schema, context.path, checkSchemaExamples);
+};
+
+function checkSchemaExamples(schema, path) {
+  if (!isDefined(schema.example) && !definesElements(schema.examples)) {
+    return [];
+  }
+
+  const examplesToCheck = [];
+
+  if (definesElements(schema.examples)) {
+    schema.examples.forEach((example, i) => {
+      examplesToCheck.push({
+        schema,
+        example,
+        path: [...path, 'examples', i],
+      });
+    });
+  }
+
+  if (isDefined(schema.example)) {
+    examplesToCheck.push({
+      schema,
+      example: schema.example,
+      path: [...path, 'example'],
+    });
+  }
+
+  return validateExamples(examplesToCheck);
+}
+
+function validateExamples(examples) {
+  return examples
+    .map(({ schema, example, path }) => {
+      // Setting required: true prevents undefined values from passing validation.
+      const { valid, errors } = validate(example, schema, { required: true });
+      if (!valid) {
+        const message = getMessage(errors, example, schema);
+        return {
+          message: `Schema example is not valid: ${message}`,
+          path,
+        };
+      }
+    })
+    .filter(e => isDefined(e));
+}
+
+function isDefined(x) {
+  return x !== undefined;
+}
+
+function definesElements(arr) {
+  return Array.isArray(arr) && arr.length;
+}
+
+function getMessage(errors, example, schema) {
+  let message = getPrimaryErrorMessage(errors);
+
+  const primaryError = errors[0];
+  if (Array.isArray(schema.oneOf) || Array.isArray(schema.anyOf)) {
+    // If a schema has a oneOf or anyOf, jsonschema will supress nested validation
+    // error messages by default. If this is the case, compute those messages and
+    // append them to the primary message (on their own, they don't include context
+    // and thus wouldn't be very helpful).
+    const { errors } = validate(example, schema, { nestedErrors: true });
+    message = appendMessage(message, getPrimaryErrorMessage(errors));
+  } else if (Array.isArray(primaryError.argument?.valid?.errors)) {
+    // Sometimes, jsonschema buries additional error info in the 'argument'
+    // field of the validation result. If so, extract and include it.
+    message = appendMessage(
+      message,
+      getPrimaryErrorMessage(primaryError.argument.valid.errors)
+    );
+  }
+
+  return message;
+}
+
+function getPrimaryErrorMessage(errors) {
+  const { path } = errors[0];
+  let { message } = errors[0];
+
+  // If the violation is nested within an object or array, this field will hold
+  // the path segments to the violation, which is necessary context for the user.
+  if (path.length) {
+    message = `${path.join('.')} ${message}`;
+  }
+
+  // Sometimes, jsonschema appends a confusing message to an error - remove it.
+  return message.replace(/ with \d+ error\[s\]:$/, '');
+}
+
+function appendMessage(msg, app) {
+  return `${msg} (${app})`;
+}

--- a/packages/ruleset/src/ibm-oas.js
+++ b/packages/ruleset/src/ibm-oas.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2024 IBM Corporation.
+ * Copyright 2017 - 2025 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -95,8 +95,8 @@ module.exports = {
     'oas3-server-trailing-slash': true,
     // Enable with warn severity
     'oas3-valid-media-example': 'warn',
-    // Enable with warn severity
-    'oas3-valid-schema-example': 'warn',
+    // Disable - replaced with ibm-valid-schema-example.
+    'oas3-valid-schema-example': 'off',
     // Enable with same severity as Spectral
     'oas3-schema': true,
     // Turn off - duplicates non-configurable validation in base validator
@@ -200,6 +200,7 @@ module.exports = {
       ibmRules.uniqueParameterRequestPropertyNames,
     'ibm-use-date-based-format': ibmRules.useDateBasedFormat,
     'ibm-valid-path-segments': ibmRules.validPathSegments,
+    'ibm-valid-schema-example': ibmRules.validSchemaExample,
     'ibm-well-defined-dictionaries': ibmRules.wellDefinedDictionaries,
   },
 };

--- a/packages/ruleset/src/rules/index.js
+++ b/packages/ruleset/src/rules/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2024 IBM Corporation.
+ * Copyright 2017 - 2025 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -93,5 +93,6 @@ module.exports = {
   uniqueParameterRequestPropertyNames: require('./unique-parameter-request-property-names'),
   useDateBasedFormat: require('./use-date-based-format'),
   validPathSegments: require('./valid-path-segments'),
+  validSchemaExample: require('./valid-schema-example'),
   wellDefinedDictionaries: require('./well-defined-dictionaries'),
 };

--- a/packages/ruleset/src/rules/valid-schema-example.js
+++ b/packages/ruleset/src/rules/valid-schema-example.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2025 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const {
+  schemas,
+} = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+const { oas3 } = require('@stoplight/spectral-formats');
+const { validSchemaExample } = require('../functions');
+
+module.exports = {
+  description:
+    'Schema examples should validate against the schema they are defined for',
+  message: '{{error}}',
+  given: schemas,
+  severity: 'warn',
+  formats: [oas3],
+  resolved: true,
+  then: {
+    function: validSchemaExample,
+  },
+};

--- a/packages/ruleset/src/utils/date-based-utils.js
+++ b/packages/ruleset/src/utils/date-based-utils.js
@@ -122,7 +122,9 @@ function isDateBasedValue(value) {
     /\b(0?[1-9]|1[012])[./-]([012]?[1-9]|3[01])[./-]\d{4}\b/,
 
     // Includes time in the format (T)tt:tt:tt (where t can be s/m/h/etc.)
-    /(\b|T)\d\d:\d\d:\d\d\b/,
+    // In this case, don't consider a colon character a word break, to avoid
+    // matching non-time, colon-separated values like MAC addresses.
+    /(\b|T)\d\d:\d\d:\d\d(\b[^:])/,
   ];
 
   return regularExpressions.some(r => r.test(value));

--- a/packages/ruleset/test/rules/use-date-based-format.test.js
+++ b/packages/ruleset/test/rules/use-date-based-format.test.js
@@ -206,6 +206,40 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
+    it('date/time dictionary with null example', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.Movie.properties.changes = {
+        type: 'object',
+        example: {
+          issues: [
+            {
+              metadata: null,
+            },
+          ],
+        },
+        properties: {
+          issues: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                metadata: {
+                  type: 'object',
+                  additionalProperties: {
+                    type: 'string',
+                    format: 'date-time',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
     it('primitive date/time oneOf schema with example', async () => {
       const testDocument = makeCopy(rootDocument);
       testDocument.components.schemas.Movie.properties.first_completed = {

--- a/packages/ruleset/test/rules/valid-schema-example.test.js
+++ b/packages/ruleset/test/rules/valid-schema-example.test.js
@@ -1,0 +1,434 @@
+/**
+ * Copyright 2025 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { validSchemaExample } = require('../../src/rules');
+const {
+  makeCopy,
+  rootDocument,
+  testRule,
+  severityCodes,
+} = require('../test-utils');
+
+const rule = validSchemaExample;
+const ruleId = 'ibm-valid-schema-example';
+const expectedSeverity = severityCodes.warning;
+const expectedMsgPrefix = 'Schema example is not valid:';
+
+describe(`Spectral rule: ${ruleId}`, () => {
+  describe('Should not yield errors', () => {
+    it('Clean spec', async () => {
+      const results = await testRule(ruleId, rule, rootDocument);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('Should yield errors', () => {
+    const expectedExamplePaths = [
+      'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.properties.prop.example',
+      'paths./v1/movies.post.responses.201.content.application/json.schema.properties.prop.example',
+      'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.properties.prop.example',
+      'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.properties.prop.example',
+    ];
+
+    const expectedExamplesPaths = [
+      'paths./v1/movies.get.responses.200.content.application/json.schema.allOf.1.properties.movies.items.properties.prop.examples.0',
+      'paths./v1/movies.post.responses.201.content.application/json.schema.properties.prop.examples.0',
+      'paths./v1/movies/{movie_id}.get.responses.200.content.application/json.schema.properties.prop.examples.0',
+      'paths./v1/movies/{movie_id}.put.responses.200.content.application/json.schema.properties.prop.examples.0',
+    ];
+
+    it('Schema has undefined example in examples array', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'string',
+        examples: [undefined],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} is not of a type(s) string`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplesPaths[i]);
+      }
+    });
+
+    it('String schema has non-string example', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'string',
+        example: 42,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} is not of a type(s) string`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('String schema has pattern-violating example in examples array', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'string',
+        pattern: '^ibm-.+$',
+        examples: ['bad example', 'ibm-good-example'],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} does not match pattern "^ibm-.+$"`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplesPaths[i]);
+      }
+    });
+
+    it('String schema has minLength-violating example', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'string',
+        minLength: 4,
+        example: 'abc',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} does not meet minimum length of 4`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Number schema has non-number example', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'integer',
+        example: '123',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} is not of a type(s) integer`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Number schema has maximum-violating number example', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'integer',
+        maximum: 100,
+        example: 9000,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} must be less than or equal to 100`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Array schema has example violating nested object schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            metadata: {
+              type: 'string',
+            },
+          },
+        },
+        example: [{ metadata: 42 }],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} 0.metadata is not of a type(s) string`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Object schema has example without required property', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+        },
+        example: { name: 'gollum' },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} requires property "id"`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Object schema has example violating deeply nested object schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'object',
+        properties: {
+          other_prop: {
+            type: 'object',
+            properties: {
+              and_another_prop: {
+                type: 'boolean',
+              },
+            },
+          },
+        },
+        example: { other_prop: { and_another_prop: 42 } },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} other_prop.and_another_prop is not of a type(s) boolean`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Object schema has example that does not match oneOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'object',
+        oneOf: [
+          {
+            title: 'A',
+            type: 'object',
+            properties: {
+              other_prop: {
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+          },
+          {
+            title: 'B',
+            type: 'object',
+            properties: {
+              another_prop: {
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+        properties: {
+          main_prop: {
+            type: 'string',
+          },
+        },
+        example: { main_prop: 'value', other_prop: 'other value' },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} is not exactly one from "A","B" (is not allowed to have the additional property "main_prop")`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Object schema has example that does not match anyOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'object',
+        anyOf: [
+          {
+            title: 'A',
+            type: 'object',
+            properties: {
+              other_prop: {
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+          },
+          {
+            title: 'B',
+            type: 'object',
+            properties: {
+              another_prop: {
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+        example: { other_prop: 42 },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} is not any of "A","B" (other_prop is not of a type(s) string)`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Object allOf schema has primitive example', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'object',
+        allOf: [
+          {
+            title: 'A',
+            type: 'object',
+            properties: {
+              other_prop: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            title: 'B',
+            type: 'object',
+            properties: {
+              another_prop: {
+                type: 'string',
+              },
+            },
+          },
+        ],
+        example: 'my-props.json',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} is not of a type(s) object`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+
+    it('Object allOf schema has violating example', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Movie.properties.prop = {
+        type: 'object',
+        allOf: [
+          {
+            title: 'A',
+            type: 'object',
+            properties: {
+              other_prop: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            title: 'B',
+            type: 'object',
+            properties: {
+              another_prop: {
+                type: 'string',
+              },
+            },
+          },
+        ],
+        example: { other_prop: 42 },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(4);
+
+      for (const i in results) {
+        expect(results[i].code).toBe(ruleId);
+        expect(results[i].message).toBe(
+          `${expectedMsgPrefix} does not match allOf schema "A" (other_prop is not of a type(s) string)`
+        );
+        expect(results[i].severity).toBe(expectedSeverity);
+        expect(results[i].path.join('.')).toBe(expectedExamplePaths[i]);
+      }
+    });
+  });
+});

--- a/packages/ruleset/test/utils/date-based-utils.test.js
+++ b/packages/ruleset/test/utils/date-based-utils.test.js
@@ -35,6 +35,8 @@ describe('Date-based utility functions', () => {
       expect(isDateBasedValue('0001-01-2000')).toBe(false);
       expect(isDateBasedValue('10.1.24.1')).toBe(false);
       expect(isDateBasedValue('10.1.255.1')).toBe(false);
+      expect(isDateBasedValue('02:00:04:00:C4:6A')).toBe(false);
+      expect(isDateBasedValue('02:00:04:00:03:00')).toBe(false);
       expect(isDateBasedValue(undefined)).toBe(false);
       expect(isDateBasedValue(null)).toBe(false);
       expect(isDateBasedValue(42)).toBe(false);

--- a/packages/validator/src/scoring-tool/rubric.js
+++ b/packages/validator/src/scoring-tool/rubric.js
@@ -435,6 +435,11 @@ module.exports = {
     denominator: 'operations',
     categories: ['usability'],
   },
+  'ibm-valid-schema-example': {
+    coefficient: 3,
+    denominator: 'schemas',
+    categories: ['usability'],
+  },
   'ibm-well-defined-dictionaries': {
     coefficient: 30,
     denominator: 'operations',


### PR DESCRIPTION
Introduce a new rule for confirming that schema examples are valid instances of the schemas they are defined on.

This replaces the Spectral rule 'oas3-valid-schema-example', which has reported a number of false positives across IBM APIs.

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run generate-utilities-docs` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [x] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [x] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [x] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [x] Added tests for new rule (packages/ruleset/test/*.test.js)
- [x] Added docs for new rule (docs/ibm-cloud-rules.md)
- [x] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
