### PR TITLE
test: cover anonymous security alternatives

### DIFF
--- a/packages/ruleset/test/rules/securityschemes.test.js
+++ b/packages/ruleset/test/rules/securityschemes.test.js
@@ -47,6 +47,18 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
+
+    it('Operation security can include an anonymous alternative', async () => {
+      const testDocument = makeCopy(rootDocument);
+
+      testDocument.paths['/v1/drinks'].get.security = [
+        { DrinkScheme: ['drinker'] },
+        {},
+      ];
+
+      const results = await testRule(ruleId, rule, testDocument);
+      expect(results).toHaveLength(0);
+    });
   });
 
   describe('Should yield errors', () => {


### PR DESCRIPTION
Summary
- Add a ruleset regression test for operation security lists that include an anonymous alternative.
- Keep the existing scheme usage valid while covering the empty security requirement object from OpenAPI.

Validation
- git diff --check
- node --check packages/ruleset/test/rules/securityschemes.test.js
- Not run: npm ci or npm run test-ruleset because this clone has no node_modules and local disk is nearly full.