### PR TITLE
fix(ibm-use-date-based-format): avoid false positives for mac addresses

### DIFF
--- a/packages/ruleset/src/utils/date-based-utils.js
+++ b/packages/ruleset/src/utils/date-based-utils.js
@@ -122,7 +122,9 @@ function isDateBasedValue(value) {
     /\b(0?[1-9]|1[012])[./-]([012]?[1-9]|3[01])[./-]\d{4}\b/,
 
     // Includes time in the format (T)tt:tt:tt (where t can be s/m/h/etc.)
-    /(\b|T)\d\d:\d\d:\d\d\b/,
+    // In this case, don't consider a colon character a word break, to avoid
+    // matching non-time, colon-separated values like MAC addresses.
+    /(\b|T)\d\d:\d\d:\d\d(\b[^:])/,
   ];
 
   return regularExpressions.some(r => r.test(value));

--- a/packages/ruleset/test/utils/date-based-utils.test.js
+++ b/packages/ruleset/test/utils/date-based-utils.test.js
@@ -35,6 +35,8 @@ describe('Date-based utility functions', () => {
       expect(isDateBasedValue('0001-01-2000')).toBe(false);
       expect(isDateBasedValue('10.1.24.1')).toBe(false);
       expect(isDateBasedValue('10.1.255.1')).toBe(false);
+      expect(isDateBasedValue('02:00:04:00:C4:6A')).toBe(false);
+      expect(isDateBasedValue('02:00:04:00:03:00')).toBe(false);
       expect(isDateBasedValue(undefined)).toBe(false);
       expect(isDateBasedValue(null)).toBe(false);
       expect(isDateBasedValue(42)).toBe(false);


### PR DESCRIPTION
This adjustment to the date-based value heuristic prevents a time from being detected if the word boundary is a colon character. This prevents colon-separated values that might otherwise look like dates, like MAC addresses, from being detected.