### PR TITLE
fix: usage of deleted yaml.safeLoad

### DIFF
--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -202,7 +202,7 @@ async function runValidator(cliArgs, parseOptions = {}) {
       if (fileExtension === 'json') {
         input = JSON.parse(originalFile);
       } else if (fileExtension === 'yaml' || fileExtension === 'yml') {
-        input = readYaml.safeLoad(originalFile);
+        input = readYaml.load(originalFile);
       }
 
       if (!isPlainObject(input)) {


### PR DESCRIPTION
## PR summary
Since major version 4 of [js-yaml](https://www.npmjs.com/package/js-yaml/v/4.0.0) usage of `yaml.safeLoad` will throw an error.
Since the upgrade of ibm-openapi-validator to version [1.37.4](https://github.com/IBM/openapi-validator/releases/tag/ibm-openapi-validator%401.37.4) the `js-yaml` was switched from `3.14.1` to `4.1.1` and now we're getting errors like:
```
$ npx ibm-openapi-validator openapi.yaml
IBM OpenAPI Validator (validator: 1.37.4), @Copyright IBM Corporation 2017, 2025.

Validation Results for openapi.yaml:

[ERROR] Invalid input file: openapi.yaml. See below for details.
[ERROR] Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```

This is fixing this issue.

**Important: The tests are already covering this issue. It is not very clear to me why in your build pipeline this was not already covered. Maybe the old version is there still cached?**

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
