### PR TITLE
fix: revert regex changes to address a regression issue

### DIFF
--- a/packages/ruleset/src/rules/parameter-casing-convention.js
+++ b/packages/ruleset/src/rules/parameter-casing-convention.js
@@ -45,7 +45,7 @@ module.exports = {
       // Spectral casing convention types aren't robust enough to handle
       // the complexity of headers, so we define our own kebab/pascal case regex.
       header: {
-        match: '/^[A-Z][A-Za-z0-9]*(?:-[A-Z][A-Za-z0-9]*)*$/',
+        match: '/^[A-Z]+[a-z0-9]*-*([A-Z]+[a-z0-9]*-*)*$/',
       },
 
       // Define an alternate message for the header pattern validation

--- a/packages/ruleset/src/rules/schema-casing-convention.js
+++ b/packages/ruleset/src/rules/schema-casing-convention.js
@@ -15,7 +15,7 @@ module.exports = {
   then: {
     function: schemaCasingConvention,
     functionOptions: {
-      match: '/^[A-Z](?:[A-Z]*[a-z0-9]+)+$/',
+      match: '/^[A-Z]+[a-z0-9]+([A-Z]+[a-z0-9]*)*$/',
     },
   },
 };

--- a/packages/ruleset/test/rules/parameter-casing-convention.test.js
+++ b/packages/ruleset/test/rules/parameter-casing-convention.test.js
@@ -178,37 +178,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
-
-    it('Should handle potential ReDoS patterns efficiently', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      // Pattern that would cause catastrophic backtracking in old regex
-      // Old pattern: /^[A-Z]+[a-z0-9]*-*([A-Z]+[a-z0-9]*-*)*$/
-      // This input would cause exponential time complexity
-      const maliciousHeader = 'A' + 'A-'.repeat(50);
-
-      testDocument.paths['/v1/movies'].get.parameters.push({
-        description: 'Header with ReDoS attack pattern',
-        name: maliciousHeader,
-        required: false,
-        in: 'header',
-        schema: {
-          type: 'string',
-        },
-      });
-
-      const startTime = Date.now();
-      const results = await testRule(ruleId, rule, testDocument);
-      const duration = Date.now() - startTime;
-
-      // Should complete quickly (well under 500ms) with fixed regex
-      // Note: Includes test overhead; actual regex execution is much faster
-      expect(duration).toBeLessThan(500);
-      // Should still validate correctly and reject the malformed header
-      expect(results).toHaveLength(1);
-      expect(results[0].code).toBe(ruleId);
-      expect(results[0].message).toBe(expectedMsgHeader);
-    });
   });
 
   describe('Should yield errors', () => {

--- a/packages/ruleset/test/rules/schema-casing-convention.test.js
+++ b/packages/ruleset/test/rules/schema-casing-convention.test.js
@@ -65,33 +65,6 @@ describe(`Spectral rule: ${ruleId}`, () => {
       const results = await testRule(ruleId, rule, testDocument);
       expect(results).toHaveLength(0);
     });
-
-    it('Should handle potential ReDoS patterns efficiently', async () => {
-      const testDocument = makeCopy(rootDocument);
-
-      // Pattern that would cause catastrophic backtracking in old regex
-      // Old pattern: /^[A-Z]+[a-z0-9]+([A-Z]+[a-z0-9]*)*$/
-      // This input would cause exponential time complexity
-      const maliciousSchemaName = 'A' + 'Aa'.repeat(50);
-
-      testDocument.components.schemas[maliciousSchemaName] = {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
-        },
-      };
-
-      const startTime = Date.now();
-      const results = await testRule(ruleId, rule, testDocument);
-      const duration = Date.now() - startTime;
-
-      // Should complete quickly (well under 500ms) with fixed regex
-      // Note: Includes test overhead; actual regex execution is much faster
-      expect(duration).toBeLessThan(500);
-      // Should still validate correctly - this pattern should actually pass
-      // as it matches the upper camel case pattern
-      expect(results).toHaveLength(0);
-    });
   });
 
   describe('Should yield errors', () => {


### PR DESCRIPTION
## PR summary

This reverts commit 30d9a513ca77e73a45f83810328042d21dc5f2c4.

## PR Checklist

### General checklist
Please make sure that your PR fulfills the following requirements:
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Dependencies have been updated as needed
- [ ] `.secrets.baseline` has been updated as needed
- [ ] `npm run update-utilities` has been run if any files in `packages/utilities/src` have been updated

#### Checklist for adding a new validation rule:
- [ ] Added new validation rule definition (packages/ruleset/src/rules/*.js, index.js)
- [ ] If necessary, added new validation rule implementation (packages/ruleset/src/functions/*.js, updated index.js)
- [ ] Added new rule to default configuration (packages/ruleset/src/ibm-oas.js)
- [ ] Added tests for new rule (packages/ruleset/test/*.test.js)
- [ ] Added docs for new rule (docs/ibm-cloud-rules.md)
- [ ] Added scoring rubric entry for new rule (packages/validator/src/scoring-tool/rubric.js)
