### PR TITLE
feat(ibm-operationid-naming-convention): extend operationid naming check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "packages/ruleset",
         "packages/validator"
       ],
+      "dependencies": {
+        "inflected": "^2.1.0"
+      },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
@@ -5972,6 +5975,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inflected": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
+      "integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==",
+      "license": "MIT"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -15054,7 +15063,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.31.1",
+      "version": "1.31.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
@@ -15116,10 +15125,10 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.35.2",
+      "version": "1.35.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.31.1",
+        "@ibm-cloud/openapi-ruleset": "1.31.2",
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
         "@stoplight/spectral-cli": "^6.14.2",
         "@stoplight/spectral-core": "^1.19.4",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "micromatch": "^4.0.8",
     "jsonpath-plus": "^10.3.0",
     "rollup": "2.79.2"
+  },
+  "dependencies": {
+    "inflected": "^2.1.0"
   }
 }

--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -208,11 +208,11 @@ function operationIdPassedConventionCheck(
     .filter(part => !part.startsWith('{') && !part.endsWith('}'))
     .filter(part => !/^v\d+$/.test(part));
 
-  const isPlural = !pluralVerbs.some(verb => verbs.includes(verb));
+  const isPlural = pluralVerbs.some(verb => verbs.includes(verb));
 
   // Singularize the words in the path according to the naming conventions.
   for (let i = 0; i < convertedPath.length; i++) {
-    if (i !== convertedPath.length - 1 || isPlural || pathEndsWithParam)
+    if (i !== convertedPath.length - 1 || !isPlural || pathEndsWithParam)
       convertedPath[i] = inflected.singularize(convertedPath[i]);
   }
 

--- a/packages/ruleset/test/rules/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/rules/operationid-naming-convention.test.js
@@ -28,7 +28,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
-      newGet.operationId = 'check_v1_drink_glass';
+      newGet.operationId = 'check_drink_glass';
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         get: newGet,
       };
@@ -41,7 +41,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
-      newGet.operationId = 'check_v1_drink_glass';
+      newGet.operationId = 'check_drink_glass';
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         get: newGet,
       };
@@ -67,7 +67,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].post = {
-        operationId: 'create_v1_drink',
+        operationId: 'create_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -78,7 +78,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].put = {
-        operationId: 'replace_v1_drinks',
+        operationId: 'replace_drinks',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -89,7 +89,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].put = {
-        operationId: 'replace_v1_drink',
+        operationId: 'replace_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -102,7 +102,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // This should not fail as it is not considered to be "resource-oriented".
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         put: {
-          operationId: 'set_v1_drink_glasses',
+          operationId: 'set_drink_glasses',
         },
       };
 
@@ -115,7 +115,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         put: {
-          operationId: 'set_v1_drink_glasses',
+          operationId: 'set_drink_glasses',
         },
       };
 
@@ -128,7 +128,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         put: {
-          operationId: 'add_v1_drink_glass',
+          operationId: 'add_drink_glass',
         },
       };
 
@@ -140,7 +140,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].delete = {
-        operationId: 'delete_v1_drink',
+        operationId: 'delete_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -152,7 +152,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         delete: {
-          operationId: 'unset_v1_drink_glasses',
+          operationId: 'unset_drink_glasses',
         },
       };
 
@@ -165,14 +165,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         delete: {
-          operationId: 'delete_v1_drink_glasses',
+          operationId: 'delete_drink_glasses',
         },
       };
 
       // Add another path so this API will be resource-oriented.
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         get: {
-          operationId: 'check_v1_drink_glass',
+          operationId: 'check_drink_glass',
         },
       };
 
@@ -185,7 +185,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         delete: {
-          operationId: 'remove_v1_drink_glass',
+          operationId: 'remove_drink_glass',
         },
       };
 
@@ -205,7 +205,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*list_v1_drinks*/);
+      expect(r.message).toMatch(/^.*list_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.get.operationId');
     });
@@ -221,7 +221,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*get_v1_drink*/);
+      expect(r.message).toMatch(/^.*get_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.get.operationId'
@@ -242,9 +242,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(
-        /^.*get_v1_drink_glass or check_v1_drink_glass*/
-      );
+      expect(r.message).toMatch(/^.*get_drink_glass or check_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.get.operationId'
@@ -260,7 +258,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*create_v1_drink*/);
+      expect(r.message).toMatch(/^.*create_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.post.operationId');
     });
@@ -277,7 +275,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*create_v1_drink*/);
+      expect(r.message).toMatch(/^.*create_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.post.operationId'
@@ -296,7 +294,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*update_v1_drink*/);
+      expect(r.message).toMatch(/^.*update_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.patch.operationId'
@@ -315,7 +313,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace_v1_drink*/);
+      expect(r.message).toMatch(/^.*replace_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.put.operationId'
@@ -334,7 +332,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace_v1_drinks*/);
+      expect(r.message).toMatch(/^.*replace_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.put.operationId');
     });
@@ -351,7 +349,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace_v1_drink*/);
+      expect(r.message).toMatch(/^.*replace_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.put.operationId'
@@ -373,7 +371,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
       expect(r.message).toMatch(
-        /^.*replace_v1_drink_glasses or set_v1_drink_glasses*/
+        /^.*replace_drink_glasses or set_drink_glasses*/
       );
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -395,9 +393,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(
-        /^.*replace_v1_drink_glass or add_v1_drink_glass*/
-      );
+      expect(r.message).toMatch(/^.*replace_drink_glass or add_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.put.operationId'
@@ -416,7 +412,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*delete_v1_drink*/);
+      expect(r.message).toMatch(/^.*delete_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.delete.operationId'
@@ -438,7 +434,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
       expect(r.message).toMatch(
-        /^.*delete_v1_drink_glasses or unset_v1_drink_glasses*/
+        /^.*delete_drink_glasses or unset_drink_glasses*/
       );
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -460,9 +456,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(
-        /^.*delete_v1_drink_glass or remove_v1_drink_glass*/
-      );
+      expect(r.message).toMatch(/^.*delete_drink_glass or remove_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'

--- a/packages/ruleset/test/rules/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/rules/operationid-naming-convention.test.js
@@ -242,7 +242,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*check_v1_drink_glass*/);
+      expect(r.message).toMatch(
+        /^.*get_v1_drink_glass or check_v1_drink_glass*/
+      );
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.get.operationId'
@@ -370,7 +372,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*set_v1_drink_glasses*/);
+      expect(r.message).toMatch(
+        /^.*replace_v1_drink_glasses or set_v1_drink_glasses*/
+      );
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses.put.operationId'
@@ -391,7 +395,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*add_v1_drink_glass*/);
+      expect(r.message).toMatch(
+        /^.*replace_v1_drink_glass or add_v1_drink_glass*/
+      );
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.put.operationId'
@@ -431,7 +437,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*unset_v1_drink_glasses*/);
+      expect(r.message).toMatch(
+        /^.*delete_v1_drink_glasses or unset_v1_drink_glasses*/
+      );
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses.delete.operationId'
@@ -452,7 +460,9 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*remove_v1_drink_glass*/);
+      expect(r.message).toMatch(
+        /^.*delete_v1_drink_glass or remove_v1_drink_glass*/
+      );
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'

--- a/packages/ruleset/test/rules/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/rules/operationid-naming-convention.test.js
@@ -15,7 +15,7 @@ const rule = operationIdNamingConvention;
 const ruleId = 'ibm-operation-id-naming-convention';
 const expectedSeverity = severityCodes.warning;
 const expectedMsgPrefix =
-  /^operationIds should follow naming convention: operationId verb should be.*$/;
+  /^operationIds should follow naming convention: operationId should be.*$/;
 
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
@@ -28,7 +28,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
-      newGet.operationId = 'check_glass';
+      newGet.operationId = 'check_v1_drink_glass';
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         get: newGet,
       };
@@ -41,7 +41,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       const newGet = makeCopy(testDocument.paths['/v1/drinks/{drink_id}'].get);
-      newGet.operationId = 'get_glass';
+      newGet.operationId = 'check_v1_drink_glass';
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         get: newGet,
       };
@@ -67,7 +67,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].post = {
-        operationId: 'create_drink',
+        operationId: 'create_v1_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -78,7 +78,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks'].put = {
-        operationId: 'replace_drinks',
+        operationId: 'replace_v1_drinks',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -89,7 +89,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].put = {
-        operationId: 'replace_drink',
+        operationId: 'replace_v1_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -102,7 +102,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       // This should not fail as it is not considered to be "resource-oriented".
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         put: {
-          operationId: 'replace_glasses',
+          operationId: 'set_v1_drink_glasses',
         },
       };
 
@@ -115,7 +115,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         put: {
-          operationId: 'set_drink_glass',
+          operationId: 'set_v1_drink_glasses',
         },
       };
 
@@ -128,7 +128,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         put: {
-          operationId: 'add_drink_glass',
+          operationId: 'add_v1_drink_glass',
         },
       };
 
@@ -140,7 +140,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}'].delete = {
-        operationId: 'delete_drink',
+        operationId: 'delete_v1_drink',
       };
 
       const results = await testRule(ruleId, rule, testDocument);
@@ -152,7 +152,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         delete: {
-          operationId: 'unset_glasses',
+          operationId: 'unset_v1_drink_glasses',
         },
       };
 
@@ -165,14 +165,14 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses'] = {
         delete: {
-          operationId: 'delete_drink_glasses',
+          operationId: 'delete_v1_drink_glasses',
         },
       };
 
       // Add another path so this API will be resource-oriented.
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         get: {
-          operationId: 'get_drink_glass',
+          operationId: 'check_v1_drink_glass',
         },
       };
 
@@ -185,7 +185,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         delete: {
-          operationId: 'remove_drink_glass',
+          operationId: 'remove_v1_drink_glass',
         },
       };
 
@@ -205,7 +205,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*list$/);
+      expect(r.message).toMatch(/^.*list_v1_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.get.operationId');
     });
@@ -221,7 +221,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*get$/);
+      expect(r.message).toMatch(/^.*get_v1_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.get.operationId'
@@ -242,7 +242,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*get or check$/);
+      expect(r.message).toMatch(/^.*check_v1_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.get.operationId'
@@ -258,7 +258,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*create$/);
+      expect(r.message).toMatch(/^.*create_v1_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.post.operationId');
     });
@@ -275,7 +275,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*create$/);
+      expect(r.message).toMatch(/^.*create_v1_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.post.operationId'
@@ -294,7 +294,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*update$/);
+      expect(r.message).toMatch(/^.*update_v1_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.patch.operationId'
@@ -313,7 +313,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace$/);
+      expect(r.message).toMatch(/^.*replace_v1_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.put.operationId'
@@ -332,7 +332,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace$/);
+      expect(r.message).toMatch(/^.*replace_v1_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.put.operationId');
     });
@@ -349,7 +349,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace$/);
+      expect(r.message).toMatch(/^.*replace_v1_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.put.operationId'
@@ -370,7 +370,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace or set$/);
+      expect(r.message).toMatch(/^.*set_v1_drink_glasses*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses.put.operationId'
@@ -391,7 +391,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*replace or add$/);
+      expect(r.message).toMatch(/^.*add_v1_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.put.operationId'
@@ -410,7 +410,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*delete$/);
+      expect(r.message).toMatch(/^.*delete_v1_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}.delete.operationId'
@@ -431,7 +431,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*delete or unset$/);
+      expect(r.message).toMatch(/^.*unset_v1_drink_glasses*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses.delete.operationId'
@@ -452,7 +452,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const r = results[0];
       expect(r.code).toBe(ruleId);
       expect(r.message).toMatch(expectedMsgPrefix);
-      expect(r.message).toMatch(/^.*delete or remove$/);
+      expect(r.message).toMatch(/^.*remove_v1_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'

--- a/packages/ruleset/test/test-utils/root-document.js
+++ b/packages/ruleset/test/test-utils/root-document.js
@@ -32,7 +32,7 @@ module.exports = {
   paths: {
     '/v1/drinks': {
       post: {
-        operationId: 'create_drink',
+        operationId: 'create_v1_drink',
         summary: 'Create a drink',
         description: 'Create a new Drink instance.',
         tags: ['TestTag'],
@@ -76,7 +76,7 @@ module.exports = {
         },
       },
       get: {
-        operationId: 'list_drinks',
+        operationId: 'list_v1_drinks',
         summary: 'List drinks',
         description: 'Retrieve all the drinks.',
         tags: ['TestTag'],
@@ -144,7 +144,7 @@ module.exports = {
         },
       ],
       get: {
-        operationId: 'get_drink',
+        operationId: 'get_v1_drink',
         summary: 'Have a drink',
         description: 'Retrieve and consume a refreshing beverage.',
         tags: ['TestTag'],
@@ -170,7 +170,7 @@ module.exports = {
     },
     '/v1/drink_menu': {
       get: {
-        operationId: 'download_menu',
+        operationId: 'download_v1_drink_menu',
         summary: 'Download Drinks Menu',
         description: 'Retrieve a document containing the drinks menu.',
         tags: ['TestTag'],
@@ -191,7 +191,7 @@ module.exports = {
         },
       },
       put: {
-        operationId: 'replace_menu',
+        operationId: 'replace_v1_drink_menu',
         summary: 'Upload Drinks Menu',
         description: 'Publish a new Drinks Menu for public viewing.',
         tags: ['TestTag'],
@@ -258,7 +258,7 @@ module.exports = {
     },
     '/v1/movies': {
       post: {
-        operationId: 'create_movie',
+        operationId: 'create_v1_movie',
         summary: 'Create a movie',
         description: 'Create a new Movie instance.',
         tags: ['TestTag'],
@@ -301,7 +301,7 @@ module.exports = {
         },
       },
       get: {
-        operationId: 'list_movies',
+        operationId: 'list_v1_movies',
         summary: 'List movies',
         description:
           'Retrieve a list of movies using an optional genre qualifier.',
@@ -383,7 +383,7 @@ module.exports = {
         },
       ],
       get: {
-        operationId: 'get_movie',
+        operationId: 'get_v1_movie',
         summary: 'Get a movie',
         description: 'Retrieve the movie and return it in the response.',
         tags: ['TestTag'],
@@ -409,7 +409,7 @@ module.exports = {
         },
       },
       put: {
-        operationId: 'replace_movie',
+        operationId: 'replace_v1_movie',
         summary: 'Replace movie',
         description: 'Replace a movie with updated state information.',
         tags: ['TestTag'],
@@ -463,7 +463,7 @@ module.exports = {
     },
     '/v1/cars': {
       post: {
-        operationId: 'create_car',
+        operationId: 'create_v1_car',
         summary: 'Create a car',
         description: 'Create a new Car instance.',
         tags: ['TestTag'],
@@ -515,7 +515,7 @@ module.exports = {
         },
       ],
       get: {
-        operationId: 'get_car',
+        operationId: 'get_v1_car',
         summary: 'Get Car',
         description: 'Retrieve a Car instance by its id.',
         tags: ['TestTag'],
@@ -534,7 +534,7 @@ module.exports = {
         },
       },
       patch: {
-        operationId: 'update_car',
+        operationId: 'update_v1_car',
         summary: 'Update a car',
         description: 'Update a new Car instance with new state information.',
         tags: ['TestTag'],

--- a/packages/ruleset/test/test-utils/root-document.js
+++ b/packages/ruleset/test/test-utils/root-document.js
@@ -32,7 +32,7 @@ module.exports = {
   paths: {
     '/v1/drinks': {
       post: {
-        operationId: 'create_v1_drink',
+        operationId: 'create_drink',
         summary: 'Create a drink',
         description: 'Create a new Drink instance.',
         tags: ['TestTag'],
@@ -76,7 +76,7 @@ module.exports = {
         },
       },
       get: {
-        operationId: 'list_v1_drinks',
+        operationId: 'list_drinks',
         summary: 'List drinks',
         description: 'Retrieve all the drinks.',
         tags: ['TestTag'],
@@ -144,7 +144,7 @@ module.exports = {
         },
       ],
       get: {
-        operationId: 'get_v1_drink',
+        operationId: 'get_drink',
         summary: 'Have a drink',
         description: 'Retrieve and consume a refreshing beverage.',
         tags: ['TestTag'],
@@ -170,7 +170,7 @@ module.exports = {
     },
     '/v1/drink_menu': {
       get: {
-        operationId: 'download_v1_drink_menu',
+        operationId: 'download_drink_menu',
         summary: 'Download Drinks Menu',
         description: 'Retrieve a document containing the drinks menu.',
         tags: ['TestTag'],
@@ -191,7 +191,7 @@ module.exports = {
         },
       },
       put: {
-        operationId: 'replace_v1_drink_menu',
+        operationId: 'replace_drink_menu',
         summary: 'Upload Drinks Menu',
         description: 'Publish a new Drinks Menu for public viewing.',
         tags: ['TestTag'],
@@ -258,7 +258,7 @@ module.exports = {
     },
     '/v1/movies': {
       post: {
-        operationId: 'create_v1_movie',
+        operationId: 'create_movie',
         summary: 'Create a movie',
         description: 'Create a new Movie instance.',
         tags: ['TestTag'],
@@ -301,7 +301,7 @@ module.exports = {
         },
       },
       get: {
-        operationId: 'list_v1_movies',
+        operationId: 'list_movies',
         summary: 'List movies',
         description:
           'Retrieve a list of movies using an optional genre qualifier.',
@@ -383,7 +383,7 @@ module.exports = {
         },
       ],
       get: {
-        operationId: 'get_v1_movie',
+        operationId: 'get_movie',
         summary: 'Get a movie',
         description: 'Retrieve the movie and return it in the response.',
         tags: ['TestTag'],
@@ -409,7 +409,7 @@ module.exports = {
         },
       },
       put: {
-        operationId: 'replace_v1_movie',
+        operationId: 'replace_movie',
         summary: 'Replace movie',
         description: 'Replace a movie with updated state information.',
         tags: ['TestTag'],
@@ -463,7 +463,7 @@ module.exports = {
     },
     '/v1/cars': {
       post: {
-        operationId: 'create_v1_car',
+        operationId: 'create_car',
         summary: 'Create a car',
         description: 'Create a new Car instance.',
         tags: ['TestTag'],
@@ -515,7 +515,7 @@ module.exports = {
         },
       ],
       get: {
-        operationId: 'get_v1_car',
+        operationId: 'get_car',
         summary: 'Get Car',
         description: 'Retrieve a Car instance by its id.',
         tags: ['TestTag'],
@@ -534,7 +534,7 @@ module.exports = {
         },
       },
       patch: {
-        operationId: 'update_v1_car',
+        operationId: 'update_car',
         summary: 'Update a car',
         description: 'Update a new Car instance with new state information.',
         tags: ['TestTag'],

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean-with-tabs.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean-with-tabs.yml
@@ -65,7 +65,7 @@ paths:
 		post:
 			summary: Create a pet
 			description: Create a pet
-			operationId: create_pets
+			operationId: create_pet
 			tags:
 				- pets
 			responses:
@@ -85,7 +85,7 @@ paths:
 		get:
 			summary: Info for a specific pet
 			description: Get information about a specific pet
-			operationId: get_pet_by_id
+			operationId: get_pet
 			tags:
 				- pets
 			parameters:

--- a/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas3/clean.yml
@@ -65,7 +65,7 @@ paths:
     post:
       summary: Create a pet
       description: Create a pet
-      operationId: create_pets
+      operationId: create_pet
       tags:
         - pets
       responses:
@@ -85,7 +85,7 @@ paths:
     get:
       summary: Info for a specific pet
       description: Get information about a specific pet
-      operationId: get_pet_by_id
+      operationId: get_pet
       tags:
         - pets
       parameters:

--- a/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
+++ b/packages/validator/test/cli-validator/mock-files/oas31/clean.yml
@@ -65,7 +65,7 @@ paths:
     post:
       summary: Create a pet
       description: Create a pet
-      operationId: create_pets
+      operationId: create_pet
       tags:
         - pets
       responses:
@@ -85,7 +85,7 @@ paths:
     get:
       summary: Info for a specific pet
       description: Get information about a specific pet
-      operationId: get_pet_by_id
+      operationId: get_pet
       tags:
         - pets
       parameters:


### PR DESCRIPTION
Extends the ibm-operationid-naming-convention rule so now it checks if operation IDs follow the handbook naming convention rule or not.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
