### PR TITLE
fix(ibm-valid-schema-example): support circular references in schemas

### DIFF
--- a/docs/openapi-ruleset-utilities.md
+++ b/docs/openapi-ruleset-utilities.md
@@ -354,6 +354,39 @@ for OpenAPI documents where a `required` property is not defined under the `prop
 
 #### Returns `boolean`
 
+### `getResolvedSpec(context)`
+
+Returns the programmatic representation of an OpenAPI document, stored in the
+Spectral-created "context" object, with all non-circular references resolved.
+
+#### Parameters
+
+- **`context`** `<object>`: passed as an argument to Spectral-based rule functions
+
+#### Returns `object`: the resolved version of an OpenAPI document
+
+### `getUnresolvedSpec(context)`
+
+Returns the programmatic representation of an OpenAPI document, stored in
+the Spectral-created "context" object, with all references still intact.
+
+#### Parameters
+
+- **`context`** `<object>`: passed as an argument to Spectral-based rule functions
+
+#### Returns `object`: the unresolved version of an OpenAPI document
+
+### `getNodes(context)`
+
+Returns the graph nodes, with information about references and the locations
+they resolve to, that are computed by the Spectral resolver.
+
+#### Parameters
+
+- **`context`** `<object>`: passed as an argument to Spectral-based rule functions
+
+#### Returns `object`: the graph nodes
+
 ### `validateComposedSchemas(schema, path, validate, includeSelf, includeNot)`
 
 Performs validation on a schema and all of its composed schemas.

--- a/packages/ruleset/src/functions/api-symmetry.js
+++ b/packages/ruleset/src/functions/api-symmetry.js
@@ -4,6 +4,7 @@
  */
 
 const {
+  getNodes,
   getSchemaType,
   isObject,
   isArraySchema,
@@ -46,7 +47,7 @@ module.exports = function apiSymmetry(apidef, options, context) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
   }
-  return checkApiForSymmetry(apidef, context.documentInventory.graph.nodes);
+  return checkApiForSymmetry(apidef, getNodes(context));
 };
 
 /**

--- a/packages/ruleset/src/functions/collection-array-property.js
+++ b/packages/ruleset/src/functions/collection-array-property.js
@@ -7,6 +7,7 @@ const {
   schemaHasConstraint,
   isArraySchema,
   isObject,
+  getUnresolvedSpec,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 const { LoggerFactory } = require('../utils');
 
@@ -21,7 +22,7 @@ module.exports = function (schema, _opts, context) {
   return collectionArrayProperty(
     schema,
     context.path,
-    context.document.parserResult.data
+    getUnresolvedSpec(context)
   );
 };
 

--- a/packages/ruleset/src/functions/request-and-response-content.js
+++ b/packages/ruleset/src/functions/request-and-response-content.js
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+const {
+  isObject,
+  getResolvedSpec,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
 const {
   LoggerFactory,
   pathHasMinimallyRepresentedResource,
@@ -29,11 +32,7 @@ module.exports = function requestAndResponseContent(
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
   }
-  return checkForContent(
-    operation,
-    context.path,
-    context.documentInventory.resolved
-  );
+  return checkForContent(operation, context.path, getResolvedSpec(context));
 };
 
 /**

--- a/packages/ruleset/src/functions/resource-response-consistency.js
+++ b/packages/ruleset/src/functions/resource-response-consistency.js
@@ -4,7 +4,11 @@
  */
 
 const { isEqual } = require('lodash');
-const { isObject } = require('@ibm-cloud/openapi-ruleset-utilities');
+const {
+  isObject,
+  getResolvedSpec,
+  getNodes,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
 const {
   computeRefsAtPaths,
   getResourceSpecificSiblingPath,
@@ -29,8 +33,8 @@ module.exports = function (operation, _opts, context) {
   return resourceResponseConsistency(
     operation,
     context.path,
-    context.documentInventory.resolved,
-    context.documentInventory.graph.nodes
+    getResolvedSpec(context),
+    getNodes(context)
   );
 };
 

--- a/packages/ruleset/src/functions/response-status-codes.js
+++ b/packages/ruleset/src/functions/response-status-codes.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
+const { getResolvedSpec } = require('@ibm-cloud/openapi-ruleset-utilities');
 const {
   LoggerFactory,
   isCreateOperation,
@@ -21,11 +22,7 @@ module.exports = function (operation, _opts, context) {
     logger = LoggerFactory.getInstance().getLogger(ruleId);
   }
 
-  return responseStatusCodes(
-    operation,
-    context.path,
-    context.documentInventory.resolved
-  );
+  return responseStatusCodes(operation, context.path, getResolvedSpec(context));
 };
 
 /**

--- a/packages/ruleset/src/functions/schema-naming-convention.js
+++ b/packages/ruleset/src/functions/schema-naming-convention.js
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
-const { schemaHasProperty } = require('@ibm-cloud/openapi-ruleset-utilities');
+const {
+  schemaHasProperty,
+  getNodes,
+} = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const {
   LoggerFactory,
@@ -40,7 +43,7 @@ module.exports = function schemaNames(apidef, options, context) {
     ruleId = context.rule.name;
     logger = LoggerFactory.getInstance().getLogger(ruleId);
   }
-  return checkSchemaNames(apidef, context.documentInventory.graph.nodes);
+  return checkSchemaNames(apidef, getNodes(context));
 };
 
 /**

--- a/packages/ruleset/src/functions/use-date-based-format.js
+++ b/packages/ruleset/src/functions/use-date-based-format.js
@@ -11,6 +11,7 @@ const {
   isObject,
   isStringSchema,
   validateNestedSchemas,
+  getResolvedSpec,
 } = require('@ibm-cloud/openapi-ruleset-utilities');
 
 const {
@@ -48,7 +49,7 @@ module.exports = function (schema, _opts, context) {
   return checkForDateBasedFormat(
     schema,
     context.path,
-    context.documentInventory.resolved
+    getResolvedSpec(context)
   );
 };
 

--- a/packages/utilities/src/utils/index.js
+++ b/packages/utilities/src/utils/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 - 2024 IBM Corporation.
+ * Copyright 2017 - 2025 IBM Corporation.
  * SPDX-License-Identifier: Apache2.0
  */
 
@@ -13,6 +13,7 @@ module.exports = {
   schemaHasProperty: require('./schema-has-property'),
   schemaLooselyHasConstraint: require('./schema-loosely-has-constraint'),
   schemaRequiresProperty: require('./schema-requires-property'),
+  ...require('./spectral-context-utils'),
   validateComposedSchemas: require('./validate-composed-schemas'),
   validateNestedSchemas: require('./validate-nested-schemas'),
   validateSubschemas: require('./validate-subschemas'),

--- a/packages/utilities/src/utils/spectral-context-utils.js
+++ b/packages/utilities/src/utils/spectral-context-utils.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2025 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+/**
+ * Returns the programmatic representation of an OpenAPI document, stored in the
+ * Spectral-created "context" object, with all non-circular references resolved.
+ * @param {object} context passed as an argument to Spectral-based rule functions
+ * @returns {object} the resolved version of an OpenAPI document
+ */
+function getResolvedSpec(context) {
+  return context.documentInventory.resolved;
+}
+
+/**
+ * Returns the programmatic representation of an OpenAPI document, stored in
+ * the Spectral-created "context" object, with all references still intact.
+ * @param {object} context passed as an argument to Spectral-based rule functions
+ * @returns {object} the unresolved version of an OpenAPI document
+ */
+function getUnresolvedSpec(context) {
+  return context.document.parserResult.data;
+}
+
+/**
+ * Returns the graph nodes, with information about references and the locations
+ * they resolve to, that are computed by the Spectral resolver.
+ * @param {object} context passed as an argument to Spectral-based rule functions
+ * @returns {object} the graph nodes
+ */
+function getNodes(context) {
+  return context.documentInventory.graph.nodes;
+}
+
+module.exports = {
+  getNodes,
+  getResolvedSpec,
+  getUnresolvedSpec,
+};

--- a/packages/utilities/test/spectral-context-utils.test.js
+++ b/packages/utilities/test/spectral-context-utils.test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { getNodes, getResolvedSpec, getUnresolvedSpec } = require('../src');
+
+describe('Utility functions: Spectral Context Utils', () => {
+  const mockSpectralContextObject = {
+    documentInventory: {
+      resolved: 'resolved spec',
+      graph: {
+        nodes: 'graph nodes',
+      },
+    },
+    document: {
+      parserResult: {
+        data: 'unresolved spec',
+      },
+    },
+  };
+
+  describe('getNodes', () => {
+    it('should return graph nodes from context object', async () => {
+      expect(getNodes(mockSpectralContextObject)).toBe('graph nodes');
+    });
+  });
+
+  describe('getResolvedSpec', () => {
+    it('should return graph nodes from context object', async () => {
+      expect(getResolvedSpec(mockSpectralContextObject)).toBe('resolved spec');
+    });
+  });
+
+  describe('getUnresolvedSpec', () => {
+    it('should return graph nodes from context object', async () => {
+      expect(getUnresolvedSpec(mockSpectralContextObject)).toBe(
+        'unresolved spec'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR summary

This rule would previously fail if it tried to validate the example for
a schema that contains a circular reference (i.e. defines a schema cycle)
because the ref resolver leaves these schemas with unresolved refs.
The JSON Schema validator tries to resolve the references but can't find
them, so it fails. This commit unconditionally adds the components from
the OpenAPI definition to the schema so that the JSON Schema parser can
find references if it needs to.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)

