### PR TITLE
fix(ibm-use-date-based-format): handle null example values

### DIFF
--- a/packages/ruleset/src/functions/use-date-based-format.js
+++ b/packages/ruleset/src/functions/use-date-based-format.js
@@ -147,7 +147,10 @@ function checkForDateBasedFormat(s, p, apidef) {
     // order the schemas are checked in (the logic may look at more examples
     // for one instance of a property than another, arbitrarily) and we don't
     // make a guarantee that order will be stable in `validateNestedSchemas`.
-    examples[logicalPath.join('.')] = [...schemaExamples, ...parentalExamples];
+    examples[logicalPath.join('.')] = [
+      ...schemaExamples,
+      ...parentalExamples,
+    ].filter(e => e !== null); // Null values are technically allowed - don't keep them.
 
     // Perform the validation using the first value example value found for the
     // schema at this logical path.

--- a/packages/ruleset/test/rules/use-date-based-format.test.js
+++ b/packages/ruleset/test/rules/use-date-based-format.test.js
@@ -206,6 +206,40 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
+    it('date/time dictionary with null example', async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.Movie.properties.changes = {
+        type: 'object',
+        example: {
+          issues: [
+            {
+              metadata: null,
+            },
+          ],
+        },
+        properties: {
+          issues: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                metadata: {
+                  type: 'object',
+                  additionalProperties: {
+                    type: 'string',
+                    format: 'date-time',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
     it('primitive date/time oneOf schema with example', async () => {
       const testDocument = makeCopy(rootDocument);
       testDocument.components.schemas.Movie.properties.first_completed = {


### PR DESCRIPTION
Previously, if the example value given for a property was an explicit 'null', this rule would crash the validator.

This commit filters null examples from the logic so that they won't cause any trouble.