### PR TITLE
feat: make HTTP ref resolving be able to switched off

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ and [OpenAPI 3.1.x](https://github.com/OAI/OpenAPI-Specification/blob/master/ver
     + [Additional Customization](#additional-customization)
   * [JSON](#json)
 - [Logging](#logging)
+- [Security Notice](#security-notice)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -1056,6 +1057,21 @@ lint_openapi -l ibm-pagination-style=debug my-new-api.yaml
 
 The default log level for the `root` logger is `info`, while the default log level for
 rule-specific loggers is `warn`.
+
+## Security Notice
+
+This tool is designed to be run as a **local CLI utility** on API definitions that you own or explicitly trust.
+
+**It is not intended to be deployed or wrapped as a service** that validates arbitrary API documents submitted by external or untrusted parties. There are several reasons for this:
+
+- **Parser attack surface**: OpenAPI documents are parsed by multiple underlying libraries (e.g. YAML/JSON parsers, `$ref` resolvers). A maliciously crafted document could exploit parser vulnerabilities, trigger denial-of-service through deeply nested structures or circular references, or attempt path traversal via external `$ref` URLs.
+- **Resource exhaustion**: Large or pathological documents can cause excessive CPU and memory consumption with no built-in limits.
+- **Untrusted ruleset execution**: Custom rulesets are loaded as JavaScript modules. If an attacker can influence the ruleset path, arbitrary code execution is possible.
+
+If you need to validate untrusted API documents as part of a service, you must apply appropriate controls, such as:
+- Running the validator in an isolated sandbox (e.g. a container with no network access and strict resource limits)
+- Validating and limiting the size and structure of inputs before passing them to the validator
+- Never allowing untrusted input to influence the ruleset or configuration paths used
 
 ## Contributing
 

--- a/packages/validator/src/cli-validator/utils/cli-options.js
+++ b/packages/validator/src/cli-validator/utils/cli-options.js
@@ -88,6 +88,10 @@ function createCLIOptions() {
       'set warnings limit to <number> (default is -1)',
       parseWarningsLimit
     )
+    .option(
+      '--file-only-refs',
+      'use a file-only $ref resolver (disables HTTP/HTTPS ref resolution) (default is false)'
+    )
     .option('--version', 'output the version number')
     .showHelpAfterError()
     .addHelpText('beforeAll', getCopyrightString());

--- a/packages/validator/src/cli-validator/utils/configuration-manager.js
+++ b/packages/validator/src/cli-validator/utils/configuration-manager.js
@@ -44,6 +44,7 @@ const defaultConfig = {
   summaryOnly: false,
   produceImpactScore: false,
   markdownReport: false,
+  fileOnlyRefs: false,
 };
 
 const supportedConfigFileTypes = ['json', 'yaml', 'yml', 'js'];
@@ -244,6 +245,10 @@ async function processArgs(args, cliParseOptions) {
 
   if ('markdownReport' in opts) {
     configObj.markdownReport = true;
+  }
+
+  if ('fileOnlyRefs' in opts) {
+    configObj.fileOnlyRefs = !!opts.fileOnlyRefs;
   }
 
   return { context, command };

--- a/packages/validator/src/schemas/config-file.yaml
+++ b/packages/validator/src/schemas/config-file.yaml
@@ -82,3 +82,9 @@ properties:
       A flag that causes the validator to generate a report with rule violations and impact scores as a Markdown file
     type: boolean
     default: false
+  fileOnlyRefs:
+    description: >
+      A flag that causes Spectral to use a file-only $ref resolver,
+      disabling resolution of HTTP/HTTPS references
+    type: boolean
+    default: false

--- a/packages/validator/src/spectral/index.js
+++ b/packages/validator/src/spectral/index.js
@@ -9,6 +9,8 @@ const {
   getRuleset,
 } = require('@stoplight/spectral-cli/dist/services/linter/utils/getRuleset');
 const ibmRuleset = require('@ibm-cloud/openapi-ruleset');
+const { Resolver } = require('@stoplight/spectral-ref-resolver');
+const { resolveFile } = require('@stoplight/json-ref-readers');
 
 const {
   checkRulesetVersion,
@@ -125,7 +127,14 @@ function convertResults(spectralResults, { config, logger }) {
  * @returns the new Spectral instance
  */
 async function setup({ config, logger }) {
-  const spectral = new Spectral();
+  const resolverOpts = config.fileOnlyRefs
+    ? {
+        resolver: new Resolver({
+          resolvers: { file: { resolve: resolveFile } },
+        }),
+      }
+    : undefined;
+  const spectral = new Spectral(resolverOpts);
 
   // We'll use the IBM ruleset by default, but also look for a user-provided
   // ruleset and use that if one was specified.


### PR DESCRIPTION
## PR summary

This PR adds a new configuration option (through config file or CLI option)
which allows the users to disable the resolving of HTTP references during
the document processing.
Furthermore, a new section has been added to the README which clarifies
what kind of consumption of the project is supported.


## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
