### PR TITLE
fix(ibm-use-date-based-format): extend date-based-utils with exceptions

### DIFF
--- a/packages/ruleset/src/utils/date-based-utils.js
+++ b/packages/ruleset/src/utils/date-based-utils.js
@@ -65,7 +65,12 @@ function isDateBasedName(name) {
     /.*timestamp.*/,
   ];
 
-  return dateBasedNamePatterns.some(regex => regex.test(name));
+  const exceptionNamePatterns = [/.*depends_on$/];
+
+  return (
+    dateBasedNamePatterns.some(regex => regex.test(name)) &&
+    !exceptionNamePatterns.some(regex => regex.test(name))
+  );
 }
 
 /**

--- a/packages/ruleset/test/rules/use-date-based-format.test.js
+++ b/packages/ruleset/test/rules/use-date-based-format.test.js
@@ -284,6 +284,34 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+
+    it("depends_on doesn't yield error", async () => {
+      const testDocument = makeCopy(rootDocument);
+      testDocument.components.schemas.Movie.properties.metadata = {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              depends_on: {
+                maxLength: '25',
+                type: 'string',
+              },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              irrelevant: {
+                type: 'boolean',
+              },
+            },
+          },
+        ],
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {


### PR DESCRIPTION
## PR summary
This PR extends the date-based-utils class with the ability to add exceptions to it. This way false positives like flagging a property ending with <code>depends_on</code> as a date based format can be avoided.
https://github.com/IBM/openapi-validator/issues/775

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated
