### PR TITLE
Fix minor problems with utility collections and add tests

### DIFF
--- a/packages/utilities/src/collections/index.js
+++ b/packages/utilities/src/collections/index.js
@@ -58,9 +58,11 @@ const collections = {
     `$.paths[*][parameters][*].schema`,
     `$.paths[*][parameters][*].content[*].schema`,
     `${operations[0]}[parameters][*].schema`,
-    `${operations[0]}[parameters,responses][*].content[*].schema`,
+    `${operations[0]}[parameters][*].content[*].schema`,
     `${operations[0]}.responses[*].headers[*].schema`,
+    `${operations[0]}.responses[*].headers[*].content[*].schema`,
     ...requestBodySchemas,
+    ...responseSchemas,
   ],
   /**
    * locations of security scheme definitions

--- a/packages/utilities/test/collections.test.js
+++ b/packages/utilities/test/collections.test.js
@@ -1,0 +1,1267 @@
+/**
+ * Copyright 2025 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const { collections } = require('../src');
+const testRulePaths = require('./utils/test-rule-paths');
+
+describe('Collections', () => {
+  describe('operations', () => {
+    const methods = [
+      'get',
+      'put',
+      'post',
+      'delete',
+      'options',
+      'head',
+      'patch',
+      'trace',
+    ];
+    for (const method of methods) {
+      it(`should find ${method} operations`, async () => {
+        const doc = { paths: { '/': { [method]: {} } } };
+        const visitedPaths = await testRulePaths(collections.operations, doc);
+
+        expect(visitedPaths).toEqual([['paths', '/', method]]);
+      });
+    }
+
+    it(`should not find non-operations in a path item`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            summary: 'foo',
+            description: 'bar',
+            servers: [{ url: 'https://api.example.com/v1' }],
+            parameters: [{ name: 'baz', in: 'query' }],
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.operations, doc);
+
+      expect(visitedPaths.length).toEqual(0);
+    });
+  });
+
+  describe('parameters', () => {
+    it(`should find path parameters`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            parameters: [{}],
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.parameters, doc);
+
+      expect(visitedPaths.sort()).toEqual([['paths', '/', 'parameters', 0]]);
+    });
+    it(`should find operation parameters`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              parameters: [{}],
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.parameters, doc);
+
+      expect(visitedPaths.sort()).toEqual([
+        ['paths', '/', 'post', 'parameters', 0],
+      ]);
+    });
+    it(`should not find unreferenced parameters`, async () => {
+      const doc = {
+        components: {
+          parameters: [{}],
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.parameters, doc);
+
+      expect(visitedPaths.length).toEqual(0);
+    });
+  });
+
+  describe('patchOperations', () => {
+    it(`should find patch operations`, async () => {
+      const doc = { paths: { '/': { patch: {} } } };
+
+      const visitedPaths = await testRulePaths(
+        collections.patchOperations,
+        doc
+      );
+
+      expect(visitedPaths).toEqual([['paths', '/', 'patch']]);
+    });
+    it(`should not find non-patch operations`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            get: {},
+            put: {},
+            post: {},
+            delete: {},
+            options: {},
+            head: {},
+            trace: {},
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.patchOperations,
+        doc
+      );
+
+      expect(visitedPaths.length).toEqual(0);
+    });
+  });
+
+  describe('paths', () => {
+    it(`should find paths`, async () => {
+      const doc = {
+        paths: {
+          '/1': {},
+          '/2': {},
+          '/3': {},
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.paths, doc);
+
+      expect(visitedPaths).toEqual([
+        ['paths', '/1'],
+        ['paths', '/2'],
+        ['paths', '/3'],
+      ]);
+    });
+  });
+
+  describe('requestBodySchemas', () => {
+    it(`should find request body schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {},
+                  },
+                  'application/xml': {
+                    schema: {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.requestBodySchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+  });
+
+  describe('responseSchemas', () => {
+    it(`should find response body schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                    'application/xml': {
+                      schema: {},
+                    },
+                  },
+                },
+                '4xx': {
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                    'application/xml': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.responseSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '4xx',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '4xx',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+  });
+
+  describe('schemas', () => {
+    it(`should find operation parameter schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              parameters: [{ schema: {} }],
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.schemas, doc);
+
+      expect(visitedPaths.sort()).toEqual(
+        [['paths', '/', 'post', 'parameters', 0, 'schema']].sort()
+      );
+    });
+    it(`should find operation parameter content schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              parameters: [{ content: { 'application/json': { schema: {} } } }],
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.schemas, doc);
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'parameters',
+            0,
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find path parameter schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            parameters: [{ schema: {} }],
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.schemas, doc);
+
+      expect(visitedPaths.sort()).toEqual(
+        [['paths', '/', 'parameters', 0, 'schema']].sort()
+      );
+    });
+    it(`should find path parameter content schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            parameters: [{ content: { 'application/json': { schema: {} } } }],
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.schemas, doc);
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'parameters',
+            0,
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find response header schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  headers: {
+                    Foo: {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.schemas, doc);
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'headers',
+            'Foo',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find response header content schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  headers: {
+                    Foo: {
+                      content: {
+                        'application/json': {
+                          schema: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.schemas, doc);
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'headers',
+            'Foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find request body schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {},
+                  },
+                  'application/xml': {
+                    schema: {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(collections.schemas, doc);
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find response body schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                    'application/xml': {
+                      schema: {},
+                    },
+                  },
+                },
+                '4xx': {
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                    'application/xml': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.responseSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '4xx',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '4xx',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+  });
+
+  describe('securitySchemes', () => {
+    it(`should find security schemes`, async () => {
+      const doc = {
+        components: {
+          securitySchemes: {
+            foo: {},
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.securitySchemes,
+        doc
+      );
+
+      expect(visitedPaths).toEqual([['components', 'securitySchemes', 'foo']]);
+    });
+  });
+
+  describe('unresolvedRequestBodySchemas', () => {
+    it(`should find request body schemas in operations`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {},
+                  },
+                  'application/xml': {
+                    schema: {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedRequestBodySchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find request body schemas in components`, async () => {
+      const doc = {
+        components: {
+          requestBodies: {
+            foo: {
+              content: {
+                'application/json': {
+                  schema: {},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedRequestBodySchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'components',
+            'requestBodies',
+            'foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+  });
+
+  describe('unresolvedResponseSchemas', () => {
+    it(`should find response body schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedResponseSchemas,
+        doc
+      );
+
+      expect(visitedPaths).toEqual([
+        [
+          'paths',
+          '/',
+          'post',
+          'responses',
+          '200',
+          'content',
+          'application/json',
+          'schema',
+        ],
+      ]);
+    });
+    it(`should find response body schemas in components`, async () => {
+      const doc = {
+        components: {
+          responses: {
+            foo: {
+              content: {
+                'application/json': {
+                  schema: {},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedResponseSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'components',
+            'responses',
+            'foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+  });
+
+  describe('unresolvedSchemas', () => {
+    it(`should find parameter schemas in operations`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              parameters: [{ schema: {} }],
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [['paths', '/', 'post', 'parameters', 0, 'schema']].sort()
+      );
+    });
+    it(`should find parameter content schemas in operations`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              parameters: [{ content: { 'application/json': { schema: {} } } }],
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'parameters',
+            0,
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find parameter schemas in paths`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            parameters: [{ schema: {} }],
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [['paths', '/', 'parameters', 0, 'schema']].sort()
+      );
+    });
+    it(`should find parameter content schemas in paths`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            parameters: [{ content: { 'application/json': { schema: {} } } }],
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'parameters',
+            0,
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find parameter schemas in components`, async () => {
+      const doc = {
+        components: {
+          parameters: {
+            foo: { schema: {} },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [['components', 'parameters', 'foo', 'schema']].sort()
+      );
+    });
+    it(`should find parameter content schemas in components`, async () => {
+      const doc = {
+        components: {
+          parameters: {
+            foo: { content: { 'application/json': { schema: {} } } },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'components',
+            'parameters',
+            'foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find response header schemas in operations`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  headers: {
+                    Foo: {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'headers',
+            'Foo',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find response header content schemas in operations`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  headers: {
+                    Foo: {
+                      content: {
+                        'application/json': {
+                          schema: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'responses',
+            '200',
+            'headers',
+            'Foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find header schemas in components`, async () => {
+      const doc = {
+        components: {
+          headers: {
+            Foo: {
+              schema: {},
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [['components', 'headers', 'Foo', 'schema']].sort()
+      );
+    });
+    it(`should find header content schemas in components`, async () => {
+      const doc = {
+        components: {
+          headers: {
+            Foo: {
+              content: {
+                'application/json': {
+                  schema: {},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'components',
+            'headers',
+            'Foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find response header schemas in components`, async () => {
+      const doc = {
+        components: {
+          responses: {
+            foo: {
+              headers: {
+                Foo: {
+                  schema: {},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [['components', 'responses', 'foo', 'headers', 'Foo', 'schema']].sort()
+      );
+    });
+    it(`should find response header content schemas in components`, async () => {
+      const doc = {
+        components: {
+          responses: {
+            foo: {
+              headers: {
+                Foo: {
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'components',
+            'responses',
+            'foo',
+            'headers',
+            'Foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find request body schemas in operations`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {},
+                  },
+                  'application/xml': {
+                    schema: {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/json',
+            'schema',
+          ],
+          [
+            'paths',
+            '/',
+            'post',
+            'requestBody',
+            'content',
+            'application/xml',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find request body schemas in components`, async () => {
+      const doc = {
+        components: {
+          requestBodies: {
+            foo: {
+              content: {
+                'application/json': {
+                  schema: {},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'components',
+            'requestBodies',
+            'foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find response body schemas`, async () => {
+      const doc = {
+        paths: {
+          '/': {
+            post: {
+              responses: {
+                200: {
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths).toEqual([
+        [
+          'paths',
+          '/',
+          'post',
+          'responses',
+          '200',
+          'content',
+          'application/json',
+          'schema',
+        ],
+      ]);
+    });
+    it(`should find response body schemas in components`, async () => {
+      const doc = {
+        components: {
+          responses: {
+            foo: {
+              content: {
+                'application/json': {
+                  schema: {},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [
+          [
+            'components',
+            'responses',
+            'foo',
+            'content',
+            'application/json',
+            'schema',
+          ],
+        ].sort()
+      );
+    });
+    it(`should find schemas in components`, async () => {
+      const doc = {
+        components: {
+          schemas: {
+            Foo: {
+              schema: {},
+            },
+          },
+        },
+      };
+
+      const visitedPaths = await testRulePaths(
+        collections.unresolvedSchemas,
+        doc
+      );
+
+      expect(visitedPaths.sort()).toEqual(
+        [['components', 'schemas', 'Foo']].sort()
+      );
+    });
+  });
+});

--- a/packages/utilities/test/utils/test-rule-paths.js
+++ b/packages/utilities/test/utils/test-rule-paths.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2025 IBM Corporation.
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+const testRule = require('./test-rule');
+
+module.exports = async (given, doc) => {
+  const visitedPaths = [];
+  const rule = {
+    given,
+    then: {
+      function: (input, options, context) => {
+        visitedPaths.push(context.path);
+        return [];
+      },
+    },
+  };
+
+  await testRule(rule, doc);
+
+  return visitedPaths;
+};

--- a/packages/utilities/test/utils/test-rule.js
+++ b/packages/utilities/test/utils/test-rule.js
@@ -6,20 +6,14 @@
 // NOTE: Duplicated from ruleset package. Need to revisit
 const { Spectral } = require('@stoplight/spectral-core');
 
-module.exports = async (ruleName, rule, doc) => {
+module.exports = async (rule, doc) => {
   const spectral = new Spectral();
 
   spectral.setRuleset({
     rules: {
-      [ruleName]: rule,
+      'mock-rule': rule,
     },
   });
 
-  try {
-    const results = await spectral.run(doc);
-    return results;
-  } catch (err) {
-    console.error(err);
-    throw err;
-  }
+  return await spectral.run(doc);
 };

--- a/packages/utilities/test/validate-subschemas.test.js
+++ b/packages/utilities/test/validate-subschemas.test.js
@@ -31,7 +31,7 @@ describe('Utility: validateSubschemas', () => {
   };
 
   it('should find all subschemas', async () => {
-    await testRule('rule-name', ruleForTesting, allSchemasDocument);
+    await testRule(ruleForTesting, allSchemasDocument);
 
     expect(visitedPaths.length).toBe(24);
     expect(visitedLogicalPaths.length).toBe(24);


### PR DESCRIPTION
## PR summary
- Rename `responseSchemas` to `responseBodySchemas` (matching `requestBodySchemas`) since there are also response _header_ schemas considered separately.
- Add response header **content** schemas to consideration in the `schemas` collection (they were already considered in the `unresolvedSchemas` collection) and rework the schema collection slightly for clarity.
- Add tests for all collections!

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- ~[ ] Dependencies have been updated as needed~
- ~[ ] `.secrets.baseline` has been updated as needed~
- [x] `npm run generate-utilities-docs` has been run if any files in `packages/utilities/src` have been updated

#### ~Checklist for adding a new validation rule:~
- ~[ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)~
- ~[ ] If necessary, added new validation rule implementation~(packages/ruleset/src/functions/*.js, updated index.js)~
- ~[ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)~
- ~[ ] Added tests for new rule (packages/ruleset/test/*.test.js)~
- ~[ ] Added docs for new rule (docs/ibm-cloud-rules.md)~
- ~[ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)~
