### PR TITLE
fix(ibm-operationid-naming-convention): make full naming check optional

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -4430,9 +4430,9 @@ paths:
       description: Create a new Thing instance.
       summary: Create a Thing
     get:
-      operationId: retrieve_things
-      description: Retrieve all Thing instances.
-      summary: Retrieve Things
+      operationId: list_thing
+      description: List all Thing instances.
+      summary: List Thing
   '/v1/things/{thing_id}':
     get:
       operationId: retrieve_thing

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -4389,7 +4389,26 @@ For example, <code>create_thing</code> would be preferred over <code>manufacture
 when deciding on an operationId for the <code>POST /v1/things</code> operation.
 Likewise, for the <code>GET /v1/things/{thing_id}</code> operation, we might prefer
 <code>get_thing</code> over <code>retrieve_thing</code> for the operationId.
-<p>This rule will analyze the operations, looking for operationId values that are not using the recommended verbs.
+<p>This rule will analyze the operations, looking for operationId values that are not using the recommended verbs. Furthermore it can also validate the complete name of the operation id by comparing it to the path segments.
+</td>
+</tr>
+<tr>
+<td valign=top><b>Configuration:</b></td>
+<td>This rule can be configured to validate the complete name of the operation id, or only the verb it begins with.
+<p>The default configuration object provided in the rule definition is:
+<pre>
+{
+  strict: true
+}
+</pre>
+<p>To switch off the complete name validation and only validate the verbs the operation ids begin with, you'll need to
+<a href="#replace-a-rule-from-ibm-cloudopenapi-ruleset">replace this rule with a new rule within your
+custom ruleset</a> and modify the configuration such that the value of the <code>strict</code> field to <code>false</code>
+<pre>
+{
+  strict: false
+}
+</pre>
 </td>
 </tr>
 <tr>
@@ -4410,6 +4429,10 @@ paths:
       operationId: manufacture_thing
       description: Create a new Thing instance.
       summary: Create a Thing
+    get:
+      operationId: retrieve_things
+      description: Retrieve all Thing instances.
+      summary: Retrieve Things
   '/v1/things/{thing_id}':
     get:
       operationId: retrieve_thing
@@ -4428,6 +4451,10 @@ paths:
       operationId: create_thing
       description: Create a new Thing instance.
       summary: Create a Thing
+    get:
+      operationId: list_things
+      description: List all Thing instances.
+      summery: List Things
   '/v1/things/{thing_id}':
     get:
       operationId: get_thing

--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -8,7 +8,7 @@ const { operationMethods } = require('../utils');
 const inflected = require('inflected');
 
 module.exports = function (rootDocument, options) {
-  const fullNamingCheck = options;
+  const fullNamingCheck = options.namingCheck;
   return operationIdNamingConvention(rootDocument, fullNamingCheck);
 };
 

--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -8,8 +8,7 @@ const { operationMethods } = require('../utils');
 const inflected = require('inflected');
 
 module.exports = function (rootDocument, options) {
-  const fullNamingCheck = options.namingCheck;
-  return operationIdNamingConvention(rootDocument, fullNamingCheck);
+  return operationIdNamingConvention(rootDocument, options.strict);
 };
 
 function operationIdNamingConvention(resolvedSpec, fullNamingCheck) {

--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -7,11 +7,12 @@ const { each, merge, pickBy, reduce } = require('lodash');
 const { operationMethods } = require('../utils');
 const inflected = require('inflected');
 
-module.exports = function (rootDocument) {
-  return operationIdNamingConvention(rootDocument);
+module.exports = function (rootDocument, options) {
+  const fullNamingCheck = options;
+  return operationIdNamingConvention(rootDocument, fullNamingCheck);
 };
 
-function operationIdNamingConvention(resolvedSpec) {
+function operationIdNamingConvention(resolvedSpec, fullNamingCheck) {
   const operations = reduce(
     resolvedSpec.paths,
     (arr, path, pathKey) => {
@@ -59,23 +60,31 @@ function operationIdNamingConvention(resolvedSpec) {
             p.startsWith(op.pathKey + '/{')
           );
 
-      const { checkPassed, correctIds, operationId } =
+      const { checkPassed, correctIds, operationId, verbs } =
         operationIdPassedConventionCheck(
           isResourceOriented,
           op['opKey'],
           op.operationId,
           pathEndsWithParam,
           numParamRefs,
-          op.pathKey
+          op.pathKey,
+          fullNamingCheck
         );
 
       if (checkPassed === false) {
-        errors.push({
-          message: `operationIds should follow naming convention: operationId should be ${correctIds.join(
-            ' or '
-          )} but it's ${operationId} instead`,
-          path: [...op.path, 'operationId'],
-        });
+        if (fullNamingCheck) {
+          errors.push({
+            message: `operationIds should follow naming convention: operationId should be ${correctIds.join(
+              ' or '
+            )} but it's ${operationId} instead`,
+            path: [...op.path, 'operationId'],
+          });
+        } else {
+          errors.push({
+            message: `operationIds should follow naming convention: operationId verb should be ${verbs.join(' or ')}`,
+            path: [...op.path, 'operationId'],
+          });
+        }
       }
     }
   });
@@ -139,7 +148,8 @@ function operationIdPassedConventionCheck(
   operationId,
   pathEndsWithParam,
   numParamRefs,
-  fullPath
+  fullPath,
+  fullNamingCheck
 ) {
   // Useful for debugging.
   // console.log(`Debug: ${httpMethod} ${isResourceOriented} ${pathEndsWithParam} ${numParamRefs}  ${operationId}`);
@@ -202,27 +212,36 @@ function operationIdPassedConventionCheck(
   // that the operationId starts with that verb
   // and that the rest of the operation id matches
   // the path according to the naming conventions
-  const convertedPath = fullPath
-    .replace(/^\/+/, '')
-    .split('/')
-    .filter(part => !part.startsWith('{') && !part.endsWith('}'))
-    .filter(part => !/^v\d+$/.test(part));
+  if (fullNamingCheck) {
+    const convertedPath = fullPath
+      .replace(/^\/+/, '')
+      .split('/')
+      .filter(part => !part.startsWith('{') && !part.endsWith('}'))
+      .filter(part => !/^v\d+$/.test(part));
 
-  const isPlural = pluralVerbs.some(verb => verbs.includes(verb));
+    const isPlural = pluralVerbs.some(verb => verbs.includes(verb));
 
-  // Singularize the words in the path according to the naming conventions.
-  for (let i = 0; i < convertedPath.length; i++) {
-    if (i !== convertedPath.length - 1 || !isPlural || pathEndsWithParam)
-      convertedPath[i] = inflected.singularize(convertedPath[i]);
+    // Singularize the words in the path according to the naming conventions.
+    for (let i = 0; i < convertedPath.length; i++) {
+      if (i !== convertedPath.length - 1 || !isPlural || pathEndsWithParam)
+        convertedPath[i] = inflected.singularize(convertedPath[i]);
+    }
+
+    const correctIds = [];
+
+    for (let i = 0; i < verbs.length; i++) {
+      const correctId = verbs[i] + '_' + convertedPath.join('_');
+      if (correctId === operationId) return { checkPassed: true };
+      else correctIds.push(correctId);
+    }
+
+    return { checkPassed: false, correctIds, operationId };
+  } else {
+    if (verbs.length > 0) {
+      const checkPassed = verbs
+        .map(verb => operationId.startsWith(verb))
+        .some(v => v);
+      return { checkPassed, verbs: verbs };
+    }
   }
-
-  const correctIds = [];
-
-  for (let i = 0; i < verbs.length; i++) {
-    const correctId = verbs[i] + '_' + convertedPath.join('_');
-    if (correctId === operationId) return { checkPassed: true };
-    else correctIds.push(correctId);
-  }
-
-  return { checkPassed: false, correctIds, operationId };
 }

--- a/packages/ruleset/src/rules/operationid-naming-convention.js
+++ b/packages/ruleset/src/rules/operationid-naming-convention.js
@@ -16,7 +16,7 @@ module.exports = {
   then: {
     function: operationIdNamingConvention,
     functionOptions: {
-      namingCheck: true,
+      strict: true,
     },
   },
 };

--- a/packages/ruleset/src/rules/operationid-naming-convention.js
+++ b/packages/ruleset/src/rules/operationid-naming-convention.js
@@ -15,5 +15,8 @@ module.exports = {
   resolved: true,
   then: {
     function: operationIdNamingConvention,
+    functionOptions: {
+      namingCheck: true,
+    },
   },
 };

--- a/packages/ruleset/test/rules/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/rules/operationid-naming-convention.test.js
@@ -14,8 +14,10 @@ const {
 const rule = operationIdNamingConvention;
 const ruleId = 'ibm-operation-id-naming-convention';
 const expectedSeverity = severityCodes.warning;
-const expectedMsgPrefix =
+const strictExpectedMsgPrefix =
   /^operationIds should follow naming convention: operationId should be.*$/;
+const notStrictstrictstrictExpectedMsgPrefix =
+        /^operationIds should follow naming convention: operationId verb should be.*$/;
 
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {
@@ -204,7 +206,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*list_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.get.operationId');
@@ -220,7 +222,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*get_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -241,7 +243,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*get_drink_glass or check_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -257,7 +259,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*create_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.post.operationId');
@@ -274,7 +276,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*create_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -293,7 +295,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*update_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -312,7 +314,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -331,7 +333,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.put.operationId');
@@ -348,7 +350,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -369,7 +371,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(
         /^.*replace_drink_glasses or set_drink_glasses*/
       );
@@ -392,7 +394,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drink_glass or add_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -411,7 +413,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*delete_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -432,7 +434,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(
         /^.*delete_drink_glasses or unset_drink_glasses*/
       );
@@ -455,8 +457,31 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(expectedMsgPrefix);
+      expect(r.message).toMatch(strictExpectedMsgPrefix);
       expect(r.message).toMatch(/^.*delete_drink_glass or remove_drink_glass*/);
+      expect(r.severity).toBe(expectedSeverity);
+      expect(r.path.join('.')).toBe(
+        'paths./v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'
+      );
+    });
+
+    it('path has multiple path params, delete', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+        delete: {
+          operationId: 'smash_drink_glass',
+        },
+      };
+
+      rule.then.functionOptions.strict = false;
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(1);
+      const r = results[0];
+      expect(r.code).toBe(ruleId);
+      expect(r.message).toMatch(notStrictstrictstrictExpectedMsgPrefix);
+      expect(r.message).toMatch(/^.*delete or remove*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
         'paths./v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'

--- a/packages/ruleset/test/rules/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/rules/operationid-naming-convention.test.js
@@ -14,9 +14,9 @@ const {
 const rule = operationIdNamingConvention;
 const ruleId = 'ibm-operation-id-naming-convention';
 const expectedSeverity = severityCodes.warning;
-const strictExpectedMsgPrefix =
+const expectedStrictMsgPrefix =
   /^operationIds should follow naming convention: operationId should be.*$/;
-const notStrictstrictstrictExpectedMsgPrefix =
+const expectedNotStrictMsgPrefix =
   /^operationIds should follow naming convention: operationId verb should be.*$/;
 
 describe(`Spectral rule: ${ruleId}`, () => {
@@ -206,7 +206,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*list_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.get.operationId');
@@ -222,7 +222,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*get_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -243,7 +243,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*get_drink_glass or check_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -259,7 +259,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*create_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.post.operationId');
@@ -276,7 +276,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*create_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -295,7 +295,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*update_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -314,7 +314,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -333,7 +333,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drinks*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe('paths./v1/drinks.put.operationId');
@@ -350,7 +350,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -371,7 +371,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(
         /^.*replace_drink_glasses or set_drink_glasses*/
       );
@@ -394,7 +394,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*replace_drink_glass or add_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -413,7 +413,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*delete_drink*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -434,7 +434,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(
         /^.*delete_drink_glasses or unset_drink_glasses*/
       );
@@ -457,7 +457,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(strictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedStrictMsgPrefix);
       expect(r.message).toMatch(/^.*delete_drink_glass or remove_drink_glass*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
@@ -465,7 +465,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       );
     });
 
-    it('path has multiple path params, delete', async () => {
+    it('path has multiple path params, delete, not strict', async () => {
       const testDocument = makeCopy(rootDocument);
 
       testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
@@ -480,7 +480,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.code).toBe(ruleId);
-      expect(r.message).toMatch(notStrictstrictstrictExpectedMsgPrefix);
+      expect(r.message).toMatch(expectedNotStrictMsgPrefix);
       expect(r.message).toMatch(/^.*delete or remove*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(

--- a/packages/ruleset/test/rules/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/rules/operationid-naming-convention.test.js
@@ -17,7 +17,7 @@ const expectedSeverity = severityCodes.warning;
 const strictExpectedMsgPrefix =
   /^operationIds should follow naming convention: operationId should be.*$/;
 const notStrictstrictstrictExpectedMsgPrefix =
-        /^operationIds should follow naming convention: operationId verb should be.*$/;
+  /^operationIds should follow naming convention: operationId verb should be.*$/;
 
 describe(`Spectral rule: ${ruleId}`, () => {
   describe('Should not yield errors', () => {


### PR DESCRIPTION
## PR summary
Modifies the ibm-operationid-naming-convention rule, so the operationid name validation can be switched off.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
