### PR TITLE
fix(build): update validator depdendency to fix CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14735,9 +14735,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.20",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
-      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -15050,7 +15050,7 @@
         "loglevel": "^1.9.2",
         "loglevel-plugin-prefix": "0.8.4",
         "minimatch": "^6.2.0",
-        "validator": "^13.11.0"
+        "validator": "^13.15.23"
       },
       "devDependencies": {
         "@stoplight/spectral-core": "^1.19.4",
@@ -15099,7 +15099,7 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.37.5",
+      "version": "1.37.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset": "1.33.3",

--- a/packages/ruleset/package.json
+++ b/packages/ruleset/package.json
@@ -32,7 +32,7 @@
     "loglevel": "^1.9.2",
     "loglevel-plugin-prefix": "0.8.4",
     "minimatch": "^6.2.0",
-    "validator": "^13.11.0"
+    "validator": "^13.15.23"
   },
   "devDependencies": {
     "@stoplight/spectral-core": "^1.19.4",


### PR DESCRIPTION
## PR summary

Bumps validator.js to address CVE-2025-12758

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
