### PR TITLE
build: fix exe build script

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branches": "main",
+  "branches": ["main"],
   "debug": true,
   "plugins": [
     "@semantic-release/commit-analyzer",
@@ -7,19 +7,6 @@
     "@semantic-release/changelog",
     "@semantic-release/npm",
     "@semantic-release/git",
-    [
-      "@semantic-release/exec",
-      {
-        "publishCmd": "npm run pkg"
-      }
-    ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          "bin/*"
-        ]
-      }
-    ]
+    "@semantic-release/github"
   ]
 }

--- a/scripts/create-binaries.sh
+++ b/scripts/create-binaries.sh
@@ -24,7 +24,7 @@ if [[ -e "../ruleset/node_modules/@ibm-cloud" ]]; then
 fi
 
 # Create the executables
-../../node_modules/.bin/pkg --out-path=./bin ./package.json
+../../node_modules/.bin/pkg --out-path=./bin -t node18-linux,node18-win,node18-macos ./package.json
 
 # Rename the executables and set their execute bit.
 cd ./bin


### PR DESCRIPTION
This commit fixes the create-binaries.sh script
by adding the "-t" (targets) option to explicitly
specify the node versions for which the executables should be built.
Because we haven't successfully published the executables in about 9 months (!), I also modified the semantic-release configuration so that we avoid the steps to build and publish the executables.  If we need to add this back later, it should be relatively easy since the create-binaries.sh script is now fixed.