### PR TITLE
fix(pagination-utils): recognize all json mime types

### DIFF
--- a/packages/ruleset/src/utils/pagination-utils.js
+++ b/packages/ruleset/src/utils/pagination-utils.js
@@ -4,6 +4,7 @@
  */
 const { isArraySchema } = require('@ibm-cloud/openapi-ruleset-utilities');
 const mergeAllOfSchemaProperties = require('./merge-allof-schema-properties');
+const { isJsonMimeType } = require('./mimetype-utils');
 
 /**
  * Looks for a query parameter called "offset" and returns the
@@ -80,7 +81,19 @@ function getResponseSchema(response) {
 
   // Find the json content of the response.
   const content = response.content;
-  const jsonResponse = content && content['application/json'];
+  if (!content) {
+    return;
+  }
+
+  const jsonMimeType = Object.keys(content).find(mimeType =>
+    isJsonMimeType(mimeType)
+  );
+
+  if (!jsonMimeType) {
+    return;
+  }
+
+  const jsonResponse = content[jsonMimeType];
 
   if (!jsonResponse || !jsonResponse.schema) {
     return;

--- a/packages/ruleset/test/utils/pagination-utils.test.js
+++ b/packages/ruleset/test/utils/pagination-utils.test.js
@@ -129,7 +129,7 @@ describe('Pagination utility functions', () => {
       const schema = { type: 'object' };
       const response = {
         content: {
-          'application/json': {
+          'application/json; charset=utf-8': {
             schema,
           },
         },


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
The old code was inflexible with respect to content types other than 'application/json'. This commit adjusts the logic to use our utility for recognizing json mime types.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
