### PR TITLE
fix(build): bump dependency to avoid CVE-2025-59343

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14201,9 +14201,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15060,7 +15060,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.32.0",
+      "version": "1.33.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
@@ -15123,10 +15123,10 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.36.0",
+      "version": "1.37.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.32.0",
+        "@ibm-cloud/openapi-ruleset": "1.33.1",
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
         "@stoplight/spectral-cli": "^6.14.2",
         "@stoplight/spectral-core": "^1.19.4",


### PR DESCRIPTION
Bumps tar-fs to 2.1.4 to avoid CVEs.