### PR TITLE
fix: allow empty-string JSON keys when checking duplicate keys

### DIFF
--- a/packages/validator/src/cli-validator/run-validator.js
+++ b/packages/validator/src/cli-validator/run-validator.js
@@ -212,7 +212,11 @@ async function runValidator(cliArgs, parseOptions = {}) {
       // jsonValidator looks through the originalFile for duplicate JSON keys
       //   this is checked for by default in readYaml
       const duplicateKeysError = jsonValidator.validate(originalFile);
-      if (fileExtension === 'json' && duplicateKeysError) {
+      if (
+        fileExtension === 'json' &&
+        duplicateKeysError &&
+        !duplicateKeysError.startsWith('Syntax error: empty string near')
+      ) {
         throw duplicateKeysError;
       }
 

--- a/packages/validator/test/cli-validator/mock-files/oas3/empty-string-key.json
+++ b/packages/validator/test/cli-validator/mock-files/oas3/empty-string-key.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Empty string key test",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Sample": {
+        "type": "object",
+        "properties": {
+          "": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/validator/test/cli-validator/tests/error-handling.test.js
+++ b/packages/validator/test/cli-validator/tests/error-handling.test.js
@@ -158,6 +158,22 @@ describe('cli tool - test error handling', function () {
     );
   });
 
+  it('should not reject valid JSON that uses an empty string key', async function () {
+    let exitCode;
+    try {
+      exitCode = await testValidator([
+        './test/cli-validator/mock-files/oas3/empty-string-key.json',
+      ]);
+    } catch (err) {
+      exitCode = err;
+    }
+
+    const capturedText = getCapturedText(consoleSpy.mock.calls);
+
+    expect(exitCode).toEqual(0);
+    expect(capturedText.join('\n')).not.toContain('Syntax error: empty string near');
+  });
+
   it('should return an error when a JSON document contains a trailing comma', async function () {
     let exitCode;
     try {


### PR DESCRIPTION
## Summary
- avoid rejecting valid JSON files that use an empty string (`""`) object key
- keep duplicate-key protection in place, but ignore the known false-positive parser error (`Syntax error: empty string near`)
- add a regression test fixture and CLI test coverage for this case

## Testing
- `npx jest test/cli-validator/tests/error-handling.test.js --runInBand` (from `packages/validator`)

## Related
- Fixes #513
