### PR TITLE
fix: bump jsonpath-plus to avoid CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2328,6 +2328,24 @@
         "ajv": "^8.0.1"
       }
     },
+    "node_modules/@stoplight/spectral-core/node_modules/jsonpath-plus": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@stoplight/spectral-core/node_modules/nimma": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
@@ -2345,25 +2363,6 @@
       "optionalDependencies": {
         "jsonpath-plus": "^6.0.1 || ^10.1.0",
         "lodash.topath": "^4.5.2"
-      }
-    },
-    "node_modules/@stoplight/spectral-core/node_modules/nimma/node_modules/jsonpath-plus": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
-      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jsep-plugin/assignment": "^1.3.0",
-        "@jsep-plugin/regex": "^1.0.4",
-        "jsep": "^1.4.0"
-      },
-      "bin": {
-        "jsonpath": "bin/jsonpath-cli.js",
-        "jsonpath-plus": "bin/jsonpath-cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@stoplight/spectral-formats": {
@@ -7373,24 +7372,6 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
-    },
-    "node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsep-plugin/assignment": "^1.3.0",
-        "@jsep-plugin/regex": "^1.0.4",
-        "jsep": "^1.4.0"
-      },
-      "bin": {
-        "jsonpath": "bin/jsonpath-cli.js",
-        "jsonpath-plus": "bin/jsonpath-cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
@@ -15070,7 +15051,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.33.6",
+      "version": "1.33.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
@@ -15080,7 +15061,7 @@
         "chalk": "^4.1.2",
         "inflected": "^2.1.0",
         "jsonschema": "^1.5.0",
-        "lodash": "^4.17.23",
+        "lodash": "^4.17.21",
         "loglevel": "^1.9.2",
         "loglevel-plugin-prefix": "0.8.4",
         "minimatch": "^6.2.0",
@@ -15133,10 +15114,10 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.37.9",
+      "version": "1.37.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.33.6",
+        "@ibm-cloud/openapi-ruleset": "1.33.5",
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
         "@stoplight/spectral-cli": "^6.14.2",
         "@stoplight/spectral-core": "^1.19.4",
@@ -15150,7 +15131,7 @@
         "globby": "^11.0.4",
         "js-yaml": "^4.1.1",
         "json-dup-key-validator": "^1.0.3",
-        "lodash": "^4.17.23",
+        "lodash": "^4.17.21",
         "nimma": "^0.7.0",
         "pad": "^2.3.0",
         "semver": "^7.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2328,24 +2328,6 @@
         "ajv": "^8.0.1"
       }
     },
-    "node_modules/@stoplight/spectral-core/node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsep-plugin/assignment": "^1.3.0",
-        "@jsep-plugin/regex": "^1.0.4",
-        "jsep": "^1.4.0"
-      },
-      "bin": {
-        "jsonpath": "bin/jsonpath-cli.js",
-        "jsonpath-plus": "bin/jsonpath-cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@stoplight/spectral-core/node_modules/nimma": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
@@ -2363,6 +2345,25 @@
       "optionalDependencies": {
         "jsonpath-plus": "^6.0.1 || ^10.1.0",
         "lodash.topath": "^4.5.2"
+      }
+    },
+    "node_modules/@stoplight/spectral-core/node_modules/nimma/node_modules/jsonpath-plus": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@stoplight/spectral-formats": {
@@ -7372,6 +7373,24 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
@@ -15051,7 +15070,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.33.5",
+      "version": "1.33.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
@@ -15061,7 +15080,7 @@
         "chalk": "^4.1.2",
         "inflected": "^2.1.0",
         "jsonschema": "^1.5.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "loglevel": "^1.9.2",
         "loglevel-plugin-prefix": "0.8.4",
         "minimatch": "^6.2.0",
@@ -15114,10 +15133,10 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.37.8",
+      "version": "1.37.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.33.5",
+        "@ibm-cloud/openapi-ruleset": "1.33.6",
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
         "@stoplight/spectral-cli": "^6.14.2",
         "@stoplight/spectral-core": "^1.19.4",
@@ -15131,7 +15150,7 @@
         "globby": "^11.0.4",
         "js-yaml": "^4.1.1",
         "json-dup-key-validator": "^1.0.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "nimma": "^0.7.0",
         "pad": "^2.3.0",
         "semver": "^7.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2260,7 +2260,7 @@
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "es-aggregate-error": "^1.0.7",
-        "jsonpath-plus": "10.2.0",
+        "jsonpath-plus": "10.3.0",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
         "minimatch": "3.1.2",
@@ -2326,24 +2326,6 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.0.1"
-      }
-    },
-    "node_modules/@stoplight/spectral-core/node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsep-plugin/assignment": "^1.3.0",
-        "@jsep-plugin/regex": "^1.0.4",
-        "jsep": "^1.4.0"
-      },
-      "bin": {
-        "jsonpath": "bin/jsonpath-cli.js",
-        "jsonpath-plus": "bin/jsonpath-cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/nimma": {
@@ -7372,6 +7354,24 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
@@ -15051,7 +15051,7 @@
     },
     "packages/ruleset": {
       "name": "@ibm-cloud/openapi-ruleset",
-      "version": "1.33.5",
+      "version": "1.33.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
@@ -15061,7 +15061,7 @@
         "chalk": "^4.1.2",
         "inflected": "^2.1.0",
         "jsonschema": "^1.5.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "loglevel": "^1.9.2",
         "loglevel-plugin-prefix": "0.8.4",
         "minimatch": "^6.2.0",
@@ -15114,10 +15114,10 @@
     },
     "packages/validator": {
       "name": "ibm-openapi-validator",
-      "version": "1.37.8",
+      "version": "1.37.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm-cloud/openapi-ruleset": "1.33.5",
+        "@ibm-cloud/openapi-ruleset": "1.33.6",
         "@ibm-cloud/openapi-ruleset-utilities": "1.9.0",
         "@stoplight/spectral-cli": "^6.14.2",
         "@stoplight/spectral-core": "^1.19.4",
@@ -15131,7 +15131,7 @@
         "globby": "^11.0.4",
         "js-yaml": "^4.1.1",
         "json-dup-key-validator": "^1.0.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "nimma": "^0.7.0",
         "pad": "^2.3.0",
         "semver": "^7.6.0"


### PR DESCRIPTION

Bump jsonpath-plus from 10.2.0 to 10.3.0 to avoid CVEs.