### PR TITLE
fix(ibm-major-version-in-path): extend rule to check major version is the first segment

### DIFF
--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -2400,7 +2400,7 @@ components:
 <td valign=top><b>Description:</b></td>
 <td>Each path defined within the API definition should include a path segment for the API major version,
 of the form <code>v&lt;n&gt;</code>, and all paths should have the same API major version segment.
-The API major version can appear in either the server URL or in each path entry.
+The API major version can appear in either the server URL or in each path entry. In the path entry, the first segment of the API's path MUST be the major version of the API.
 </td>
 </tr>
 <tr>

--- a/docs/ibm-cloud-rules.md
+++ b/docs/ibm-cloud-rules.md
@@ -2400,7 +2400,7 @@ components:
 <td valign=top><b>Description:</b></td>
 <td>Each path defined within the API definition should include a path segment for the API major version,
 of the form <code>v&lt;n&gt;</code>, and all paths should have the same API major version segment.
-The API major version can appear in either the server URL or in each path entry. In the path entry, the first segment of the API's path MUST be the major version of the API.
+The API major version can appear in either the server URL or in each path entry. In the path entry, the first segment of the API's path must be the major version of the API.
 </td>
 </tr>
 <tr>

--- a/packages/ruleset/src/functions/major-version-in-path.js
+++ b/packages/ruleset/src/functions/major-version-in-path.js
@@ -106,6 +106,16 @@ function checkMajorVersion(apiDef) {
       return [];
     }
 
+    if (!verionIsFirstInPaths(urls) && versionIsInPath(urls)) {
+      logger.debug(`${ruleId}: first segment of path isn't the major version`);
+      return [
+        {
+          message: "First segment of path isn't the major version of the API",
+          path: ['paths'],
+        },
+      ];
+    }
+
     const versions = urls.map(url => getVersion(url));
 
     if (versions.length > 1 && !versions.every(v => v === versions[0])) {
@@ -196,4 +206,16 @@ function getDefaultUrl(server) {
   }
 
   return urlString;
+}
+
+function verionIsFirstInPaths(paths) {
+  const versionRegex = /^\/v\d+\//;
+
+  return paths.every(path => versionRegex.test(path));
+}
+
+function versionIsInPath(paths) {
+  const versionRegex = /\/v\d+\//;
+
+  return paths.every(path => versionRegex.test(path));
 }

--- a/packages/ruleset/src/functions/major-version-in-path.js
+++ b/packages/ruleset/src/functions/major-version-in-path.js
@@ -106,16 +106,6 @@ function checkMajorVersion(apiDef) {
       return [];
     }
 
-    if (!verionIsFirstInPaths(urls) && versionIsInPath(urls)) {
-      logger.debug(`${ruleId}: first segment of path isn't the major version`);
-      return [
-        {
-          message: "First segment of path isn't the major version of the API",
-          path: ['paths'],
-        },
-      ];
-    }
-
     const versions = urls.map(url => getVersion(url));
 
     if (versions.length > 1 && !versions.every(v => v === versions[0])) {
@@ -132,6 +122,16 @@ function checkMajorVersion(apiDef) {
           message:
             'Major version segments in paths do not match. Found: ' +
             uniqueVersions.join(', '),
+          path: ['paths'],
+        },
+      ];
+    }
+
+    if (!versionIsFirstInPaths(urls) && versionIsInPath(urls)) {
+      logger.debug(`${ruleId}: first segment of path isn't the major version`);
+      return [
+        {
+          message: "First segment of path isn't the major version of the API",
           path: ['paths'],
         },
       ];
@@ -208,7 +208,7 @@ function getDefaultUrl(server) {
   return urlString;
 }
 
-function verionIsFirstInPaths(paths) {
+function versionIsFirstInPaths(paths) {
   const versionRegex = /^\/v\d+\//;
 
   return paths.every(path => versionRegex.test(path));

--- a/packages/ruleset/test/rules/major-version-in-path.test.js
+++ b/packages/ruleset/test/rules/major-version-in-path.test.js
@@ -135,4 +135,21 @@ describe(`Spectral rule: ${ruleId}`, () => {
     expect(validation.path).toStrictEqual([]);
     expect(validation.severity).toBe(severityCodes.warning);
   });
+
+  it('should error when paths start with different versions', async () => {
+    const testDocument = makeCopy(rootDocument);
+    testDocument.paths['metadata/v1/some_path'] = {};
+
+    const results = await testRule(ruleId, rule, testDocument);
+
+    expect(results).toHaveLength(1);
+
+    const validation = results[0];
+    expect(validation.code).toBe(ruleId);
+    expect(validation.message).toBe(
+      "First segment of path isn't the major version of the API"
+    );
+    expect(validation.path).toStrictEqual(['paths']);
+    expect(validation.severity).toBe(severityCodes.warning);
+  });
 });


### PR DESCRIPTION
Extends the ibm-major-version-in-path rule so it validates that the version number is the first segment of the API's path if the version number is located in the path.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
