### PR TITLE
fix(ibm-operationid-naming-convention): extend rule

### DIFF
--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -212,11 +212,16 @@ function operationIdPassedConventionCheck(
   // and that the rest of the operation id matches
   // the path according to the naming conventions
   if (fullNamingCheck) {
-    const convertedPath = fullPath
+    const tempPath = fullPath
       .replace(/^\/+/, '')
       .split('/')
-      .filter(part => !part.startsWith('{') && !part.endsWith('}'))
-      .filter(part => !/^v\d+$/.test(part));
+      .filter(part => !part.startsWith('{') && !part.endsWith('}'));
+    //.filter(part => !/^v\d+$/.test(part));
+
+    const versionIndex = tempPath.findIndex(part => /^v\d+$/.test(part));
+
+    const convertedPath =
+      versionIndex >= 0 ? tempPath.slice(versionIndex + 1) : tempPath;
 
     const isPlural = pluralVerbs.some(verb => verbs.includes(verb));
 

--- a/packages/ruleset/src/functions/operationid-naming-convention.js
+++ b/packages/ruleset/src/functions/operationid-naming-convention.js
@@ -216,7 +216,6 @@ function operationIdPassedConventionCheck(
       .replace(/^\/+/, '')
       .split('/')
       .filter(part => !part.startsWith('{') && !part.endsWith('}'));
-    //.filter(part => !/^v\d+$/.test(part));
 
     const versionIndex = tempPath.findIndex(part => /^v\d+$/.test(part));
 

--- a/packages/ruleset/test/rules/operationid-naming-convention.test.js
+++ b/packages/ruleset/test/rules/operationid-naming-convention.test.js
@@ -128,7 +128,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('path has multiple path params, put', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
+      testDocument.paths['metadata/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
         put: {
           operationId: 'add_drink_glass',
         },
@@ -468,11 +468,12 @@ describe(`Spectral rule: ${ruleId}`, () => {
     it('path has multiple path params, delete, not strict', async () => {
       const testDocument = makeCopy(rootDocument);
 
-      testDocument.paths['/v1/drinks/{drink_id}/glasses/{glass_id}'] = {
-        delete: {
-          operationId: 'smash_drink_glass',
-        },
-      };
+      testDocument.paths['/metadata/v1/drinks/{drink_id}/glasses/{glass_id}'] =
+        {
+          delete: {
+            operationId: 'smash_drink_glass',
+          },
+        };
 
       rule.then.functionOptions.strict = false;
 
@@ -484,7 +485,7 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(r.message).toMatch(/^.*delete or remove*/);
       expect(r.severity).toBe(expectedSeverity);
       expect(r.path.join('.')).toBe(
-        'paths./v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'
+        'paths./metadata/v1/drinks/{drink_id}/glasses/{glass_id}.delete.operationId'
       );
     });
   });


### PR DESCRIPTION
Modifies the operation ID checking logic so it only uses the segments of the path after the version number to create the ID name.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
