### PR TITLE
fix(ruleset): ignore binary responses in collection array property rule

### DIFF
--- a/packages/ruleset/src/functions/collection-array-property.js
+++ b/packages/ruleset/src/functions/collection-array-property.js
@@ -57,7 +57,10 @@ function collectionArrayProperty(schema, path, apidef) {
 
   // If this is a collection "list"-type operation, then check to make sure
   // that "schema" defines an array property named after the last path segment.
-  if (isListOperation(operation, pathString, apidef)) {
+  if (
+    isListOperation(operation, pathString, apidef) &&
+    !isBinarySchema(schema)
+  ) {
     logger.debug('Detected list-type operation');
     const pathSegments = pathString.split('/');
     const propertyName = pathSegments[pathSegments.length - 1];
@@ -110,6 +113,17 @@ function isListOperation(operation, path, apidef) {
   );
 
   return !!siblingPath;
+}
+
+/**
+ * Returns true iff "schema" represents binary file content.
+ * @param {*} schema the schema to check
+ * @returns boolean true if the schema is a binary string schema
+ */
+function isBinarySchema(schema) {
+  return (
+    isObject(schema) && schema.type === 'string' && schema.format === 'binary'
+  );
 }
 
 /**

--- a/packages/ruleset/test/rules/collection-array-property.test.js
+++ b/packages/ruleset/test/rules/collection-array-property.test.js
@@ -24,6 +24,34 @@ describe(`Spectral rule: ${ruleId}`, () => {
       expect(results).toHaveLength(0);
     });
 
+    it('does not require an array property for binary file responses', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/gateway_letters'] = {
+        get: {
+          operationId: 'list_gateway_letter_of_authorization',
+          responses: {
+            200: {
+              description: 'Letter of Authorization retrieved successfully.',
+              content: {
+                'application/pdf': {
+                  schema: {
+                    description: 'Letter of Authorization',
+                    type: 'string',
+                    format: 'binary',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const results = await testRule(ruleId, rule, testDocument);
+
+      expect(results).toHaveLength(0);
+    });
+
     it('would normally warn but path contains quote character, which throws off spectral', async () => {
       const testDocument = makeCopy(rootDocument);
 


### PR DESCRIPTION
## Summary

Fixes a false positive in `ibm-collection-array-property` for binary file responses.

## What changed

- Added regression coverage for a `list...` operation returning `application/pdf`.
- Skipped collection array property validation for `type: string`, `format: binary` response schemas.
- Preserved existing validation for JSON collection responses.

## Why

Issue #786 reports that PDF download endpoints are flagged as missing a collection array property even though they return binary files, not collections.

## Testing

- `npm run jest --workspace packages/ruleset -- test/rules/collection-array-property.test.js --runInBand`
- `npm run lint --workspace packages/ruleset`
- `npm run test-ruleset`
- `git diff --check`

Fixes #786