### PR TITLE
fix(ibm-api-symmetry): loosen definition of graph fragment pattern

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -1014,7 +1014,7 @@ components:
 <tr>
 <td valign=top><b>Description:</b></td>
 <td>
-Each resource-representing schema should follow the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-schemas">IBM Cloud API Handbook schema structure conventions</a>. Specifically, this rule ensures that Summary, Prototype, and Patch schemas are proper graph fragments of the canonical schema they are variants of. According to the Handbook, "a graph fragment schema has the same structure as its canonical schema with some properties omitted from the schema or from any nested object schemas."
+Each resource-representing schema should follow the <a href="https://cloud.ibm.com/docs/api-handbook?topic=api-handbook-schemas">IBM Cloud API Handbook schema structure conventions</a>. Specifically, this rule ensures that Summary, Prototype, and Patch schemas are proper graph fragments of the canonical schema they are variants of. According to the Handbook, "a graph fragment schema has the same structure as its canonical schema, but may omit one or more properties from the schema or from any nested object schemas."
 
 This convention ensures that resource-oriented APIs are symmetrical between requests and responses in how resources are represented.
 

--- a/packages/ruleset/src/functions/api-symmetry.js
+++ b/packages/ruleset/src/functions/api-symmetry.js
@@ -7,8 +7,6 @@ const {
   getSchemaType,
   isObject,
   isArraySchema,
-  schemaHasConstraint,
-  schemaLooselyHasConstraint,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const {
@@ -55,8 +53,8 @@ module.exports = function apiSymmetry(apidef, options, context) {
  * symmetry in APIs. Namely, the check verifies that "Summary", "Prototype",
  * and "Patch" schemas are all proper "graph fragments" of their corresponding
  * canonical schema. The API Handbook defines a graph fragment this way:
- * "A graph fragment schema has the same structure as its canonical schema with
- * some properties omitted from the schema or from any nested object schemas."
+ * "A graph fragment schema has the same structure as its canonical schema,
+ * but may omit one or more properties from the schema or from any nested object schemas."
  *
  * @param {*} apidef the entire, resolved API definition as an object
  * @param {*} nodes the spectral-computed graph nodes mapping paths to referenced schemas
@@ -136,7 +134,6 @@ function checkApiForSymmetry(apidef, nodes) {
  * - The variant does not define any nested schemas (including those defined
  *   by arrays or dictionaries) that aren't themselves graph fragments of
  *   the corresponding canonical schema.
- * - The variant omits at least one property from the canonical schema
  *
  * @param {object} variant - the variant schema to check
  * @param {object} canonical - the canonical schema to check against
@@ -154,264 +151,14 @@ function checkForGraphFragmentPattern(
   considerWriteOnly,
   schemaFinder
 ) {
-  let variantOmitsProperties = false;
-
-  // The function is wrapped in a partial so that we can track `variantOmitsProperties`
-  // across the entire schema without overriding it during recursive invocations of the
-  // graph fragment checker.
-
-  function isGraphFragment(variant, canonical, canonicalPath, fromApplicator) {
-    logger.debug(
-      `${ruleId}: entering isGraphFragment(${fromApplicator}, ${canonicalPath.join(
-        '.'
-      )})`
-    );
-    let result = true;
-
-    // Check for simple type equivalency - if the types are not the same,
-    // the graph fragment pattern is violated.
-    if (
-      !fromApplicator &&
-      !canonicalSchemaMeetsConstraint(
-        canonical,
-        canonicalPath,
-        schemaFinder,
-        schema => getSchemaType(variant) === getSchemaType(schema)
-      )
-    ) {
-      infoLogStack.push(
-        `${ruleId}: variant and canonical schemas are different types`
-      );
-      result = false;
-    }
-
-    // Ensure list schemas also maintain a graph fragment structure.
-    if (
-      isObject(variant.items) &&
-      isArraySchema(variant) &&
-      !canonicalSchemaMeetsConstraint(
-        canonical,
-        canonicalPath,
-        schemaFinder,
-        (schema, path) =>
-          isObject(schema.items) &&
-          isGraphFragment(
-            variant.items,
-            schema.items,
-            [...path, 'items'],
-            false
-          )
-      )
-    ) {
-      infoLogStack.push(
-        `${ruleId}: variant is array with schema that is not a graph fragment of canonical items schema`
-      );
-      result = false;
-    }
-
-    // Ensure dictionary schemas also maintain a graph fragment structure
-    // (additional properties).
-    if (
-      variant.additionalProperties &&
-      !canonicalSchemaMeetsConstraint(
-        canonical,
-        canonicalPath,
-        schemaFinder,
-        (schema, path) =>
-          schema.additionalProperties &&
-          isGraphFragment(
-            variant.additionalProperties,
-            schema.additionalProperties,
-            [...path, 'additionalProperties'],
-            false
-          )
-      )
-    ) {
-      infoLogStack.push(
-        `${ruleId}: variant is dictionary with an additionalProperties schema that is not a graph fragment of canonical`
-      );
-      result = false;
-    }
-
-    // Ensure dictionary schemas also maintain a graph fragment structure
-    // (pattern properties).
-    if (
-      isObject(variant.patternProperties) &&
-      !canonicalSchemaMeetsConstraint(
-        canonical,
-        canonicalPath,
-        schemaFinder,
-        (schema, path) =>
-          isObject(schema.patternProperties) &&
-          // This is a little convoluted but it is enforcing that
-          // 1) every pattern in the variant schema is also in canonical
-          //    schema, and
-          // 2) every patterned schema in the variant must be a graph fragment
-          //    of at least one patterned schema in the canonical schema.
-          Object.entries(variant.patternProperties).every(
-            ([variantPattern, variantPatternSchema]) =>
-              Object.keys(schema.patternProperties).includes(variantPattern) &&
-              Object.entries(schema.patternProperties).some(
-                ([canonPattern, canonPatternSchema]) =>
-                  isGraphFragment(
-                    variantPatternSchema,
-                    canonPatternSchema,
-                    [...path, 'patternProperties', canonPattern],
-                    false
-                  )
-              )
-          )
-      )
-    ) {
-      infoLogStack.push(
-        `${ruleId}: variant is dictionary with a patternProperties schema that is not a graph fragment of canonical`
-      );
-      result = false;
-    }
-
-    // If the variant schema (or sub-schema) has properties, ensure that each
-    // property is defined *somewhere* on the corresponding canonical schema
-    // (or sub-schema) and ensure it is also a valid graph fragment of the
-    // corresponding property in the canonical schema.
-    //
-    // We use a looser contraint-checking function here because it is
-    // sufficient for "one of" or "any of" the canonical schemas to define the
-    // property defined on the variant schema, and we need to resolve reference
-    // schemas on the fly each time we check the canonical schema for a constraint.
-    if (isObject(variant.properties)) {
-      for (const [name, prop] of Object.entries(variant.properties)) {
-        let propExistsSomewhere = false;
-
-        const valid = canonicalSchemaMeetsConstraint(
-          canonical,
-          canonicalPath,
-          schemaFinder,
-          (schema, path) => {
-            const exists =
-              'properties' in schema && isObject(schema.properties[name]);
-            propExistsSomewhere = propExistsSomewhere || exists;
-
-            return (
-              exists &&
-              isGraphFragment(
-                prop,
-                schema.properties[name],
-                [...path, 'properties', name],
-                false
-              )
-            );
-          }
-        );
-
-        // Note: Prototype schemas are allowed to define writeOnly properties
-        // that don't exist on the canonical schema.
-        if (!valid && !(considerWriteOnly && prop.writeOnly)) {
-          infoLogStack.push(
-            propExistsSomewhere
-              ? `${ruleId}: nested object property ${name} is not a graph fragment of canonical property ${name}`
-              : `${ruleId}: property '${name}' does not exist on the canonical schema`
-          );
-          result = false;
-        }
-      }
-    }
-
-    // All applicator schemas of the schema (or sub-schema) variant should be valid
-    // graph fragments of the corresponding canonical schema (or sub-schema).
-    ['allOf', 'oneOf', 'anyOf'].forEach(applicator => {
-      if (
-        Array.isArray(variant[applicator]) &&
-        variant[applicator].length > 0 &&
-        !variant[applicator].reduce(
-          (previousResult, v) =>
-            previousResult &&
-            isGraphFragment(v, canonical, canonicalPath, true),
-          true
-        )
-      ) {
-        infoLogStack.push(
-          `${ruleId}: variant schema applicator '${applicator}' is not a graph fragment of the canonical schema`
-        );
-        result = false;
-      }
-    });
-
-    // To be a proper graph fragment, at least one property needs to be omitted
-    // from the schema structure. Check to make sure this is the case.
-    //
-    // For this, variant schemas need to be taken as a whole (as opposed to
-    // looking at each applicator schema individually, if they exist) so  we
-    // skip this check if we're currently processing a variant applicator
-    // schema.
-    //
-    // If we've already determined that the variant schema omits at least one
-    // property, we don't need to re-perform this check anymore.
-    //
-    // Note: we don't bother checking for reference schemas here because there
-    // should be differences other than omitting non-reference properties.
-
-    if (!fromApplicator && !variantOmitsProperties) {
-      logger.debug(
-        `${ruleId}: checking that variant schema is a proper subset of canonical schema`
-      );
-
-      const propertyOmitted = schemaHasConstraint(canonical, c => {
-        if (c && isObject(c.properties)) {
-          let omitted = false;
-          for (const [name, prop] of Object.entries(c.properties)) {
-            logger.debug(`${ruleId}: checking canonical property '${name}'`);
-
-            const included = schemaLooselyHasConstraint(
-              variant,
-              s =>
-                'properties' in s &&
-                isObject(s.properties[name]) &&
-                getSchemaType(s.properties[name]) === getSchemaType(prop)
-            );
-
-            logger.debug(
-              `${ruleId}: finished checking canonical property '${name}', included=${included}`
-            );
-
-            if (!included) {
-              omitted = true;
-              logger.debug(
-                `${ruleId}: canonical property ${name} is NOT present in variant schema`
-              );
-              break;
-            } else {
-              logger.debug(
-                `${ruleId}: canonical property ${name} is present in variant schema`
-              );
-            }
-          }
-
-          return omitted;
-        }
-        return false;
-      });
-
-      if (propertyOmitted) {
-        variantOmitsProperties = true;
-      }
-      logger.debug(
-        `${ruleId}: finished checking for omitted properties, propertyOmitted=${propertyOmitted}`
-      );
-    } else {
-      logger.debug(`${ruleId}: bypassing omitted properties check`);
-    }
-
-    logger.debug(`${ruleId}: exiting isGraphFragment, result=${result}`);
-
-    return result;
-  }
-
   // Invoke primary algorithm.
   const variantIsGraphFragment = isGraphFragment(
     variant,
     canonical,
     canonicalPath,
-    false
+    false,
+    considerWriteOnly,
+    schemaFinder
   );
 
   // Print the logs gathered within the `isGraphFragment` function,
@@ -421,16 +168,213 @@ function checkForGraphFragmentPattern(
   }
 
   logger.debug(
-    `${ruleId}: isGraphFragment() returned [${variantIsGraphFragment},${variantOmitsProperties}]`
+    `${ruleId}: isGraphFragment() returned ${variantIsGraphFragment}`
   );
 
-  if (!variantOmitsProperties) {
-    logger.info(
-      `${ruleId}: variant schema properties are not a proper subset of the canonical schema properties (no properties omitted)`
+  return variantIsGraphFragment;
+}
+
+function isGraphFragment(
+  variant,
+  canonical,
+  canonicalPath,
+  fromApplicator,
+  considerWriteOnly,
+  schemaFinder
+) {
+  logger.debug(
+    `${ruleId}: entering isGraphFragment(${fromApplicator}, ${canonicalPath.join(
+      '.'
+    )})`
+  );
+  let result = true;
+
+  // Check for simple type equivalency - if the types are not the same,
+  // the graph fragment pattern is violated.
+  if (
+    !fromApplicator &&
+    !canonicalSchemaMeetsConstraint(
+      canonical,
+      canonicalPath,
+      schemaFinder,
+      schema => getSchemaType(variant) === getSchemaType(schema)
+    )
+  ) {
+    infoLogStack.push(
+      `${ruleId}: variant and canonical schemas are different types`
     );
+    result = false;
   }
 
-  return variantIsGraphFragment && variantOmitsProperties;
+  // Ensure list schemas also maintain a graph fragment structure.
+  if (
+    isObject(variant.items) &&
+    isArraySchema(variant) &&
+    !canonicalSchemaMeetsConstraint(
+      canonical,
+      canonicalPath,
+      schemaFinder,
+      (schema, path) =>
+        isObject(schema.items) &&
+        isGraphFragment(
+          variant.items,
+          schema.items,
+          [...path, 'items'],
+          false,
+          considerWriteOnly,
+          schemaFinder
+        )
+    )
+  ) {
+    infoLogStack.push(
+      `${ruleId}: variant is array with schema that is not a graph fragment of canonical items schema`
+    );
+    result = false;
+  }
+
+  // Ensure dictionary schemas also maintain a graph fragment structure
+  // (additional properties).
+  if (
+    variant.additionalProperties &&
+    !canonicalSchemaMeetsConstraint(
+      canonical,
+      canonicalPath,
+      schemaFinder,
+      (schema, path) =>
+        schema.additionalProperties &&
+        isGraphFragment(
+          variant.additionalProperties,
+          schema.additionalProperties,
+          [...path, 'additionalProperties'],
+          false,
+          considerWriteOnly,
+          schemaFinder
+        )
+    )
+  ) {
+    infoLogStack.push(
+      `${ruleId}: variant is dictionary with an additionalProperties schema that is not a graph fragment of canonical`
+    );
+    result = false;
+  }
+
+  // Ensure dictionary schemas also maintain a graph fragment structure
+  // (pattern properties).
+  if (
+    isObject(variant.patternProperties) &&
+    !canonicalSchemaMeetsConstraint(
+      canonical,
+      canonicalPath,
+      schemaFinder,
+      (schema, path) =>
+        isObject(schema.patternProperties) &&
+        // This is a little convoluted but it is enforcing that
+        // 1) every pattern in the variant schema is also in canonical
+        //    schema, and
+        // 2) every patterned schema in the variant must be a graph fragment
+        //    of at least one patterned schema in the canonical schema.
+        Object.entries(variant.patternProperties).every(
+          ([variantPattern, variantPatternSchema]) =>
+            Object.keys(schema.patternProperties).includes(variantPattern) &&
+            Object.entries(schema.patternProperties).some(
+              ([canonPattern, canonPatternSchema]) =>
+                isGraphFragment(
+                  variantPatternSchema,
+                  canonPatternSchema,
+                  [...path, 'patternProperties', canonPattern],
+                  false,
+                  considerWriteOnly,
+                  schemaFinder
+                )
+            )
+        )
+    )
+  ) {
+    infoLogStack.push(
+      `${ruleId}: variant is dictionary with a patternProperties schema that is not a graph fragment of canonical`
+    );
+    result = false;
+  }
+
+  // If the variant schema (or sub-schema) has properties, ensure that each
+  // property is defined *somewhere* on the corresponding canonical schema
+  // (or sub-schema) and ensure it is also a valid graph fragment of the
+  // corresponding property in the canonical schema.
+  //
+  // We use a looser contraint-checking function here because it is
+  // sufficient for "one of" or "any of" the canonical schemas to define the
+  // property defined on the variant schema, and we need to resolve reference
+  // schemas on the fly each time we check the canonical schema for a constraint.
+  if (isObject(variant.properties)) {
+    for (const [name, prop] of Object.entries(variant.properties)) {
+      let propExistsSomewhere = false;
+
+      const valid = canonicalSchemaMeetsConstraint(
+        canonical,
+        canonicalPath,
+        schemaFinder,
+        (schema, path) => {
+          const exists =
+            'properties' in schema && isObject(schema.properties[name]);
+          propExistsSomewhere = propExistsSomewhere || exists;
+
+          return (
+            exists &&
+            isGraphFragment(
+              prop,
+              schema.properties[name],
+              [...path, 'properties', name],
+              false,
+              considerWriteOnly,
+              schemaFinder
+            )
+          );
+        }
+      );
+
+      // Note: Prototype schemas are allowed to define writeOnly properties
+      // that don't exist on the canonical schema.
+      if (!valid && !(considerWriteOnly && prop.writeOnly)) {
+        infoLogStack.push(
+          propExistsSomewhere
+            ? `${ruleId}: nested object property ${name} is not a graph fragment of canonical property ${name}`
+            : `${ruleId}: property '${name}' does not exist on the canonical schema`
+        );
+        result = false;
+      }
+    }
+  }
+
+  // All applicator schemas of the schema (or sub-schema) variant should be valid
+  // graph fragments of the corresponding canonical schema (or sub-schema).
+  ['allOf', 'oneOf', 'anyOf'].forEach(applicator => {
+    if (
+      Array.isArray(variant[applicator]) &&
+      variant[applicator].length > 0 &&
+      !variant[applicator].reduce(
+        (previousResult, v) =>
+          previousResult &&
+          isGraphFragment(
+            v,
+            canonical,
+            canonicalPath,
+            true,
+            considerWriteOnly,
+            schemaFinder
+          ),
+        true
+      )
+    ) {
+      infoLogStack.push(
+        `${ruleId}: variant schema applicator '${applicator}' is not a graph fragment of the canonical schema`
+      );
+      result = false;
+    }
+  });
+
+  logger.debug(`${ruleId}: exiting isGraphFragment, result=${result}`);
+
+  return result;
 }
 
 /**

--- a/packages/ruleset/test/rules/api-symmetry.test.js
+++ b/packages/ruleset/test/rules/api-symmetry.test.js
@@ -756,6 +756,59 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
+    it('prototype schema is identical to canonical schema (no omitted properties)', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkPrototype =
+        testDocument.components.schemas.Drink;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('prototype schema is identical to canonical - properties nested in oneOf', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Soda.properties.id = {
+        type: 'string',
+      };
+
+      testDocument.components.schemas.Juice.properties.id = {
+        type: 'string',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('prototype schema is identical to canonical but defines writeOnly properties', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.DrinkPrototype = makeCopy(
+        testDocument.components.schemas.Drink
+      );
+
+      testDocument.components.schemas.DrinkPrototype.properties.random = {
+        type: 'string',
+        description: 'the only differentiator',
+        writeOnly: true,
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
+    it('patch schema is identical to canonical schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.CarPatch.properties.id = {
+        type: 'string',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
     // Already covered in root document:
     // - Valid Prototype schemas
     // - Valid Patch schemas
@@ -980,47 +1033,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
       }
     });
 
-    it('prototype schema is identical to canonical schema (no omitted properties)', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.components.schemas.DrinkPrototype =
-        testDocument.components.schemas.Drink;
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-
-      const expectedPaths = ['components.schemas.DrinkPrototype'];
-      for (const i in results) {
-        expect(results[i].code).toBe(ruleId);
-        expect(results[i].message).toBe(expectedMsg);
-        expect(results[i].severity).toBe(expectedSeverity);
-        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
-      }
-    });
-
-    it('prototype schema is identical to canonical - properties nested in oneOf', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.components.schemas.Soda.properties.id = {
-        type: 'string',
-      };
-
-      testDocument.components.schemas.Juice.properties.id = {
-        type: 'string',
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-
-      const expectedPaths = ['components.schemas.DrinkPrototype'];
-      for (const i in results) {
-        expect(results[i].code).toBe(ruleId);
-        expect(results[i].message).toBe(expectedMsg);
-        expect(results[i].severity).toBe(expectedSeverity);
-        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
-      }
-    });
-
     it('prototype schema defines property that exists in canonical but uses wrong type', async () => {
       const testDocument = makeCopy(rootDocument);
 
@@ -1070,50 +1082,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
 
       const expectedPaths = ['components.schemas.DrinkPrototype'];
-      for (const i in results) {
-        expect(results[i].code).toBe(ruleId);
-        expect(results[i].message).toBe(expectedMsg);
-        expect(results[i].severity).toBe(expectedSeverity);
-        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
-      }
-    });
-
-    it('prototype schema is identical to canonical but defines writeOnly properties', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.components.schemas.DrinkPrototype = makeCopy(
-        testDocument.components.schemas.Drink
-      );
-
-      testDocument.components.schemas.DrinkPrototype.properties.random = {
-        type: 'string',
-        description: 'the only differentiator',
-        writeOnly: true,
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-
-      const expectedPaths = ['components.schemas.DrinkPrototype'];
-      for (const i in results) {
-        expect(results[i].code).toBe(ruleId);
-        expect(results[i].message).toBe(expectedMsg);
-        expect(results[i].severity).toBe(expectedSeverity);
-        expect(results[i].path.join('.')).toBe(expectedPaths[i]);
-      }
-    });
-
-    it('patch schema is identical to canonical schema', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      testDocument.components.schemas.CarPatch.properties.id = {
-        type: 'string',
-      };
-
-      const results = await testRule(ruleId, rule, testDocument);
-      expect(results).toHaveLength(1);
-
-      const expectedPaths = ['components.schemas.CarPatch'];
       for (const i in results) {
         expect(results[i].code).toBe(ruleId);
         expect(results[i].message).toBe(expectedMsg);

--- a/packages/validator/test/cli-validator/tests/error-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/error-handling.test.js
@@ -109,7 +109,7 @@ describe('cli tool - test error handling', function () {
       '[ERROR] Invalid input file: ./test/cli-validator/mock-files/bad-json.json. See below for details.'
     );
     expect(capturedText[4].trim()).toMatch(
-      /^\[ERROR\] SyntaxError:.*in JSON at position 14$/
+      /^\[ERROR\] SyntaxError:.*in JSON at position 14/
     );
   });
 


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

Specifically, don't require that properties are omitted from a variant schema in order to consider it a proper graph fragment.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
