### PR TITLE
fix(build): bump version to avoid CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -696,21 +696,11 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.1",
         "resolve-from": "^5.0.0"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
@@ -725,20 +715,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -4017,7 +3993,7 @@
       "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "parse-json": "^5.2.0",
         "path-type": "^4.0.0"
       },
@@ -4836,7 +4812,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -15138,7 +15114,7 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.37.3",
+      "version": "1.37.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset": "1.33.3",
@@ -15153,7 +15129,7 @@
         "console-table-printer": "^2.12.1",
         "find-up": "5.0.0",
         "globby": "^11.0.4",
-        "js-yaml": "^3.14.1",
+        "js-yaml": "^4.1.1",
         "json-dup-key-validator": "^1.0.3",
         "lodash": "^4.17.21",
         "nimma": "^0.7.0",


### PR DESCRIPTION
Bumps every js-yaml to 4.1.1 to avoid CVEs.