### PR TITLE
fix(ibm-api-symmetry): handle dependencies between canonical and reference schemas

### DIFF
--- a/packages/ruleset/test/rules/api-symmetry.test.js
+++ b/packages/ruleset/test/rules/api-symmetry.test.js
@@ -809,6 +809,49 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
+    it('canonical schema contains nested reference to reference schema', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.components.schemas.Actor = {
+        type: 'object',
+        allOf: [
+          { $ref: '#/components/schemas/ActorReference' },
+          {
+            properties: {
+              name: { type: 'string' },
+              gender: { type: 'string' },
+              age: { type: 'integer' },
+            },
+          },
+        ],
+      };
+      testDocument.components.schemas.ActorReference = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+      testDocument.components.schemas.ActorPrototype = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          gender: { type: 'string' },
+          age: { type: 'integer' },
+        },
+      };
+
+      testDocument.components.schemas.Movie.properties.lead_role = {
+        $ref: '#/components/schemas/Actor',
+      };
+
+      testDocument.components.schemas.MoviePrototype.properties.lead_role = {
+        $ref: '#/components/schemas/ActorPrototype',
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
+
     // Already covered in root document:
     // - Valid Prototype schemas
     // - Valid Patch schemas


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

Previously, if a canonical schema contained a reference to its corresponding reference schema, it would create an infinite cycle when the rule tried to resolve a reference schema into its corresponding canonical schema.

This commit adds logic to detect that scenario and prevent the cycle.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)